### PR TITLE
feat: Phase 2 — Agent prompts + LLM dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,34 +61,41 @@ Every experiment is structured as a bundle of falsifiable predictions:
 
 ## Quick Start
 
+See [docs/quickstart.md](docs/quickstart.md) for a full walkthrough, or the [BLIS example](examples/blis/) for a concrete campaign configuration.
+
 ### Install
 
 ```bash
 pip install -e ".[dev]"
 ```
 
-### Initialize a Campaign
-
-Copy the templates to create a new campaign directory:
-
-```bash
-mkdir -p my-campaign/runs
-cp templates/state.json my-campaign/
-cp templates/ledger.json my-campaign/
-cp templates/principles.json my-campaign/
-cp templates/campaign.yaml my-campaign/
-```
-
-Edit `my-campaign/state.json` to set your `run_id` and `my-campaign/campaign.yaml` to describe your target system, then use the orchestrator engine to drive the state machine:
+### Run a Single Iteration
 
 ```python
+import json, shutil, yaml
+from pathlib import Path
 from orchestrator.engine import Engine
+from orchestrator.llm_dispatch import LLMDispatcher
+from orchestrator.gates import HumanGate
 
-engine = Engine("my-campaign")
-print(engine.state)  # {"phase": "INIT", "iteration": 0, ...}
+# Set up working directory
+work_dir = Path("my-campaign")
+work_dir.mkdir(exist_ok=True)
+for t in ["state.json", "ledger.json", "principles.json"]:
+    shutil.copy(f"templates/{t}", work_dir / t)
+
+# Load campaign config (see examples/blis/campaign.yaml)
+campaign = yaml.safe_load(Path("campaign.yaml").read_text())
+
+# Initialize and run
+engine = Engine(work_dir)
+dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign)
+gate = HumanGate()
 
 engine.transition("FRAMING")
-# ... dispatch agents, run reviews, advance through phases
+dispatcher.dispatch("planner", "frame",
+    output_path=work_dir / "runs/iter-1/problem.md", iteration=1)
+# ... see docs/quickstart.md for the full loop
 ```
 
 ### Run Tests
@@ -97,7 +104,7 @@ engine.transition("FRAMING")
 pytest -v
 ```
 
-The full test suite validates schemas, templates, state machine transitions, gates, dispatch, fast-fail rules, protocol conformance, and end-to-end integration.
+The test suite validates schemas, templates, state machine transitions, gates, stub and LLM dispatch, fast-fail rules, protocol conformance, prompt loading, and end-to-end integration (164 tests).
 
 ## Project Structure
 
@@ -123,19 +130,37 @@ templates/               Starter files for new campaigns
 
 orchestrator/            Python orchestrator (deterministic, not an LLM)
   engine.py                State machine with atomic checkpoint/resume
-  dispatch.py              Agent dispatch (stub dispatcher for Phase 1)
+  dispatch.py              Stub agent dispatch (for testing without LLM)
+  llm_dispatch.py          LLM-based agent dispatch via LiteLLM
+  prompt_loader.py         Template loading with {{placeholder}} rendering
   gates.py                 Human approval gates
   fastfail.py              Fast-fail rule evaluation
   protocols.py             Dispatcher and Gate interface contracts
+  util.py                  Shared utilities (atomic_write)
+
+prompts/                 Methodology prompt templates
+  methodology/
+    frame.md               Problem framing (planner)
+    design.md              Hypothesis bundle design (planner)
+    run.md                 Analysis-mode execution (executor)
+    review_design.md       Design review from a perspective (reviewer)
+    review_findings.md     Findings review from a perspective (reviewer)
+    extract.md             Principle extraction (extractor)
+
+examples/
+  blis/                    Reference campaign for BLIS inference simulator
+    campaign.yaml            Filled-in campaign config
+    README.md                Step-by-step walkthrough
 
 docs/
+  quickstart.md            How to run Nous on any target system
   protocol.md              Full methodology specification
   data-model.md            Plain-English guide to every data structure
   architecture.md          System architecture and component design
   case-studies/
     blis.md                30-iteration validation on LLM inference serving
 
-tests/                   139 tests (schemas, templates, engine, gates, dispatch, fastfail, protocols, integration)
+tests/                   164 tests (schemas, templates, engine, gates, stub dispatch, LLM dispatch, prompt loader, fastfail, protocols, integration)
 ```
 
 ## Case Study: LLM Inference Serving
@@ -152,9 +177,11 @@ See [docs/contributing/workflow.md](docs/contributing/workflow.md) for the Claud
 
 ## Current Status
 
-**Phase 1 (current):** Schemas, templates, orchestrator skeleton, and protocol documentation. The orchestrator drives the full state machine with stub agent dispatch, enabling end-to-end testing of the loop without LLM calls.
+**Phase 1 (complete):** Schemas, templates, orchestrator skeleton, and protocol documentation. The orchestrator drives the full state machine with stub agent dispatch.
 
-**Phase 2 (next):** Agent prompts and real LLM dispatch — replacing stubs with actual agent implementations that produce hypothesis bundles, execute experiments, run reviews, and extract principles.
+**Phase 2 (current):** Agent prompts and real LLM dispatch. `LLMDispatcher` replaces stubs with LLM-driven agents via [LiteLLM](https://docs.litellm.ai/) (model-agnostic — Claude, GPT, Gemini, etc.). Six methodology prompt templates, schema validation with retry, and a BLIS example campaign. The executor operates in analysis mode (reasons about code, does not run experiments).
+
+**Phase 3 (next):** Plugin integration — `/nous:init` and `/nous:investigate` commands, real experiment execution via shell access, worktree isolation.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,10 @@ The dispatcher invokes AI agents by role and phase, passing structured input and
 | **Reviewer** | DESIGN_REVIEW, FINDINGS_REVIEW | `review-*.md` |
 | **Extractor** | EXTRACTION | Updated `principles.json` |
 
-**Phase 1 implementation:** `StubDispatcher` produces valid, schema-conformant artifacts without calling any LLM. This enables full end-to-end testing of the orchestrator loop. The stub is designed to be replaced by a real dispatcher that loads prompt templates, calls an LLM API, validates the response against the schema, and writes the output.
+**Implementations:**
+
+- `StubDispatcher` (`dispatch.py`) produces valid, schema-conformant artifacts without calling any LLM. Used for testing the orchestrator loop.
+- `LLMDispatcher` (`llm_dispatch.py`) calls a real LLM via [LiteLLM](https://docs.litellm.ai/), parses structured output from code fences, validates against schemas, and writes artifacts atomically. This is the production dispatcher.
 
 **Dispatch interface:**
 ```python
@@ -107,9 +110,55 @@ dispatcher.dispatch(
     phase="run",               # which phase
     output_path=path,          # where to write
     iteration=1,               # current iteration
-    h_main_result="CONFIRMED", # optional: control stub behavior
 )
 ```
+
+Both dispatchers satisfy the `Dispatcher` protocol (`protocols.py`).
+
+## LLM Dispatch (Phase 2)
+
+`LLMDispatcher` is the real dispatcher that replaces stub agents with LLM-driven agents.
+
+### Two-Layer Prompt System
+
+Prompts have two layers:
+
+| Layer | Source | Content |
+|-------|--------|---------|
+| **Methodology layer** | Ships with Nous (`prompts/methodology/`) | Generic scientific method: "check for confounds", "is the causal mechanism plausible?", "are 3 seeds enough?" |
+| **Domain adapter layer** | Generated per system from `campaign.yaml` | System-specific vocabulary, metrics, knobs, experiment commands |
+
+The methodology layer is 6 prompt templates (one per role+phase combination). At dispatch time, `PromptLoader` renders each template by replacing `{{placeholder}}` markers with domain-specific context from `campaign.yaml`:
+
+- `{{target_system}}`, `{{system_description}}` — from `campaign.yaml`
+- `{{observable_metrics}}`, `{{controllable_knobs}}` — from `campaign.yaml`
+- `{{active_principles}}` — formatted from `principles.json`
+- Phase-specific context: `{{bundle_yaml}}`, `{{findings_json}}`, `{{perspective_name}}`
+
+### Schema Validation with Retry
+
+For structured outputs (bundle YAML, findings JSON, principles JSON), the dispatcher:
+
+1. Extracts content from a code fence (`` ```yaml `` or `` ```json ``)
+2. Parses and validates against the relevant JSON Schema
+3. On validation failure: retries once, sending the error message as feedback
+4. On second failure: raises `RuntimeError`
+
+Markdown outputs (problem framing, reviews) are written directly without validation.
+
+### Executor Analysis Mode
+
+In Phase 2, the executor operates in **analysis mode** — it reasons about the target system based on its understanding of the code and mechanisms, but does not run actual experiments. The prompt explicitly states this limitation. Phase 3 will add real experiment execution via plugin shell access.
+
+### Model Configuration
+
+`LLMDispatcher` uses any [LiteLLM-supported model](https://docs.litellm.ai/docs/providers). Default: `aws/claude-opus-4-6`. Pass a different model string to the constructor:
+
+```python
+dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model="gpt-4o")
+```
+
+The `completion_fn` constructor parameter allows test injection without mocking internals.
 
 ### Gates (`orchestrator/gates.py`)
 
@@ -258,16 +307,14 @@ The orchestrator is designed for crash-safe operation:
 
 ## Extending Nous
 
-### Adding a Custom Agent
+### Using a Different Dispatcher
 
-Replace `StubDispatcher` with a real dispatcher that:
-1. Loads a prompt template for the (role, phase) pair
-2. Injects context: current principles, prior findings, problem framing
-3. Calls an LLM API
-4. Validates the response against the relevant schema
-5. Writes the validated output to the specified path
+Nous ships with two dispatchers:
 
-The dispatcher interface is role-based: `dispatch(role, phase, output_path=..., **kwargs)`. Your implementation must produce artifacts that pass schema validation — the orchestrator trusts the schema contract, not the content.
+- `StubDispatcher` — deterministic stubs for testing
+- `LLMDispatcher` — real LLM calls via LiteLLM
+
+To create a custom dispatcher, implement the `Dispatcher` protocol from `orchestrator/protocols.py`. Your dispatcher must produce artifacts that pass schema validation — the orchestrator trusts the schema contract, not the content.
 
 ### Adding a New Arm Type
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -166,6 +166,15 @@ An activity log. One JSON line per event — every LLM call, tool invocation, st
 
 Phase 1 defines the envelope; Phase 4 will tighten per-event-type payload schemas.
 
+## Dispatch and Prompt Templates
+
+The orchestrator invokes agents through a dispatcher. Two implementations exist:
+
+- `StubDispatcher` (`orchestrator/dispatch.py`) — produces deterministic, schema-valid artifacts without LLM calls. Used for testing.
+- `LLMDispatcher` (`orchestrator/llm_dispatch.py`) — calls a real LLM via LiteLLM, parses structured output, validates against schemas, and writes artifacts atomically.
+
+`LLMDispatcher` reads `campaign.yaml` at construction time and injects domain-specific context (target system name, metrics, knobs, active principles) into prompt templates from `prompts/methodology/`. For structured outputs (bundle, findings, principles), it extracts content from code fences and validates against the relevant schema before writing. The FRAMING phase dispatches `role="planner", phase="frame"` to produce `problem.md`.
+
 ## 7. summary.json — "How did the whole campaign go?"
 
 **Schema:** `schemas/summary.schema.json`

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -35,6 +35,7 @@ The campaign configuration. Describes the target system, configures the reviewer
 
 | Section | What it configures |
 |---|---|
+| `research_question` | The guiding research question for this campaign |
 | `target_system.name` / `description` | What system Nous is investigating |
 | `target_system.observable_metrics` | What you can measure (latency, throughput, error rate, etc.) |
 | `target_system.controllable_knobs` | What you can change (algorithms, configs, resource limits) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,6 +21,9 @@ pip install -e ".[dev]"
 Create a `campaign.yaml` that describes your target system. See [campaign.schema.yaml](../schemas/campaign.schema.yaml) for the full schema, or use the [BLIS example](../examples/blis/campaign.yaml) as a starting point.
 
 ```yaml
+research_question: >
+  What mechanism drives the primary performance bottleneck in your system?
+
 target_system:
   name: "Your System Name"
   description: >
@@ -55,6 +58,7 @@ prompts:
 
 | Field | Description |
 |-------|-------------|
+| `research_question` | The guiding question for the campaign — what mechanism are you investigating? |
 | `target_system.observable_metrics` | What agents can measure — these appear in predictions and findings |
 | `target_system.controllable_knobs` | What agents can change — these define the experimental design space |
 | `review.design_perspectives` | How many reviewers check the hypothesis bundle (one per perspective) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,172 @@
+# Quickstart
+
+Run a single Nous iteration on any target system via the Python API.
+
+## Prerequisites
+
+- **Python 3.11+**
+- **An LLM API key** — any [LiteLLM-supported provider](https://docs.litellm.ai/docs/providers). Set the appropriate environment variable (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`).
+- **A target system** — something you can describe in terms of observable metrics and controllable knobs.
+
+## Install
+
+```bash
+git clone https://github.com/AI-native-Systems-Research/agentic-strategy-evolution.git
+cd agentic-strategy-evolution
+pip install -e ".[dev]"
+```
+
+## Create a campaign configuration
+
+Create a `campaign.yaml` that describes your target system. See [campaign.schema.yaml](../schemas/campaign.schema.yaml) for the full schema, or use the [BLIS example](../examples/blis/campaign.yaml) as a starting point.
+
+```yaml
+target_system:
+  name: "Your System Name"
+  description: >
+    What the system does, its architecture, and what you want to investigate.
+  observable_metrics:
+    - latency_p99_ms
+    - throughput_rps
+    - error_rate_pct
+  controllable_knobs:
+    - algorithm
+    - cache_size
+    - concurrency_limit
+
+review:
+  design_perspectives:
+    - statistical-rigor
+    - causal-sufficiency
+    - confound-risk
+  findings_perspectives:
+    - statistical-rigor
+    - causal-sufficiency
+    - confound-risk
+    - reproducibility
+  max_review_rounds: 3
+
+prompts:
+  methodology_layer: "prompts/methodology"
+  domain_adapter_layer: null
+```
+
+### Key fields
+
+| Field | Description |
+|-------|-------------|
+| `target_system.observable_metrics` | What agents can measure — these appear in predictions and findings |
+| `target_system.controllable_knobs` | What agents can change — these define the experimental design space |
+| `review.design_perspectives` | How many reviewers check the hypothesis bundle (one per perspective) |
+| `review.findings_perspectives` | How many reviewers check the findings (typically more than design) |
+
+## Initialize working directory
+
+```python
+import json
+import shutil
+from pathlib import Path
+
+work_dir = Path("my-experiment")
+work_dir.mkdir(exist_ok=True)
+
+# Copy template files
+for template in ["state.json", "ledger.json", "principles.json"]:
+    shutil.copy(f"templates/{template}", work_dir / template)
+
+# Set a run ID
+state = json.loads((work_dir / "state.json").read_text())
+state["run_id"] = "my-experiment-001"
+(work_dir / "state.json").write_text(json.dumps(state, indent=2))
+```
+
+## Run a single iteration
+
+```python
+import yaml
+from orchestrator.engine import Engine
+from orchestrator.llm_dispatch import LLMDispatcher
+from orchestrator.gates import HumanGate
+
+campaign = yaml.safe_load(Path("campaign.yaml").read_text())
+
+engine = Engine(work_dir)
+dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign)
+gate = HumanGate()  # interactive approval prompts
+
+iteration = 1
+iter_dir = work_dir / "runs" / f"iter-{iteration}"
+
+# Framing: define the problem
+engine.transition("FRAMING")
+dispatcher.dispatch("planner", "frame", output_path=iter_dir / "problem.md", iteration=iteration)
+
+# Design: create hypothesis bundle
+engine.transition("DESIGN")
+dispatcher.dispatch("planner", "design", output_path=iter_dir / "bundle.yaml", iteration=iteration)
+
+# Design review: multiple perspectives evaluate the bundle
+engine.transition("DESIGN_REVIEW")
+for p in campaign["review"]["design_perspectives"]:
+    dispatcher.dispatch("reviewer", "review-design",
+        output_path=iter_dir / "reviews" / f"review-{p}.md",
+        iteration=iteration, perspective=p)
+
+# Human gate: you review and approve
+engine.transition("HUMAN_DESIGN_GATE")
+gate.prompt("Approve the hypothesis bundle?",
+    artifact_path=str(iter_dir / "bundle.yaml"))
+
+# Execution: analyze the system
+engine.transition("RUNNING")
+dispatcher.dispatch("executor", "run",
+    output_path=iter_dir / "findings.json", iteration=iteration)
+
+# Findings review
+engine.transition("FINDINGS_REVIEW")
+for p in campaign["review"]["findings_perspectives"]:
+    dispatcher.dispatch("reviewer", "review-findings",
+        output_path=iter_dir / "reviews" / f"review-findings-{p}.md",
+        iteration=iteration, perspective=p)
+
+# Human gate: approve findings
+engine.transition("HUMAN_FINDINGS_GATE")
+gate.prompt("Approve the findings?")
+
+# Extract principles
+engine.transition("TUNING")
+engine.transition("EXTRACTION")
+dispatcher.dispatch("extractor", "extract",
+    output_path=work_dir / "principles.json", iteration=iteration)
+
+engine.transition("DONE")
+print("Done! Principles:", work_dir / "principles.json")
+```
+
+## Review output
+
+After completion, check:
+
+- **`runs/iter-1/problem.md`** — How the problem was framed
+- **`runs/iter-1/bundle.yaml`** — The hypothesis bundle (validate against `schemas/bundle.schema.yaml`)
+- **`runs/iter-1/findings.json`** — Executor findings (validate against `schemas/findings.schema.json`)
+- **`runs/iter-1/reviews/`** — All reviewer perspectives
+- **`principles.json`** — Extracted principles that guide future iterations
+
+## Choosing a model
+
+By default, `LLMDispatcher` uses `aws/claude-opus-4-6`. Pass any [LiteLLM model string](https://docs.litellm.ai/docs/providers) to use a different model:
+
+```python
+dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model="gpt-4o")
+```
+
+## Phase 2 limitation
+
+The executor currently operates in **analysis mode** — it reasons about the system rather than running actual experiments. Real experiment execution is planned for Phase 3.
+
+## Next steps
+
+- See [examples/blis/](../examples/blis/) for a complete BLIS campaign configuration
+- See [docs/architecture.md](architecture.md) for how the orchestrator, dispatcher, and agents fit together
+- See [docs/data-model.md](data-model.md) for schema documentation

--- a/examples/blis/README.md
+++ b/examples/blis/README.md
@@ -1,0 +1,159 @@
+# Running Nous on BLIS
+
+This example shows how to run a single Nous iteration on [BLIS](https://github.com/inference-sim/inference-sim), a discrete-event simulator for LLM inference serving systems.
+
+## Prerequisites
+
+- Python 3.11+
+- An LLM API key set as an environment variable (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or any [LiteLLM-supported provider](https://docs.litellm.ai/docs/providers))
+- Nous installed: `pip install -e ".[dev]"`
+
+## Campaign configuration
+
+The `campaign.yaml` in this directory configures Nous for BLIS:
+
+| Section | What it controls |
+|---------|-----------------|
+| `target_system.name` | Human-readable name shown in prompts |
+| `target_system.description` | System description given to all agents |
+| `target_system.observable_metrics` | What agents can measure (TTFT, TPOT, throughput, etc.) |
+| `target_system.controllable_knobs` | What agents can change (scheduler_policy, max_batch_size, etc.) |
+| `review.design_perspectives` | Reviewer perspectives for hypothesis bundle review (5 perspectives) |
+| `review.findings_perspectives` | Reviewer perspectives for findings review (10 perspectives) |
+| `review.max_review_rounds` | Maximum convergence rounds per review gate |
+
+## Running a single iteration
+
+```python
+import json
+import shutil
+from pathlib import Path
+
+import yaml
+
+from orchestrator.engine import Engine
+from orchestrator.llm_dispatch import LLMDispatcher
+from orchestrator.gates import HumanGate
+
+# 1. Set up working directory
+work_dir = Path("blis-run-001")
+work_dir.mkdir(exist_ok=True)
+
+# Copy templates
+for t in ["state.json", "ledger.json", "principles.json"]:
+    shutil.copy(f"templates/{t}", work_dir / t)
+
+# Update run ID
+state = json.loads((work_dir / "state.json").read_text())
+state["run_id"] = "blis-run-001"
+(work_dir / "state.json").write_text(json.dumps(state, indent=2))
+
+# 2. Load campaign config
+campaign = yaml.safe_load(Path("examples/blis/campaign.yaml").read_text())
+
+# 3. Initialize components
+engine = Engine(work_dir)
+dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign)
+gate = HumanGate()  # interactive approval prompts
+
+# 4. Run the loop
+iteration = 1
+iter_dir = work_dir / "runs" / f"iter-{iteration}"
+
+# INIT -> FRAMING: produce problem.md
+engine.transition("FRAMING")
+dispatcher.dispatch(
+    "planner", "frame",
+    output_path=iter_dir / "problem.md", iteration=iteration,
+)
+
+# FRAMING -> DESIGN: produce hypothesis bundle
+engine.transition("DESIGN")
+dispatcher.dispatch(
+    "planner", "design",
+    output_path=iter_dir / "bundle.yaml", iteration=iteration,
+)
+
+# DESIGN -> DESIGN_REVIEW: reviewers evaluate the bundle
+engine.transition("DESIGN_REVIEW")
+for perspective in campaign["review"]["design_perspectives"]:
+    dispatcher.dispatch(
+        "reviewer", "review-design",
+        output_path=iter_dir / "reviews" / f"review-{perspective}.md",
+        iteration=iteration, perspective=perspective,
+    )
+
+# DESIGN_REVIEW -> HUMAN_DESIGN_GATE: you approve or reject
+engine.transition("HUMAN_DESIGN_GATE")
+gate.prompt(
+    "Review the bundle and reviews. Approve?",
+    artifact_path=str(iter_dir / "bundle.yaml"),
+    reviews=[str(p) for p in (iter_dir / "reviews").glob("review-*.md")],
+)
+
+# HUMAN_DESIGN_GATE -> RUNNING: executor analyzes the system
+engine.transition("RUNNING")
+dispatcher.dispatch(
+    "executor", "run",
+    output_path=iter_dir / "findings.json", iteration=iteration,
+)
+
+# RUNNING -> FINDINGS_REVIEW: reviewers evaluate findings
+engine.transition("FINDINGS_REVIEW")
+for perspective in campaign["review"]["findings_perspectives"]:
+    dispatcher.dispatch(
+        "reviewer", "review-findings",
+        output_path=iter_dir / "reviews" / f"review-findings-{perspective}.md",
+        iteration=iteration, perspective=perspective,
+    )
+
+# FINDINGS_REVIEW -> HUMAN_FINDINGS_GATE
+engine.transition("HUMAN_FINDINGS_GATE")
+gate.prompt("Review the findings and reviews. Approve?")
+
+# HUMAN_FINDINGS_GATE -> TUNING -> EXTRACTION
+engine.transition("TUNING")
+engine.transition("EXTRACTION")
+dispatcher.dispatch(
+    "extractor", "extract",
+    output_path=work_dir / "principles.json", iteration=iteration,
+)
+
+# EXTRACTION -> DONE
+engine.transition("DONE")
+print("Iteration complete! Check", iter_dir)
+```
+
+## Expected output
+
+After running, your working directory will contain:
+
+```
+blis-run-001/
+  state.json              # phase: DONE
+  principles.json         # extracted principles
+  ledger.json
+  runs/
+    iter-1/
+      problem.md          # problem framing
+      bundle.yaml         # hypothesis bundle
+      findings.json       # executor findings
+      reviews/
+        review-*.md       # design reviews
+        review-findings-*.md  # findings reviews
+```
+
+## Phase 2 limitation
+
+In Phase 2, the executor operates in **analysis mode** — it reasons about the BLIS codebase and mechanisms but does not run actual benchmarks. The executor produces findings based on its understanding of how scheduling policies, batching, and cache management affect performance.
+
+Phase 3 will add real experiment execution via shell access.
+
+## Customizing
+
+To adapt this for a different LLM inference system:
+
+1. Copy `campaign.yaml` to a new directory
+2. Update `target_system` fields (name, description, metrics, knobs)
+3. Optionally adjust reviewer perspectives in `review`
+4. Run the same Python script with the new campaign config

--- a/examples/blis/campaign.yaml
+++ b/examples/blis/campaign.yaml
@@ -1,3 +1,7 @@
+research_question: >
+  Can SLO-gated admission control reduce TTFT P99 latency under high load
+  without degrading overall throughput?
+
 target_system:
   name: "BLIS — LLM Inference Serving Simulator"
   description: >

--- a/examples/blis/campaign.yaml
+++ b/examples/blis/campaign.yaml
@@ -1,0 +1,43 @@
+target_system:
+  name: "BLIS — LLM Inference Serving Simulator"
+  description: >
+    BLIS is a discrete-event simulator for LLM inference serving systems.
+    It models request arrivals, scheduling policies, KV-cache management,
+    and GPU resource allocation to study performance under realistic workloads.
+  observable_metrics:
+    - TTFT_P50_ms
+    - TTFT_P99_ms
+    - TPOT_ms
+    - throughput_req_per_sec
+    - gpu_utilization_pct
+    - kv_cache_hit_rate
+  controllable_knobs:
+    - scheduler_policy
+    - max_batch_size
+    - preemption_mode
+    - cache_eviction_policy
+    - admission_control_threshold
+
+review:
+  design_perspectives:
+    - statistical-rigor
+    - causal-sufficiency
+    - confound-risk
+    - generalization
+    - mechanism-clarity
+  findings_perspectives:
+    - statistical-rigor
+    - causal-sufficiency
+    - confound-risk
+    - generalization
+    - mechanism-clarity
+    - reproducibility
+    - measurement-validity
+    - error-classification
+    - principle-consistency
+    - domain-plausibility
+  max_review_rounds: 3
+
+prompts:
+  methodology_layer: "prompts/methodology"
+  domain_adapter_layer: null

--- a/orchestrator/dispatch.py
+++ b/orchestrator/dispatch.py
@@ -1,45 +1,20 @@
 """Agent dispatch for the Nous orchestrator.
 
-Real dispatcher (future): loads prompt template, invokes LLM API, writes output.
-Phase 1: StubDispatcher produces valid schema-conformant artifacts without
-calling any LLM, enabling end-to-end testing of the orchestrator loop.
+StubDispatcher produces valid schema-conformant artifacts without calling any
+LLM, enabling end-to-end testing of the orchestrator loop.
+
+For real LLM dispatch, see llm_dispatch.py (Phase 2).
 """
 import json
 import logging
-import os
-import tempfile
 import warnings
 from pathlib import Path
 
 import yaml
 
+from orchestrator.util import atomic_write
+
 logger = logging.getLogger(__name__)
-
-
-def _atomic_write(path: Path, data: str | bytes) -> None:
-    """Write data to path atomically via temp file + fsync + rename."""
-    if isinstance(data, str):
-        data = data.encode()
-    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
-    fd_closed = False
-    try:
-        os.write(fd, data)
-        os.fsync(fd)
-        os.close(fd)
-        fd_closed = True
-        os.replace(tmp, str(path))
-    except BaseException:
-        try:
-            if not fd_closed:
-                os.close(fd)
-        except OSError:
-            pass
-        try:
-            if os.path.exists(tmp):
-                os.unlink(tmp)
-        except OSError:
-            pass
-        raise
 
 
 class StubDispatcher:
@@ -117,7 +92,7 @@ class StubDispatcher:
                 },
             ],
         }
-        _atomic_write(path, yaml.safe_dump(bundle, default_flow_style=False, sort_keys=False))
+        atomic_write(path, yaml.safe_dump(bundle, default_flow_style=False, sort_keys=False))
 
     def _write_findings(self, path: Path, iteration: int, h_main_result: str) -> None:
         findings = {
@@ -151,10 +126,10 @@ class StubDispatcher:
             if h_main_result == "CONFIRMED"
             else "Stub analysis: H-main refuted, mechanism does not hold.",
         }
-        _atomic_write(path, json.dumps(findings, indent=2) + "\n")
+        atomic_write(path, json.dumps(findings, indent=2) + "\n")
 
     def _write_review(self, path: Path, perspective: str) -> None:
-        _atomic_write(
+        atomic_write(
             path,
             f"# Review — {perspective}\n\n"
             f"**Severity:** SUGGESTION\n\n"
@@ -194,4 +169,4 @@ class StubDispatcher:
                 "status": "active",
             }
         )
-        _atomic_write(path, json.dumps(store, indent=2) + "\n")
+        atomic_write(path, json.dumps(store, indent=2) + "\n")

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -1,0 +1,313 @@
+"""LLM-based agent dispatch for the Nous orchestrator.
+
+Replaces StubDispatcher with real LLM calls via LiteLLM.  Loads prompt
+templates, calls the model, parses structured output from code fences,
+validates against JSON Schema, and writes artifacts atomically.
+"""
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Callable
+
+import jsonschema
+import litellm
+import yaml
+
+from orchestrator.prompt_loader import PromptLoader
+from orchestrator.util import atomic_write
+
+logger = logging.getLogger(__name__)
+
+_FENCE_RE = {
+    "yaml": re.compile(r"```yaml\s*\n(.*?)```", re.DOTALL),
+    "json": re.compile(r"```json\s*\n(.*?)```", re.DOTALL),
+}
+
+# Schema cache: schema_name -> parsed schema dict
+_schema_cache: dict[str, dict] = {}
+
+
+class LLMDispatcher:
+    """Dispatch agent roles to an LLM and produce schema-conformant artifacts."""
+
+    def __init__(
+        self,
+        work_dir: Path,
+        campaign: dict,
+        model: str = "aws/claude-opus-4-6",
+        prompts_dir: Path | None = None,
+        completion_fn: Callable | None = None,
+    ) -> None:
+        self.work_dir = Path(work_dir)
+        self.campaign = campaign
+        self.model = model
+        self.loader = PromptLoader(
+            prompts_dir
+            or Path(__file__).parent.parent / "prompts" / "methodology"
+        )
+        self._completion = completion_fn or litellm.completion
+
+    # ------------------------------------------------------------------
+    # Public interface (satisfies Dispatcher protocol)
+    # ------------------------------------------------------------------
+
+    def dispatch(
+        self,
+        role: str,
+        phase: str,
+        *,
+        output_path: Path,
+        iteration: int,
+        perspective: str | None = None,
+        h_main_result: str = "CONFIRMED",
+    ) -> None:
+        """Dispatch an LLM agent to produce an artifact.
+
+        *h_main_result* is ignored — kept for protocol compatibility with
+        StubDispatcher.  The executor determines results from its own analysis.
+        """
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        template, fmt, schema = self._route(role, phase)
+        context = self._build_context(role, phase, iteration, perspective)
+        prompt = self.loader.load(template, context)
+
+        response = self._call_llm(prompt)
+
+        if fmt is None:
+            # Plain markdown output — no parsing or validation needed.
+            atomic_write(output_path, response)
+        else:
+            data = self._extract_fenced_content(response, fmt)
+            if schema is not None:
+                try:
+                    self._validate(data, schema)
+                except jsonschema.ValidationError as exc:
+                    logger.warning(
+                        "Schema validation failed for %s/%s, retrying: %s",
+                        role, phase, exc.message,
+                    )
+                    data = self._retry_with_feedback(
+                        prompt, response, exc, fmt, schema
+                    )
+
+            if fmt == "yaml":
+                atomic_write(
+                    output_path,
+                    yaml.safe_dump(data, default_flow_style=False, sort_keys=False),
+                )
+            else:
+                atomic_write(output_path, json.dumps(data, indent=2) + "\n")
+
+        logger.info("Dispatched role=%s phase=%s -> %s", role, phase, output_path)
+
+    # ------------------------------------------------------------------
+    # Routing
+    # ------------------------------------------------------------------
+
+    _ROUTES: dict[tuple[str, str], tuple[str, str | None, str | None]] = {
+        # (role, phase) -> (template_name, output_format, schema_name)
+        ("planner", "frame"): ("frame", None, None),
+        ("planner", "design"): ("design", "yaml", "bundle.schema.yaml"),
+        ("executor", "run"): ("run", "json", "findings.schema.json"),
+        ("reviewer", "review-design"): ("review_design", None, None),
+        ("reviewer", "review-findings"): ("review_findings", None, None),
+        ("extractor", "extract"): ("extract", "json", "principles.schema.json"),
+    }
+
+    def _route(
+        self, role: str, phase: str
+    ) -> tuple[str, str | None, str | None]:
+        key = (role, phase)
+        if key not in self._ROUTES:
+            raise ValueError(f"Unknown role/phase combination: {role}/{phase}")
+        return self._ROUTES[key]
+
+    # ------------------------------------------------------------------
+    # Context building
+    # ------------------------------------------------------------------
+
+    def _build_context(
+        self,
+        role: str,
+        phase: str,
+        iteration: int,
+        perspective: str | None,
+    ) -> dict[str, str]:
+        ts = self.campaign["target_system"]
+        ctx: dict[str, str] = {
+            "target_system": ts["name"],
+            "system_description": ts["description"],
+            "observable_metrics": ", ".join(ts["observable_metrics"]),
+            "controllable_knobs": ", ".join(ts["controllable_knobs"]),
+            "active_principles": self._format_principles(),
+            "iteration": str(iteration),
+        }
+
+        if phase in ("frame", "design"):
+            ctx["research_question"] = self._read_research_question(phase, iteration)
+
+        if phase in ("design", "review-design"):
+            bundle_path = self.work_dir / "runs" / f"iter-{iteration}" / "bundle.yaml"
+            if bundle_path.exists():
+                ctx["bundle_yaml"] = bundle_path.read_text()
+
+        if phase == "run":
+            bundle_path = self.work_dir / "runs" / f"iter-{iteration}" / "bundle.yaml"
+            ctx["bundle_yaml"] = bundle_path.read_text()
+
+        if phase == "review-findings":
+            findings_path = (
+                self.work_dir / "runs" / f"iter-{iteration}" / "findings.json"
+            )
+            ctx["findings_json"] = findings_path.read_text()
+
+        if phase == "extract":
+            findings_path = (
+                self.work_dir / "runs" / f"iter-{iteration}" / "findings.json"
+            )
+            ctx["findings_json"] = findings_path.read_text()
+            principles_path = self.work_dir / "principles.json"
+            if principles_path.exists():
+                ctx["current_principles_json"] = principles_path.read_text()
+            else:
+                ctx["current_principles_json"] = json.dumps({"principles": []}, indent=2)
+
+        if perspective is not None:
+            ctx["perspective_name"] = perspective
+
+        return ctx
+
+    def _read_research_question(self, phase: str, iteration: int) -> str:
+        """Read the research question for frame/design phases."""
+        if phase == "frame":
+            # For framing, the research question comes from campaign config
+            # or is the first iteration's guiding question.
+            return self.campaign.get(
+                "research_question",
+                "What is the primary performance bottleneck in the target system?",
+            )
+        # For design, read from the problem.md produced by framing.
+        problem_path = self.work_dir / "runs" / f"iter-{iteration}" / "problem.md"
+        if problem_path.exists():
+            text = problem_path.read_text()
+            # Extract the first non-empty, non-heading line after "## Research Question"
+            in_section = False
+            for line in text.splitlines():
+                if line.strip().startswith("## Research Question"):
+                    in_section = True
+                    continue
+                if in_section and line.strip().startswith("##"):
+                    break
+                if in_section and line.strip():
+                    return line.strip()
+        return "See problem.md for the research question."
+
+    def _format_principles(self) -> str:
+        """Read principles.json and format active ones for prompt injection."""
+        path = self.work_dir / "principles.json"
+        if not path.exists():
+            return "No principles extracted yet."
+        try:
+            store = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return "No principles extracted yet."
+        active = [
+            p for p in store.get("principles", []) if p.get("status") == "active"
+        ]
+        if not active:
+            return "No principles extracted yet."
+        lines = [
+            f"- {p['id']}: {p['statement']} [confidence: {p['confidence']}]"
+            for p in active
+        ]
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # LLM interaction
+    # ------------------------------------------------------------------
+
+    def _call_llm(
+        self, system_prompt: str, user_message: str | None = None
+    ) -> str:
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message or "Please proceed."},
+        ]
+        response = self._completion(
+            model=self.model, messages=messages, max_tokens=4096
+        )
+        return response.choices[0].message.content
+
+    def _retry_with_feedback(
+        self,
+        original_prompt: str,
+        first_response: str,
+        error: jsonschema.ValidationError,
+        fmt: str,
+        schema_name: str,
+    ) -> dict:
+        """Retry the LLM call with validation error feedback."""
+        feedback = (
+            f"Your output failed schema validation:\n{error.message}\n\n"
+            f"Please fix the issue and return only the corrected "
+            f"{fmt} in a code fence."
+        )
+        messages = [
+            {"role": "system", "content": original_prompt},
+            {"role": "user", "content": "Please proceed."},
+            {"role": "assistant", "content": first_response},
+            {"role": "user", "content": feedback},
+        ]
+        response = self._completion(
+            model=self.model, messages=messages, max_tokens=4096
+        )
+        retry_text = response.choices[0].message.content
+        data = self._extract_fenced_content(retry_text, fmt)
+        try:
+            self._validate(data, schema_name)
+        except jsonschema.ValidationError as exc:
+            raise RuntimeError(
+                f"LLM output failed schema validation after retry: {exc.message}"
+            ) from exc
+        return data
+
+    # ------------------------------------------------------------------
+    # Parsing & validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_fenced_content(text: str, fmt: str) -> dict:
+        """Extract and parse content from a code-fenced block.
+
+        If the response contains multiple fences, uses the last one
+        (LLMs often explain before giving the final answer).
+        Falls back to parsing the entire response if no fence is found.
+        """
+        pattern = _FENCE_RE.get(fmt)
+        if pattern is None:
+            raise ValueError(f"Unsupported format: {fmt}")
+
+        matches = pattern.findall(text)
+        if matches:
+            raw = matches[-1]  # use last fence
+        else:
+            raw = text  # fallback: try parsing entire response
+
+        if fmt == "yaml":
+            return yaml.safe_load(raw)
+        return json.loads(raw)
+
+    @staticmethod
+    def _validate(data: dict, schema_name: str) -> None:
+        """Validate *data* against the named schema file."""
+        if schema_name not in _schema_cache:
+            schema_path = Path(__file__).parent.parent / "schemas" / schema_name
+            raw = schema_path.read_text()
+            if schema_name.endswith(".yaml"):
+                _schema_cache[schema_name] = yaml.safe_load(raw)
+            else:
+                _schema_cache[schema_name] = json.loads(raw)
+        jsonschema.validate(data, _schema_cache[schema_name])

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -204,14 +204,7 @@ class LLMDispatcher:
     def _read_research_question(self, phase: str, iteration: int) -> str:
         """Read the research question for frame/design phases."""
         if phase == "frame":
-            rq = self.campaign.get("research_question")
-            if rq is None:
-                logger.warning(
-                    "No 'research_question' in campaign config; "
-                    "using default framing question."
-                )
-                return "What is the primary performance bottleneck in the target system?"
-            return rq
+            return self.campaign["research_question"]
         # For design, read from the problem.md produced by framing.
         problem_path = self.work_dir / "runs" / f"iter-{iteration}" / "problem.md"
         if not problem_path.exists():

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -40,6 +40,7 @@ class LLMDispatcher:
         completion_fn: Callable | None = None,
     ) -> None:
         self.work_dir = Path(work_dir)
+        self._validate_campaign(campaign)
         self.campaign = campaign
         self.model = model
         self.loader = PromptLoader(
@@ -47,6 +48,22 @@ class LLMDispatcher:
             or Path(__file__).parent.parent / "prompts" / "methodology"
         )
         self._completion = completion_fn or litellm.completion
+
+    @staticmethod
+    def _validate_campaign(campaign: dict) -> None:
+        ts = campaign.get("target_system")
+        if not isinstance(ts, dict):
+            raise ValueError(
+                "Campaign config missing 'target_system' section. "
+                "See examples/blis/campaign.yaml for the expected format."
+            )
+        required = ["name", "description", "observable_metrics", "controllable_knobs"]
+        missing = [k for k in required if k not in ts]
+        if missing:
+            raise ValueError(
+                f"Campaign 'target_system' missing required keys: {missing}. "
+                f"See examples/blis/campaign.yaml for the expected format."
+            )
 
     # ------------------------------------------------------------------
     # Public interface (satisfies Dispatcher protocol)
@@ -149,26 +166,30 @@ class LLMDispatcher:
         if phase in ("frame", "design"):
             ctx["research_question"] = self._read_research_question(phase, iteration)
 
-        if phase in ("design", "review-design"):
+        if phase in ("design", "review-design", "run"):
             bundle_path = self.work_dir / "runs" / f"iter-{iteration}" / "bundle.yaml"
-            if bundle_path.exists():
+            if phase == "design" and not bundle_path.exists():
+                pass  # bundle doesn't exist yet during design — template ignores it
+            elif not bundle_path.exists():
+                raise FileNotFoundError(
+                    f"Cannot run '{phase}' phase: {bundle_path} not found. "
+                    f"Ensure the design phase completed for iteration {iteration}."
+                )
+            else:
                 ctx["bundle_yaml"] = bundle_path.read_text()
 
-        if phase == "run":
-            bundle_path = self.work_dir / "runs" / f"iter-{iteration}" / "bundle.yaml"
-            ctx["bundle_yaml"] = bundle_path.read_text()
-
-        if phase == "review-findings":
+        if phase in ("review-findings", "extract"):
             findings_path = (
                 self.work_dir / "runs" / f"iter-{iteration}" / "findings.json"
             )
+            if not findings_path.exists():
+                raise FileNotFoundError(
+                    f"Cannot run '{phase}' phase: {findings_path} not found. "
+                    f"Ensure the executor completed for iteration {iteration}."
+                )
             ctx["findings_json"] = findings_path.read_text()
 
         if phase == "extract":
-            findings_path = (
-                self.work_dir / "runs" / f"iter-{iteration}" / "findings.json"
-            )
-            ctx["findings_json"] = findings_path.read_text()
             principles_path = self.work_dir / "principles.json"
             if principles_path.exists():
                 ctx["current_principles_json"] = principles_path.read_text()
@@ -285,11 +306,30 @@ class LLMDispatcher:
             {"role": "assistant", "content": first_response},
             {"role": "user", "content": feedback},
         ]
-        response = self._completion(
-            model=self.model, messages=messages, max_tokens=4096
-        )
+        try:
+            response = self._completion(
+                model=self.model, messages=messages, max_tokens=4096
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"LLM API call failed during schema-validation retry "
+                f"(model={self.model}): {exc}"
+            ) from exc
+        if not response.choices:
+            raise RuntimeError(
+                "LLM returned empty choices list during retry."
+            )
         retry_text = response.choices[0].message.content
-        data = self._extract_fenced_content(retry_text, fmt)
+        if retry_text is None:
+            raise RuntimeError(
+                "LLM returned None content during retry."
+            )
+        try:
+            data = self._extract_fenced_content(retry_text, fmt)
+        except (json.JSONDecodeError, yaml.YAMLError, ValueError) as exc:
+            raise RuntimeError(
+                f"LLM retry response could not be parsed as {fmt}: {exc}"
+            ) from exc
         try:
             self._validate(data, schema_name)
         except jsonschema.ValidationError as exc:

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -20,8 +20,8 @@ from orchestrator.util import atomic_write
 logger = logging.getLogger(__name__)
 
 _FENCE_RE = {
-    "yaml": re.compile(r"```yaml\s*\n(.*?)```", re.DOTALL),
-    "json": re.compile(r"```json\s*\n(.*?)```", re.DOTALL),
+    "yaml": re.compile(r"```yaml\s*\n(.*?)```", re.DOTALL | re.IGNORECASE),
+    "json": re.compile(r"```json\s*\n(.*?)```", re.DOTALL | re.IGNORECASE),
 }
 
 # Schema cache: schema_name -> parsed schema dict
@@ -183,27 +183,37 @@ class LLMDispatcher:
     def _read_research_question(self, phase: str, iteration: int) -> str:
         """Read the research question for frame/design phases."""
         if phase == "frame":
-            # For framing, the research question comes from campaign config
-            # or is the first iteration's guiding question.
-            return self.campaign.get(
-                "research_question",
-                "What is the primary performance bottleneck in the target system?",
-            )
+            rq = self.campaign.get("research_question")
+            if rq is None:
+                logger.warning(
+                    "No 'research_question' in campaign config; "
+                    "using default framing question."
+                )
+                return "What is the primary performance bottleneck in the target system?"
+            return rq
         # For design, read from the problem.md produced by framing.
         problem_path = self.work_dir / "runs" / f"iter-{iteration}" / "problem.md"
-        if problem_path.exists():
-            text = problem_path.read_text()
-            # Extract the first non-empty, non-heading line after "## Research Question"
-            in_section = False
-            for line in text.splitlines():
-                if line.strip().startswith("## Research Question"):
-                    in_section = True
-                    continue
-                if in_section and line.strip().startswith("##"):
-                    break
-                if in_section and line.strip():
-                    return line.strip()
-        return "See problem.md for the research question."
+        if not problem_path.exists():
+            raise FileNotFoundError(
+                f"Expected {problem_path} for design phase. "
+                f"Was the framing phase completed for iteration {iteration}?"
+            )
+        text = problem_path.read_text()
+        in_section = False
+        for line in text.splitlines():
+            if line.strip().startswith("## Research Question"):
+                in_section = True
+                continue
+            if in_section and line.strip().startswith("##"):
+                break
+            if in_section and line.strip():
+                return line.strip()
+        logger.warning(
+            "Could not extract research question from %s; "
+            "using full problem.md content as context.",
+            problem_path,
+        )
+        return text[:500]
 
     def _format_principles(self) -> str:
         """Read principles.json and format active ones for prompt injection."""
@@ -212,15 +222,19 @@ class LLMDispatcher:
             return "No principles extracted yet."
         try:
             store = json.loads(path.read_text())
-        except (json.JSONDecodeError, OSError):
-            return "No principles extracted yet."
+        except json.JSONDecodeError as exc:
+            logger.error("principles.json contains invalid JSON: %s", exc)
+            raise RuntimeError(
+                f"Cannot read principles.json: corrupt JSON. {exc}"
+            ) from exc
         active = [
             p for p in store.get("principles", []) if p.get("status") == "active"
         ]
         if not active:
             return "No principles extracted yet."
         lines = [
-            f"- {p['id']}: {p['statement']} [confidence: {p['confidence']}]"
+            f"- {p.get('id', '?')}: {p.get('statement', '?')} "
+            f"[confidence: {p.get('confidence', '?')}]"
             for p in active
         ]
         return "\n".join(lines)
@@ -236,10 +250,20 @@ class LLMDispatcher:
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message or "Please proceed."},
         ]
-        response = self._completion(
-            model=self.model, messages=messages, max_tokens=4096
-        )
-        return response.choices[0].message.content
+        try:
+            response = self._completion(
+                model=self.model, messages=messages, max_tokens=4096
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"LLM API call failed (model={self.model}): {exc}"
+            ) from exc
+        if not response.choices:
+            raise RuntimeError("LLM returned empty choices list.")
+        content = response.choices[0].message.content
+        if content is None:
+            raise RuntimeError("LLM returned None content.")
+        return content
 
     def _retry_with_feedback(
         self,
@@ -294,11 +318,19 @@ class LLMDispatcher:
         if matches:
             raw = matches[-1]  # use last fence
         else:
-            raw = text  # fallback: try parsing entire response
+            logger.warning(
+                "No ```%s``` code fence found in LLM response (%d chars); "
+                "attempting raw parse.",
+                fmt, len(text),
+            )
+            raw = text
 
-        if fmt == "yaml":
-            return yaml.safe_load(raw)
-        return json.loads(raw)
+        parsed = yaml.safe_load(raw) if fmt == "yaml" else json.loads(raw)
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"Expected a {fmt} object from LLM, got {type(parsed).__name__}"
+            )
+        return parsed
 
     @staticmethod
     def _validate(data: dict, schema_name: str) -> None:

--- a/orchestrator/prompt_loader.py
+++ b/orchestrator/prompt_loader.py
@@ -1,0 +1,49 @@
+"""Prompt template loading and rendering for the Nous orchestrator.
+
+Loads markdown prompt templates from disk and renders them by replacing
+``{{placeholder}}`` markers with context values.
+"""
+import logging
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
+
+
+class PromptLoader:
+    """Load and render prompt templates with ``{{variable}}`` substitution."""
+
+    def __init__(self, prompts_dir: Path) -> None:
+        self.prompts_dir = Path(prompts_dir)
+
+    def load(self, template_name: str, context: dict[str, str]) -> str:
+        """Load *template_name*.md and replace ``{{key}}`` with *context[key]*.
+
+        Returns the rendered prompt string.
+
+        Raises:
+            FileNotFoundError: Template file does not exist.
+            ValueError: Template contains unreplaced ``{{placeholders}}``
+                after rendering (i.e. required context keys were not provided).
+        """
+        path = self.prompts_dir / f"{template_name}.md"
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"Prompt template not found: {path}"
+            )
+
+        text = path.read_text()
+        for key, value in context.items():
+            text = text.replace(f"{{{{{key}}}}}", value)
+
+        remaining = _PLACEHOLDER_RE.findall(text)
+        if remaining:
+            raise ValueError(
+                f"Unreplaced placeholders in {template_name}.md: "
+                f"{', '.join(sorted(set(remaining)))}"
+            )
+
+        logger.debug("Loaded prompt %s (%d chars)", template_name, len(text))
+        return text

--- a/orchestrator/util.py
+++ b/orchestrator/util.py
@@ -1,7 +1,10 @@
 """Shared utilities for the Nous orchestrator."""
+import logging
 import os
 import tempfile
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def atomic_write(path: Path, data: str | bytes) -> None:
@@ -20,11 +23,11 @@ def atomic_write(path: Path, data: str | bytes) -> None:
         try:
             if not fd_closed:
                 os.close(fd)
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug("Failed to close fd during cleanup: %s", exc)
         try:
             if os.path.exists(tmp):
                 os.unlink(tmp)
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug("Failed to remove temp file %s during cleanup: %s", tmp, exc)
         raise

--- a/orchestrator/util.py
+++ b/orchestrator/util.py
@@ -1,0 +1,30 @@
+"""Shared utilities for the Nous orchestrator."""
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write(path: Path, data: str | bytes) -> None:
+    """Write data to path atomically via temp file + fsync + rename."""
+    if isinstance(data, str):
+        data = data.encode()
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    fd_closed = False
+    try:
+        os.write(fd, data)
+        os.fsync(fd)
+        os.close(fd)
+        fd_closed = True
+        os.replace(tmp, str(path))
+    except BaseException:
+        try:
+            if not fd_closed:
+                os.close(fd)
+        except OSError:
+            pass
+        try:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -1,0 +1,71 @@
+You are a scientific planner for the Nous hypothesis-driven experimentation framework.
+
+Your task is to design a **hypothesis bundle** — a structured set of falsifiable hypotheses that test a mechanism in the target system.
+
+## Target System
+
+- **Name:** {{target_system}}
+- **Description:** {{system_description}}
+- **Observable metrics:** {{observable_metrics}}
+- **Controllable knobs:** {{controllable_knobs}}
+
+## Research Question
+
+{{research_question}}
+
+## Iteration
+
+This is iteration {{iteration}} of the investigation.
+
+## Active Principles
+
+{{active_principles}}
+
+## Instructions
+
+Design a hypothesis bundle with the following structure:
+
+1. **metadata**: iteration number, hypothesis family name (a short descriptive label), and the research question.
+
+2. **arms**: An array of hypothesis arms. You MUST include at least:
+   - One `h-main` arm: The primary falsifiable prediction with a causal mechanism.
+   - One `h-control-negative` arm: A regime where the effect should vanish (e.g., low load, no contention). This validates that the mechanism is specific, not a general artifact.
+
+   Optional additional arms (include when appropriate):
+   - `h-ablation`: Remove one component of a multi-part mechanism to test if it's necessary.
+   - `h-robustness`: Test the same mechanism under varied conditions.
+   - `h-super-additivity`: Test whether combined factors produce more than the sum of parts.
+
+3. Each arm must have:
+   - `type`: One of h-main, h-ablation, h-super-additivity, h-control-negative, h-robustness.
+   - `prediction`: A quantitative, falsifiable claim with a measurable success/failure threshold using the observable metrics.
+   - `mechanism`: A causal explanation of how and why the predicted outcome occurs.
+   - `diagnostic`: What to investigate if the prediction is wrong — what would the error tell us?
+
+## Constraints
+
+- You MUST NOT violate any active principles. If a principle says mechanism X doesn't work under condition Y, do not propose X under condition Y.
+- Predictions must be quantitative and reference specific observable metrics.
+- The h-control-negative arm must test a regime where the mechanism should NOT apply.
+
+## Output Format
+
+Output the bundle as YAML inside a code fence. Example structure:
+
+```yaml
+metadata:
+  iteration: 1
+  family: "descriptive-name"
+  research_question: "..."
+arms:
+  - type: h-main
+    prediction: "..."
+    mechanism: "..."
+    diagnostic: "..."
+  - type: h-control-negative
+    prediction: "..."
+    mechanism: "..."
+    diagnostic: "..."
+```
+
+Output ONLY the YAML code fence. Do not include any explanation outside the code fence.

--- a/prompts/methodology/extract.md
+++ b/prompts/methodology/extract.md
@@ -1,0 +1,81 @@
+You are a scientific extractor for the Nous hypothesis-driven experimentation framework.
+
+Your task is to update the principle store based on the latest experiment findings. Principles are the living knowledge base that guides future iterations.
+
+## Target System
+
+- **Name:** {{target_system}}
+- **Description:** {{system_description}}
+
+## Iteration
+
+This is iteration {{iteration}}.
+
+## Latest Findings
+
+```json
+{{findings_json}}
+```
+
+## Current Principle Store
+
+```json
+{{current_principles_json}}
+```
+
+## Instructions
+
+Analyze the findings and update the principle store:
+
+1. **Extract new principles** from confirmed or partially confirmed findings. Each principle should capture a reusable insight about the target system or the investigation process.
+
+2. **Update existing principles** if new evidence strengthens or weakens them. Adjust confidence levels (low, medium, high) based on cumulative evidence.
+
+3. **Handle contradictions**: If a finding contradicts an existing principle:
+   - Set `superseded_by` on the old principle to the new principle's ID.
+   - Set `status` to `"updated"` on the old principle.
+   - Create a new principle that incorporates the updated understanding.
+   - Add the old principle's ID to the new principle's `contradicts` array.
+
+4. **Principle fields**:
+   - `id`: Use format `RP-{n}` for domain principles, `MP-{n}` for meta principles. Number sequentially from existing IDs.
+   - `statement`: A concise, falsifiable statement of what was learned.
+   - `confidence`: `"low"`, `"medium"`, or `"high"` based on strength of evidence.
+   - `regime`: Under what conditions does this principle apply?
+   - `evidence`: Array of evidence references (e.g., `"iteration-1-h-main"`).
+   - `contradicts`: Array of principle IDs this contradicts (empty if none).
+   - `extraction_iteration`: The current iteration number.
+   - `mechanism`: The causal explanation behind this principle.
+   - `applicability_bounds`: When does this principle NOT apply?
+   - `superseded_by`: ID of the principle that replaces this one, or `null`.
+   - `category`: `"domain"` for principles about the target system, `"meta"` for principles about the investigation process itself.
+   - `status`: `"active"` for new/current principles, `"updated"` for superseded ones, `"pruned"` for discarded ones.
+
+5. **Output the FULL principles array** — all existing principles (with any updates) plus any new ones. Do not omit unchanged principles.
+
+## Output Format
+
+Output the updated principle store as JSON inside a code fence:
+
+```json
+{
+  "principles": [
+    {
+      "id": "RP-1",
+      "statement": "...",
+      "confidence": "medium",
+      "regime": "...",
+      "evidence": ["iteration-1-h-main"],
+      "contradicts": [],
+      "extraction_iteration": 1,
+      "mechanism": "...",
+      "applicability_bounds": "...",
+      "superseded_by": null,
+      "category": "domain",
+      "status": "active"
+    }
+  ]
+}
+```
+
+Output ONLY the JSON code fence. Do not include any explanation outside the code fence.

--- a/prompts/methodology/frame.md
+++ b/prompts/methodology/frame.md
@@ -1,0 +1,44 @@
+You are a scientific planner for the Nous hypothesis-driven experimentation framework.
+
+Your task is to produce a **problem framing document** for a new investigation on the target system described below.
+
+## Target System
+
+- **Name:** {{target_system}}
+- **Description:** {{system_description}}
+- **Observable metrics:** {{observable_metrics}}
+- **Controllable knobs:** {{controllable_knobs}}
+
+## Research Question
+
+{{research_question}}
+
+## Prior Knowledge
+
+The following principles have been extracted from previous iterations:
+
+{{active_principles}}
+
+## Instructions
+
+Write a problem framing document in markdown with exactly these sections:
+
+### Research Question
+Restate the research question precisely. Include what mechanism or behavior is being investigated.
+
+### Baseline
+Describe the current system behavior without intervention. Reference specific observable metrics.
+
+### Experimental Conditions
+Describe the conditions under which the hypothesis will be tested. Include input characteristics, scale parameters, and environment configuration using the controllable knobs listed above.
+
+### Success Criteria
+Define quantitative thresholds for success using the observable metrics. Be specific — e.g., "TTFT p99 < 500ms under 100 concurrent requests."
+
+### Constraints
+List what cannot be changed: resource limits, SLOs, compatibility requirements, and any boundaries from active principles.
+
+### Prior Knowledge
+Reference any active principles that apply. Explain how they inform the experimental design. If no principles exist yet, state that this is the first iteration.
+
+Output ONLY the markdown document. Do not include any preamble or explanation outside the document.

--- a/prompts/methodology/review_design.md
+++ b/prompts/methodology/review_design.md
@@ -1,0 +1,66 @@
+You are a scientific reviewer for the Nous hypothesis-driven experimentation framework.
+
+Your task is to review a hypothesis bundle from the perspective described below. You are one of several reviewers, each bringing a different perspective.
+
+## Your Perspective
+
+**{{perspective_name}}**
+
+Review the bundle through the lens of this perspective. Focus on issues that this perspective is uniquely positioned to identify.
+
+## Target System
+
+- **Name:** {{target_system}}
+- **Description:** {{system_description}}
+
+## Iteration
+
+This is iteration {{iteration}}.
+
+## Hypothesis Bundle Under Review
+
+```yaml
+{{bundle_yaml}}
+```
+
+## Active Principles
+
+{{active_principles}}
+
+## Instructions
+
+Evaluate the hypothesis bundle for scientific rigor and feasibility. Look for:
+
+1. **Falsifiability**: Are predictions quantitative and falsifiable? Could the experiment actually distinguish confirmation from refutation?
+2. **Causal mechanisms**: Are the proposed mechanisms plausible and specific? Could something else explain the predicted outcome?
+3. **Control quality**: Does the h-control-negative arm effectively test a regime where the mechanism should not apply?
+4. **Principle compliance**: Does the bundle violate any active principles? This is a CRITICAL finding if so.
+5. **Completeness**: Are there obvious confounds not addressed? Missing arms that would strengthen the test?
+6. **Feasibility**: Can the experiment be run with the available metrics and knobs?
+
+## Output Format
+
+Write your review in markdown with this structure:
+
+```
+# Review — {{perspective_name}}
+
+## CRITICAL
+<!-- Findings that require the bundle to be redesigned before running. -->
+<!-- If none, write "No CRITICAL findings." -->
+
+## IMPORTANT
+<!-- Findings that should be addressed but don't block execution. -->
+<!-- If none, write "No IMPORTANT findings." -->
+
+## SUGGESTION
+<!-- Minor improvements or things to consider for future iterations. -->
+<!-- If none, write "No SUGGESTION findings." -->
+```
+
+For each finding, state:
+1. What is wrong or could be improved.
+2. Why it matters (what could go wrong).
+3. A suggested fix.
+
+Output ONLY the markdown review. Do not include any preamble or explanation outside the review.

--- a/prompts/methodology/review_findings.md
+++ b/prompts/methodology/review_findings.md
@@ -1,0 +1,67 @@
+You are a scientific reviewer for the Nous hypothesis-driven experimentation framework.
+
+Your task is to review experiment findings from the perspective described below. You are one of several reviewers, each bringing a different perspective.
+
+## Your Perspective
+
+**{{perspective_name}}**
+
+Review the findings through the lens of this perspective. Focus on issues that this perspective is uniquely positioned to identify.
+
+## Target System
+
+- **Name:** {{target_system}}
+- **Description:** {{system_description}}
+
+## Iteration
+
+This is iteration {{iteration}}.
+
+## Experiment Findings Under Review
+
+```json
+{{findings_json}}
+```
+
+## Active Principles
+
+{{active_principles}}
+
+## Instructions
+
+Evaluate the experiment findings for scientific validity. Look for:
+
+1. **Statistical validity**: Are the conclusions supported by the evidence? Are sample sizes and measurements adequate?
+2. **Reproducibility**: Could another researcher reproduce these results? Are conditions described precisely enough?
+3. **Error classification**: When arms are REFUTED, is the error_type correct? Could a different error type better explain the discrepancy?
+4. **Measurement quality**: Are the observed values reliable? Could measurement artifacts explain the results?
+5. **Causal attribution**: Do the conclusions follow from the evidence? Could confounding factors explain the observed outcomes?
+6. **Principle consistency**: Do the findings contradict any active principles without explanation? This is a CRITICAL finding if so.
+7. **Completeness**: Is the discrepancy analysis thorough? Are there unexplained anomalies?
+
+## Output Format
+
+Write your review in markdown with this structure:
+
+```
+# Review — {{perspective_name}}
+
+## CRITICAL
+<!-- Findings that invalidate the conclusions or require re-running the experiment. -->
+<!-- If none, write "No CRITICAL findings." -->
+
+## IMPORTANT
+<!-- Findings that should be considered when interpreting results. -->
+<!-- If none, write "No IMPORTANT findings." -->
+
+## SUGGESTION
+<!-- Minor improvements for the next iteration's methodology. -->
+<!-- If none, write "No SUGGESTION findings." -->
+```
+
+For each finding, state:
+1. What is wrong or questionable.
+2. Why it matters (what conclusions could be incorrect).
+3. A suggested resolution or mitigation.
+
+Output ONLY the markdown review. Do not include any preamble or explanation outside the review.

--- a/prompts/methodology/run.md
+++ b/prompts/methodology/run.md
@@ -1,0 +1,75 @@
+You are a scientific executor for the Nous hypothesis-driven experimentation framework.
+
+Your task is to **analyze** the target system and produce findings for each hypothesis arm in the approved bundle.
+
+## Important: Analysis Mode
+
+Phase 2 limitation: You are analyzing the system based on your understanding of the code and mechanisms. You are NOT running actual experiments. State your reasoning clearly. If you cannot determine an outcome with confidence, say so in the diagnostic_note and set status to PARTIALLY_CONFIRMED.
+
+## Target System
+
+- **Name:** {{target_system}}
+- **Description:** {{system_description}}
+- **Observable metrics:** {{observable_metrics}}
+- **Controllable knobs:** {{controllable_knobs}}
+
+## Iteration
+
+This is iteration {{iteration}}.
+
+## Approved Hypothesis Bundle
+
+```yaml
+{{bundle_yaml}}
+```
+
+## Active Principles
+
+{{active_principles}}
+
+## Instructions
+
+For each arm in the bundle, produce a finding with:
+
+- `arm_type`: Must match the arm's `type` field from the bundle.
+- `predicted`: The prediction from the bundle (copy it exactly).
+- `observed`: What you expect would be observed based on your analysis of the system's code and mechanisms. Be specific and quantitative where possible.
+- `status`: One of:
+  - `CONFIRMED` — your analysis supports the prediction.
+  - `REFUTED` — your analysis contradicts the prediction.
+  - `PARTIALLY_CONFIRMED` — evidence is mixed or you cannot determine with confidence.
+- `error_type`: When status is REFUTED, specify the type of error:
+  - `direction` — the effect goes the opposite way.
+  - `magnitude` — the effect exists but is much larger/smaller than predicted.
+  - `regime` — the effect exists but not in the predicted regime.
+  - Set to `null` when status is CONFIRMED or PARTIALLY_CONFIRMED.
+- `diagnostic_note`: Explanation of your reasoning. What evidence supports your conclusion? What uncertainties remain? Set to `null` only if the result is unambiguous.
+
+Also produce:
+- `discrepancy_analysis`: A summary of what happened across all arms. What did we learn? Were there surprises? What should the next iteration investigate?
+- `dominant_component_pct`: If one component dominates the observed effect (>80%), set this to the percentage. Otherwise set to `null`.
+
+## Output Format
+
+Output the findings as JSON inside a code fence:
+
+```json
+{
+  "iteration": 1,
+  "bundle_ref": "runs/iter-1/bundle.yaml",
+  "arms": [
+    {
+      "arm_type": "h-main",
+      "predicted": "...",
+      "observed": "...",
+      "status": "CONFIRMED",
+      "error_type": null,
+      "diagnostic_note": "..."
+    }
+  ],
+  "discrepancy_analysis": "...",
+  "dominant_component_pct": null
+}
+```
+
+Output ONLY the JSON code fence. Do not include any explanation outside the code fence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 dependencies = [
     "jsonschema>=4.20.0",
     "pyyaml>=6.0",
+    "litellm>=1.40.0",
 ]
 
 [project.optional-dependencies]
@@ -16,7 +17,7 @@ dev = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["orchestrator*"]
+include = ["orchestrator*", "prompts*"]
 
 [build-system]
 requires = ["setuptools>=68.0"]

--- a/schemas/campaign.schema.yaml
+++ b/schemas/campaign.schema.yaml
@@ -7,10 +7,15 @@ description: >
   and referenced by state.json via config_ref.
 
 type: object
-required: [target_system, review, prompts]
+required: [target_system, research_question, review, prompts]
 additionalProperties: false
 
 properties:
+  research_question:
+    type: string
+    minLength: 1
+    description: "The guiding research question for this campaign."
+
   target_system:
     type: object
     required: [name, description, observable_metrics, controllable_knobs]

--- a/templates/campaign.yaml
+++ b/templates/campaign.yaml
@@ -1,3 +1,5 @@
+research_question: "TODO: What mechanism or behavior are you investigating?"
+
 target_system:
   name: "TODO-SET-SYSTEM-NAME"
   description: "TODO: Describe what the system does."

--- a/tests/test_integration_llm.py
+++ b/tests/test_integration_llm.py
@@ -74,6 +74,7 @@ FINDINGS_JSON = json.dumps({
         },
     ],
     "discrepancy_analysis": "All arms confirmed. Batch amortization holds.",
+    "dominant_component_pct": None,
 }, indent=2)
 
 PRINCIPLES_JSON = json.dumps({

--- a/tests/test_integration_llm.py
+++ b/tests/test_integration_llm.py
@@ -19,6 +19,7 @@ SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
 TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
 SAMPLE_CAMPAIGN = {
+    "research_question": "Does batch size affect latency in TestSystem?",
     "target_system": {
         "name": "TestSystem",
         "description": "A test system for integration testing.",

--- a/tests/test_integration_llm.py
+++ b/tests/test_integration_llm.py
@@ -1,0 +1,285 @@
+"""Integration test — full single-iteration loop with mocked LLM responses."""
+import json
+import shutil
+import warnings
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.engine import Engine
+from orchestrator.llm_dispatch import LLMDispatcher
+from orchestrator.fastfail import check_fast_fail, FastFailAction
+from orchestrator.gates import HumanGate
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+SAMPLE_CAMPAIGN = {
+    "target_system": {
+        "name": "TestSystem",
+        "description": "A test system for integration testing.",
+        "observable_metrics": ["latency_ms", "throughput_rps"],
+        "controllable_knobs": ["batch_size", "worker_count"],
+    },
+    "review": {
+        "design_perspectives": ["rigor", "causal"],
+        "findings_perspectives": ["rigor", "causal"],
+        "max_review_rounds": 1,
+    },
+    "prompts": {
+        "methodology_layer": "prompts/methodology",
+        "domain_adapter_layer": None,
+    },
+}
+
+BUNDLE_YAML = """\
+metadata:
+  iteration: 1
+  family: integration-test
+  research_question: "Does batch size affect latency in TestSystem?"
+arms:
+  - type: h-main
+    prediction: "latency decreases by 20% when batch_size doubles"
+    mechanism: "Larger batches amortize fixed overhead"
+    diagnostic: "Check if overhead is actually fixed"
+  - type: h-control-negative
+    prediction: "no effect at batch_size=1"
+    mechanism: "No batching means no amortization"
+    diagnostic: "Verify single-item path"
+"""
+
+FINDINGS_JSON = json.dumps({
+    "iteration": 1,
+    "bundle_ref": "runs/iter-1/bundle.yaml",
+    "arms": [
+        {
+            "arm_type": "h-main",
+            "predicted": "latency decreases by 20% when batch_size doubles",
+            "observed": "latency decreased by 22%",
+            "status": "CONFIRMED",
+            "error_type": None,
+            "diagnostic_note": "Consistent with amortization model.",
+        },
+        {
+            "arm_type": "h-control-negative",
+            "predicted": "no effect at batch_size=1",
+            "observed": "no significant change observed",
+            "status": "CONFIRMED",
+            "error_type": None,
+            "diagnostic_note": None,
+        },
+    ],
+    "discrepancy_analysis": "All arms confirmed. Batch amortization holds.",
+}, indent=2)
+
+PRINCIPLES_JSON = json.dumps({
+    "principles": [
+        {
+            "id": "RP-1",
+            "statement": "Batch size amortizes fixed overhead",
+            "confidence": "medium",
+            "regime": "batch_size > 1",
+            "evidence": ["iteration-1-h-main"],
+            "contradicts": [],
+            "extraction_iteration": 1,
+            "mechanism": "Fixed per-request overhead shared across batch",
+            "applicability_bounds": "Only when fixed overhead dominates",
+            "superseded_by": None,
+            "category": "domain",
+            "status": "active",
+        }
+    ]
+}, indent=2)
+
+
+def _mock_responses() -> dict[tuple[str, str], str]:
+    """Map (role, phase) to canned LLM responses."""
+    return {
+        ("planner", "frame"): (
+            "# Problem Framing\n\n"
+            "## Research Question\nDoes batch size affect latency?\n\n"
+            "## Baseline\nSingle-request latency is 50ms.\n\n"
+            "## Experimental Conditions\nVary batch_size from 1 to 64.\n\n"
+            "## Success Criteria\n20% latency reduction at batch_size=32.\n\n"
+            "## Constraints\nThroughput must not degrade.\n\n"
+            "## Prior Knowledge\nNo principles extracted yet.\n"
+        ),
+        ("planner", "design"): f"```yaml\n{BUNDLE_YAML}```",
+        ("executor", "run"): f"```json\n{FINDINGS_JSON}\n```",
+        ("reviewer", "review-design"): (
+            "# Review — {perspective}\n\n"
+            "## CRITICAL\nNo CRITICAL findings.\n\n"
+            "## IMPORTANT\nNo IMPORTANT findings.\n\n"
+            "## SUGGESTION\nConsider adding a robustness arm.\n"
+        ),
+        ("reviewer", "review-findings"): (
+            "# Review — {perspective}\n\n"
+            "## CRITICAL\nNo CRITICAL findings.\n\n"
+            "## IMPORTANT\nNo IMPORTANT findings.\n\n"
+            "## SUGGESTION\nReport confidence intervals.\n"
+        ),
+        ("extractor", "extract"): f"```json\n{PRINCIPLES_JSON}\n```",
+    }
+
+
+def _make_routing_completion(responses: dict[tuple[str, str], str]):
+    """Build a completion_fn that returns canned responses based on prompt content."""
+    call_log: list[dict] = []
+
+    def mock_fn(**kwargs):
+        call_log.append(kwargs)
+        system_msg = kwargs["messages"][0]["content"]
+
+        # Determine which response to return based on prompt keywords
+        if "problem framing document" in system_msg:
+            text = responses[("planner", "frame")]
+        elif "principle store" in system_msg.lower():
+            text = responses[("extractor", "extract")]
+        elif "hypothesis bundle" in system_msg and "review" not in system_msg.lower():
+            text = responses[("planner", "design")]
+        elif "review" in system_msg.lower() and "hypothesis bundle" in system_msg.lower():
+            text = responses[("reviewer", "review-design")]
+        elif "review" in system_msg.lower() and "experiment findings" in system_msg.lower():
+            text = responses[("reviewer", "review-findings")]
+        elif "analyze" in system_msg.lower() and "findings" in system_msg.lower():
+            text = responses[("executor", "run")]
+        else:
+            text = "Unrecognized prompt."
+
+        resp = MagicMock()
+        resp.choices = [MagicMock(message=MagicMock(content=text))]
+        return resp
+
+    mock_fn.call_log = call_log  # type: ignore[attr-defined]
+    return mock_fn
+
+
+def load_schema(name: str) -> dict:
+    path = SCHEMAS_DIR / name
+    if path.suffix in (".yaml", ".yml"):
+        return yaml.safe_load(path.read_text())
+    return json.loads(path.read_text())
+
+
+@pytest.fixture(autouse=True)
+def _allow_auto_approve(monkeypatch):
+    monkeypatch.setenv("NOUS_ALLOW_AUTO_APPROVE", "1")
+
+
+def _make_gate():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return HumanGate(auto_approve=True)
+
+
+class TestSingleIterationWithMockedLLM:
+    """Drive the full orchestrator loop with LLMDispatcher and mocked LLM responses."""
+
+    @pytest.fixture()
+    def campaign_dir(self, tmp_path: Path) -> Path:
+        shutil.copy(TEMPLATES_DIR / "state.json", tmp_path / "state.json")
+        shutil.copy(TEMPLATES_DIR / "ledger.json", tmp_path / "ledger.json")
+        shutil.copy(TEMPLATES_DIR / "principles.json", tmp_path / "principles.json")
+        state = json.loads((tmp_path / "state.json").read_text())
+        state["run_id"] = "test-llm-integration-001"
+        (tmp_path / "state.json").write_text(json.dumps(state, indent=2))
+        return tmp_path
+
+    def test_full_iteration_with_mocked_llm(self, campaign_dir: Path) -> None:
+        engine = Engine(campaign_dir)
+        mock_fn = _make_routing_completion(_mock_responses())
+        dispatcher = LLMDispatcher(
+            work_dir=campaign_dir,
+            campaign=SAMPLE_CAMPAIGN,
+            completion_fn=mock_fn,
+        )
+        gate = _make_gate()
+        iter_dir = campaign_dir / "runs" / "iter-1"
+
+        # INIT -> FRAMING
+        engine.transition("FRAMING")
+        dispatcher.dispatch(
+            "planner", "frame",
+            output_path=iter_dir / "problem.md", iteration=1,
+        )
+        assert (iter_dir / "problem.md").exists()
+
+        # FRAMING -> DESIGN
+        engine.transition("DESIGN")
+        dispatcher.dispatch(
+            "planner", "design",
+            output_path=iter_dir / "bundle.yaml", iteration=1,
+        )
+        bundle = yaml.safe_load((iter_dir / "bundle.yaml").read_text())
+        jsonschema.validate(bundle, load_schema("bundle.schema.yaml"))
+
+        # DESIGN -> DESIGN_REVIEW
+        engine.transition("DESIGN_REVIEW")
+        for perspective in SAMPLE_CAMPAIGN["review"]["design_perspectives"]:
+            dispatcher.dispatch(
+                "reviewer", "review-design",
+                output_path=iter_dir / "reviews" / f"review-{perspective}.md",
+                iteration=1, perspective=perspective,
+            )
+
+        # DESIGN_REVIEW -> HUMAN_DESIGN_GATE
+        engine.transition("HUMAN_DESIGN_GATE")
+        assert gate.prompt("Approve design?") == "approve"
+
+        # HUMAN_DESIGN_GATE -> RUNNING
+        engine.transition("RUNNING")
+        dispatcher.dispatch(
+            "executor", "run",
+            output_path=iter_dir / "findings.json", iteration=1,
+        )
+        findings = json.loads((iter_dir / "findings.json").read_text())
+        jsonschema.validate(findings, load_schema("findings.schema.json"))
+
+        # Check fast-fail
+        ff = check_fast_fail(findings)
+        assert ff == FastFailAction.CONTINUE
+
+        # RUNNING -> FINDINGS_REVIEW
+        engine.transition("FINDINGS_REVIEW")
+        for perspective in SAMPLE_CAMPAIGN["review"]["findings_perspectives"]:
+            dispatcher.dispatch(
+                "reviewer", "review-findings",
+                output_path=iter_dir / "reviews" / f"review-findings-{perspective}.md",
+                iteration=1, perspective=perspective,
+            )
+
+        # FINDINGS_REVIEW -> HUMAN_FINDINGS_GATE
+        engine.transition("HUMAN_FINDINGS_GATE")
+        assert gate.prompt("Approve findings?") == "approve"
+
+        # H-main confirmed -> TUNING
+        engine.transition("TUNING")
+
+        # TUNING -> EXTRACTION
+        engine.transition("EXTRACTION")
+        dispatcher.dispatch(
+            "extractor", "extract",
+            output_path=campaign_dir / "principles.json", iteration=1,
+        )
+        principles = json.loads((campaign_dir / "principles.json").read_text())
+        jsonschema.validate(principles, load_schema("principles.schema.json"))
+        assert len(principles["principles"]) >= 1
+
+        # EXTRACTION -> DONE
+        engine.transition("DONE")
+        assert engine.phase == "DONE"
+
+        # Verify all expected artifacts exist
+        assert (iter_dir / "problem.md").exists()
+        assert (iter_dir / "bundle.yaml").exists()
+        assert (iter_dir / "findings.json").exists()
+        assert (iter_dir / "reviews").is_dir()
+
+        # Verify LLM was called the expected number of times:
+        # 1 frame + 1 design + 2 design reviewers + 1 executor +
+        # 2 findings reviewers + 1 extractor = 8
+        assert len(mock_fn.call_log) == 8

--- a/tests/test_llm_dispatch.py
+++ b/tests/test_llm_dispatch.py
@@ -97,6 +97,7 @@ VALID_FINDINGS_JSON = json.dumps({
         },
     ],
     "discrepancy_analysis": "All arms confirmed. Batch amortization mechanism validated.",
+    "dominant_component_pct": None,
 }, indent=2)
 
 VALID_PRINCIPLES_JSON = json.dumps({
@@ -325,6 +326,45 @@ class TestLLMDispatcher:
         d = _make_dispatcher(work_dir, [])
         with pytest.raises(ValueError, match="Unknown role/phase"):
             d.dispatch("wizard", "conjure", output_path=work_dir / "x", iteration=1)
+
+
+    def test_invalid_campaign_missing_target_system_raises(self, work_dir: Path) -> None:
+        bad_campaign = {"review": {}, "prompts": {}}
+        with pytest.raises(ValueError, match="missing 'target_system'"):
+            LLMDispatcher(
+                work_dir=work_dir, campaign=bad_campaign,
+                completion_fn=make_mock_completion([]),
+            )
+
+    def test_invalid_campaign_missing_keys_raises(self, work_dir: Path) -> None:
+        bad_campaign = {
+            "target_system": {"name": "X"},
+            "review": {},
+            "prompts": {},
+        }
+        with pytest.raises(ValueError, match="missing required keys"):
+            LLMDispatcher(
+                work_dir=work_dir, campaign=bad_campaign,
+                completion_fn=make_mock_completion([]),
+            )
+
+    def test_missing_bundle_for_run_raises(self, work_dir: Path) -> None:
+        # Remove the bundle so the run phase fails with a clear message
+        (work_dir / "runs" / "iter-1" / "bundle.yaml").unlink()
+        d = _make_dispatcher(work_dir, ["unused"])
+        out = work_dir / "runs" / "iter-1" / "findings_fail.json"
+        with pytest.raises(FileNotFoundError, match="design phase completed"):
+            d.dispatch("executor", "run", output_path=out, iteration=1)
+
+    def test_missing_findings_for_review_raises(self, work_dir: Path) -> None:
+        (work_dir / "runs" / "iter-1" / "findings.json").unlink()
+        d = _make_dispatcher(work_dir, ["unused"])
+        out = work_dir / "runs" / "iter-1" / "review-test.md"
+        with pytest.raises(FileNotFoundError, match="executor completed"):
+            d.dispatch(
+                "reviewer", "review-findings",
+                output_path=out, iteration=1, perspective="test",
+            )
 
 
 class TestBLISCampaign:

--- a/tests/test_llm_dispatch.py
+++ b/tests/test_llm_dispatch.py
@@ -124,6 +124,10 @@ def work_dir(tmp_path: Path) -> Path:
     """Create a work directory with minimal campaign structure."""
     iter_dir = tmp_path / "runs" / "iter-1"
     iter_dir.mkdir(parents=True)
+    (iter_dir / "problem.md").write_text(
+        "# Problem Framing\n\n## Research Question\n"
+        "Does batch size affect latency in TestSystem?\n"
+    )
     (iter_dir / "bundle.yaml").write_text(VALID_BUNDLE_YAML)
     (iter_dir / "findings.json").write_text(VALID_FINDINGS_JSON)
     (tmp_path / "principles.json").write_text(

--- a/tests/test_llm_dispatch.py
+++ b/tests/test_llm_dispatch.py
@@ -1,0 +1,323 @@
+"""Tests for LLMDispatcher — all LLM calls are mocked via completion_fn injection."""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.llm_dispatch import LLMDispatcher
+from orchestrator.protocols import Dispatcher
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+
+
+def load_schema(name: str) -> dict:
+    path = SCHEMAS_DIR / name
+    if path.suffix in (".yaml", ".yml"):
+        return yaml.safe_load(path.read_text())
+    return json.loads(path.read_text())
+
+
+# ------------------------------------------------------------------
+# Mock helpers
+# ------------------------------------------------------------------
+
+def make_mock_completion(responses: list[str]):
+    """Return a callable mimicking litellm.completion."""
+    call_log: list[dict] = []
+    idx = {"n": 0}
+
+    def mock_fn(**kwargs):
+        call_log.append(kwargs)
+        resp = MagicMock()
+        resp.choices = [MagicMock(message=MagicMock(content=responses[idx["n"]]))]
+        idx["n"] += 1
+        return resp
+
+    mock_fn.call_log = call_log  # type: ignore[attr-defined]
+    return mock_fn
+
+
+SAMPLE_CAMPAIGN = {
+    "target_system": {
+        "name": "TestSystem",
+        "description": "A test system for unit tests.",
+        "observable_metrics": ["latency_ms", "throughput_rps"],
+        "controllable_knobs": ["batch_size", "worker_count"],
+    },
+    "review": {
+        "design_perspectives": ["rigor"],
+        "findings_perspectives": ["rigor"],
+        "max_review_rounds": 1,
+    },
+    "prompts": {
+        "methodology_layer": "prompts/methodology",
+        "domain_adapter_layer": None,
+    },
+}
+
+VALID_BUNDLE_YAML = """\
+metadata:
+  iteration: 1
+  family: test-family
+  research_question: "Does batch size affect latency?"
+arms:
+  - type: h-main
+    prediction: "latency decreases by 20% when batch_size doubles"
+    mechanism: "Larger batches amortize fixed overhead"
+    diagnostic: "Check if overhead is actually fixed"
+  - type: h-control-negative
+    prediction: "no effect at batch_size=1"
+    mechanism: "No batching means no amortization"
+    diagnostic: "Verify single-item path is unchanged"
+"""
+
+VALID_FINDINGS_JSON = json.dumps({
+    "iteration": 1,
+    "bundle_ref": "runs/iter-1/bundle.yaml",
+    "arms": [
+        {
+            "arm_type": "h-main",
+            "predicted": "latency decreases by 20%",
+            "observed": "latency decreased by 18%",
+            "status": "CONFIRMED",
+            "error_type": None,
+            "diagnostic_note": "Close to predicted value.",
+        },
+        {
+            "arm_type": "h-control-negative",
+            "predicted": "no effect at batch_size=1",
+            "observed": "no significant change",
+            "status": "CONFIRMED",
+            "error_type": None,
+            "diagnostic_note": None,
+        },
+    ],
+    "discrepancy_analysis": "All arms confirmed. Batch amortization mechanism validated.",
+}, indent=2)
+
+VALID_PRINCIPLES_JSON = json.dumps({
+    "principles": [
+        {
+            "id": "RP-1",
+            "statement": "Batch size amortizes fixed overhead in TestSystem",
+            "confidence": "medium",
+            "regime": "batch_size > 1",
+            "evidence": ["iteration-1-h-main"],
+            "contradicts": [],
+            "extraction_iteration": 1,
+            "mechanism": "Fixed per-request overhead is shared across batch items",
+            "applicability_bounds": "Only when fixed overhead dominates",
+            "superseded_by": None,
+            "category": "domain",
+            "status": "active",
+        }
+    ]
+}, indent=2)
+
+
+@pytest.fixture()
+def work_dir(tmp_path: Path) -> Path:
+    """Create a work directory with minimal campaign structure."""
+    iter_dir = tmp_path / "runs" / "iter-1"
+    iter_dir.mkdir(parents=True)
+    (iter_dir / "bundle.yaml").write_text(VALID_BUNDLE_YAML)
+    (iter_dir / "findings.json").write_text(VALID_FINDINGS_JSON)
+    (tmp_path / "principles.json").write_text(
+        json.dumps({"principles": []}, indent=2)
+    )
+    return tmp_path
+
+
+def _make_dispatcher(
+    work_dir: Path, responses: list[str], **kwargs
+) -> LLMDispatcher:
+    return LLMDispatcher(
+        work_dir=work_dir,
+        campaign=SAMPLE_CAMPAIGN,
+        completion_fn=make_mock_completion(responses),
+        **kwargs,
+    )
+
+
+# ------------------------------------------------------------------
+# Unit tests
+# ------------------------------------------------------------------
+
+class TestLLMDispatcher:
+    def test_dispatch_planner_frame_writes_problem_md(self, work_dir: Path) -> None:
+        md = "# Problem Framing\n\n## Research Question\nDoes batch size matter?"
+        d = _make_dispatcher(work_dir, [md])
+        out = work_dir / "runs" / "iter-1" / "problem.md"
+
+        d.dispatch("planner", "frame", output_path=out, iteration=1)
+
+        assert out.exists()
+        assert "Research Question" in out.read_text()
+
+    def test_dispatch_planner_design_produces_valid_bundle(self, work_dir: Path) -> None:
+        resp = f"Here is the bundle:\n\n```yaml\n{VALID_BUNDLE_YAML}```"
+        d = _make_dispatcher(work_dir, [resp])
+        out = work_dir / "runs" / "iter-1" / "bundle_out.yaml"
+
+        d.dispatch("planner", "design", output_path=out, iteration=1)
+
+        bundle = yaml.safe_load(out.read_text())
+        schema = load_schema("bundle.schema.yaml")
+        jsonschema.validate(bundle, schema)
+
+    def test_dispatch_executor_produces_valid_findings(self, work_dir: Path) -> None:
+        resp = f"Analysis:\n\n```json\n{VALID_FINDINGS_JSON}\n```"
+        d = _make_dispatcher(work_dir, [resp])
+        out = work_dir / "runs" / "iter-1" / "findings_out.json"
+
+        d.dispatch("executor", "run", output_path=out, iteration=1)
+
+        findings = json.loads(out.read_text())
+        schema = load_schema("findings.schema.json")
+        jsonschema.validate(findings, schema)
+
+    def test_dispatch_reviewer_produces_markdown(self, work_dir: Path) -> None:
+        review_md = "# Review — rigor\n\n## CRITICAL\nNo CRITICAL findings.\n"
+        d = _make_dispatcher(work_dir, [review_md])
+        out = work_dir / "runs" / "iter-1" / "review-rigor.md"
+
+        d.dispatch(
+            "reviewer", "review-design",
+            output_path=out, iteration=1, perspective="rigor",
+        )
+
+        assert out.exists()
+        assert "rigor" in out.read_text()
+
+    def test_dispatch_extractor_writes_principles(self, work_dir: Path) -> None:
+        resp = f"Updated principles:\n\n```json\n{VALID_PRINCIPLES_JSON}\n```"
+        d = _make_dispatcher(work_dir, [resp])
+        out = work_dir / "principles.json"
+
+        d.dispatch("extractor", "extract", output_path=out, iteration=1)
+
+        store = json.loads(out.read_text())
+        assert len(store["principles"]) == 1
+        assert store["principles"][0]["id"] == "RP-1"
+
+    def test_schema_validation_failure_retries_once(self, work_dir: Path) -> None:
+        # First response: invalid bundle (missing research_question)
+        bad_yaml = "metadata:\n  iteration: 1\n  family: x\narms:\n  - type: h-main\n    prediction: p\n    mechanism: m\n    diagnostic: d\n"
+        bad_resp = f"```yaml\n{bad_yaml}```"
+        good_resp = f"```yaml\n{VALID_BUNDLE_YAML}```"
+        mock_fn = make_mock_completion([bad_resp, good_resp])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = work_dir / "runs" / "iter-1" / "bundle_retry.yaml"
+
+        d.dispatch("planner", "design", output_path=out, iteration=1)
+
+        assert len(mock_fn.call_log) == 2
+        bundle = yaml.safe_load(out.read_text())
+        assert bundle["metadata"]["research_question"] is not None
+
+    def test_schema_validation_failure_after_retry_raises(self, work_dir: Path) -> None:
+        bad_yaml = "metadata:\n  iteration: 1\n  family: x\narms:\n  - type: h-main\n    prediction: p\n    mechanism: m\n    diagnostic: d\n"
+        bad_resp = f"```yaml\n{bad_yaml}```"
+        mock_fn = make_mock_completion([bad_resp, bad_resp])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = work_dir / "runs" / "iter-1" / "bundle_fail.yaml"
+
+        with pytest.raises(RuntimeError, match="schema validation after retry"):
+            d.dispatch("planner", "design", output_path=out, iteration=1)
+
+    def test_missing_prompt_template_raises(self, work_dir: Path, tmp_path: Path) -> None:
+        empty_prompts = tmp_path / "empty_prompts"
+        empty_prompts.mkdir()
+        d = _make_dispatcher(work_dir, ["unused"], prompts_dir=empty_prompts)
+        out = work_dir / "out.md"
+
+        with pytest.raises(FileNotFoundError):
+            d.dispatch("planner", "frame", output_path=out, iteration=1)
+
+    def test_protocol_conformance(self, work_dir: Path) -> None:
+        d = _make_dispatcher(work_dir, [])
+        assert isinstance(d, Dispatcher)
+
+    def test_context_includes_campaign_fields(self, work_dir: Path) -> None:
+        md = "# Framing\n\nStub output."
+        mock_fn = make_mock_completion([md])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = work_dir / "runs" / "iter-1" / "problem.md"
+
+        d.dispatch("planner", "frame", output_path=out, iteration=1)
+
+        system_prompt = mock_fn.call_log[0]["messages"][0]["content"]
+        assert "TestSystem" in system_prompt
+        assert "latency_ms" in system_prompt
+        assert "batch_size" in system_prompt
+
+    def test_context_includes_active_principles(self, work_dir: Path) -> None:
+        (work_dir / "principles.json").write_text(VALID_PRINCIPLES_JSON)
+        resp = f"```yaml\n{VALID_BUNDLE_YAML}```"
+        mock_fn = make_mock_completion([resp])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = work_dir / "runs" / "iter-1" / "bundle_principles.yaml"
+
+        d.dispatch("planner", "design", output_path=out, iteration=1)
+
+        system_prompt = mock_fn.call_log[0]["messages"][0]["content"]
+        assert "Batch size amortizes fixed overhead" in system_prompt
+
+    def test_h_main_result_ignored(self, work_dir: Path) -> None:
+        resp = f"```json\n{VALID_FINDINGS_JSON}\n```"
+        mock_fn = make_mock_completion([resp])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = work_dir / "runs" / "iter-1" / "findings_hmain.json"
+
+        # Pass REFUTED but executor should still use its own analysis
+        d.dispatch(
+            "executor", "run", output_path=out, iteration=1, h_main_result="REFUTED",
+        )
+
+        findings = json.loads(out.read_text())
+        # The mock response has CONFIRMED — proving h_main_result was ignored
+        assert findings["arms"][0]["status"] == "CONFIRMED"
+
+    def test_no_code_fence_falls_back_to_raw_parse(self, work_dir: Path) -> None:
+        # Return raw JSON without code fence
+        d = _make_dispatcher(work_dir, [VALID_FINDINGS_JSON])
+        out = work_dir / "runs" / "iter-1" / "findings_raw.json"
+
+        d.dispatch("executor", "run", output_path=out, iteration=1)
+
+        findings = json.loads(out.read_text())
+        schema = load_schema("findings.schema.json")
+        jsonschema.validate(findings, schema)
+
+    def test_multiple_code_fences_uses_last(self, work_dir: Path) -> None:
+        first_json = json.dumps({"bad": True})
+        resp = (
+            f"First attempt:\n```json\n{first_json}\n```\n\n"
+            f"Corrected:\n```json\n{VALID_FINDINGS_JSON}\n```"
+        )
+        d = _make_dispatcher(work_dir, [resp])
+        out = work_dir / "runs" / "iter-1" / "findings_multi.json"
+
+        d.dispatch("executor", "run", output_path=out, iteration=1)
+
+        findings = json.loads(out.read_text())
+        assert "arms" in findings  # Used the valid last fence, not the bad first one
+
+    def test_unknown_role_phase_raises(self, work_dir: Path) -> None:
+        d = _make_dispatcher(work_dir, [])
+        with pytest.raises(ValueError, match="Unknown role/phase"):
+            d.dispatch("wizard", "conjure", output_path=work_dir / "x", iteration=1)

--- a/tests/test_llm_dispatch.py
+++ b/tests/test_llm_dispatch.py
@@ -42,6 +42,7 @@ def make_mock_completion(responses: list[str]):
 
 
 SAMPLE_CAMPAIGN = {
+    "research_question": "Does batch size affect latency in TestSystem?",
     "target_system": {
         "name": "TestSystem",
         "description": "A test system for unit tests.",

--- a/tests/test_llm_dispatch.py
+++ b/tests/test_llm_dispatch.py
@@ -321,3 +321,11 @@ class TestLLMDispatcher:
         d = _make_dispatcher(work_dir, [])
         with pytest.raises(ValueError, match="Unknown role/phase"):
             d.dispatch("wizard", "conjure", output_path=work_dir / "x", iteration=1)
+
+
+class TestBLISCampaign:
+    def test_blis_campaign_validates_against_schema(self) -> None:
+        blis_path = Path(__file__).resolve().parent.parent / "examples" / "blis" / "campaign.yaml"
+        campaign = yaml.safe_load(blis_path.read_text())
+        schema = load_schema("campaign.schema.yaml")
+        jsonschema.validate(campaign, schema)

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -1,0 +1,77 @@
+"""Tests for the prompt template loader."""
+from pathlib import Path
+
+import pytest
+
+from orchestrator.prompt_loader import PromptLoader
+
+
+@pytest.fixture()
+def prompts_dir(tmp_path: Path) -> Path:
+    """Create a temporary prompts directory with sample templates."""
+    d = tmp_path / "prompts"
+    d.mkdir()
+    return d
+
+
+def _write_template(prompts_dir: Path, name: str, content: str) -> None:
+    (prompts_dir / f"{name}.md").write_text(content)
+
+
+class TestPromptLoader:
+    def test_load_and_render(self, prompts_dir: Path) -> None:
+        _write_template(prompts_dir, "greet", "Hello, {{name}}!")
+        loader = PromptLoader(prompts_dir)
+
+        result = loader.load("greet", {"name": "Alice"})
+
+        assert result == "Hello, Alice!"
+
+    def test_missing_template_raises_file_not_found(self, prompts_dir: Path) -> None:
+        loader = PromptLoader(prompts_dir)
+
+        with pytest.raises(FileNotFoundError, match="no_such_template"):
+            loader.load("no_such_template", {})
+
+    def test_unreplaced_placeholder_raises_value_error(self, prompts_dir: Path) -> None:
+        _write_template(prompts_dir, "needs_ctx", "Value: {{missing}}")
+        loader = PromptLoader(prompts_dir)
+
+        with pytest.raises(ValueError, match="missing"):
+            loader.load("needs_ctx", {})
+
+    def test_extra_context_keys_ignored(self, prompts_dir: Path) -> None:
+        _write_template(prompts_dir, "simple", "Just text.")
+        loader = PromptLoader(prompts_dir)
+
+        result = loader.load("simple", {"unused_key": "whatever"})
+
+        assert result == "Just text."
+
+    def test_multiple_placeholders_replaced(self, prompts_dir: Path) -> None:
+        _write_template(
+            prompts_dir,
+            "multi",
+            "System: {{system}}\nMetric: {{metric}}\nKnob: {{knob}}",
+        )
+        loader = PromptLoader(prompts_dir)
+
+        result = loader.load("multi", {
+            "system": "BLIS",
+            "metric": "TTFT",
+            "knob": "batch_size",
+        })
+
+        assert result == "System: BLIS\nMetric: TTFT\nKnob: batch_size"
+
+    def test_same_placeholder_multiple_times(self, prompts_dir: Path) -> None:
+        _write_template(
+            prompts_dir,
+            "repeat",
+            "{{name}} is great. We love {{name}}.",
+        )
+        loader = PromptLoader(prompts_dir)
+
+        result = loader.load("repeat", {"name": "Nous"})
+
+        assert result == "Nous is great. We love Nous."

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -517,6 +517,7 @@ class TestCampaignSchema:
     def test_valid_campaign(self, load_schema):
         schema = load_schema("campaign.schema.yaml")
         instance = {
+            "research_question": "Can routing algorithms reduce tail latency?",
             "target_system": {
                 "name": "BLIS",
                 "description": "LLM inference serving simulator",
@@ -538,6 +539,7 @@ class TestCampaignSchema:
     def test_minimal_campaign(self, load_schema):
         schema = load_schema("campaign.schema.yaml")
         instance = {
+            "research_question": "What affects latency?",
             "target_system": {
                 "name": "my-system",
                 "description": "A system.",
@@ -610,6 +612,7 @@ class TestCampaignSchema:
     def test_extra_top_level_field_rejected(self, load_schema):
         schema = load_schema("campaign.schema.yaml")
         instance = {
+            "research_question": "What affects latency?",
             "target_system": {
                 "name": "x",
                 "description": "x",


### PR DESCRIPTION
## Summary

Implements #8 — replaces stub agents with real LLM-driven agents via LiteLLM.

- **LLMDispatcher** (`orchestrator/llm_dispatch.py`): model-agnostic LLM dispatch using `litellm.completion()`, with `completion_fn` injection for testing, code fence extraction, JSON Schema validation with one-retry, and atomic artifact writes
- **PromptLoader** (`orchestrator/prompt_loader.py`): loads markdown templates with `{{placeholder}}` rendering, strict validation of unreplaced placeholders
- **6 methodology prompt templates** (`prompts/methodology/`): frame, design, run, review_design, review_findings, extract — the generic scientific method layer
- **BLIS example** (`examples/blis/`): reference `campaign.yaml` and step-by-step README
- **Quickstart guide** (`docs/quickstart.md`): how to run Nous on any target system via Python API
- Shared `atomic_write` utility extracted to `orchestrator/util.py`
- Updated architecture, data-model, and README docs for Phase 2

### Phase 2 limitation

The executor operates in **analysis mode** — it reasons about the target system but does not run actual experiments. Real experiment execution comes in Phase 3 (plugin shell access).

### Test coverage

168 tests total (27 new):
- 6 prompt loader tests
- 20 LLM dispatch unit tests (all mocked via `completion_fn`)
- 1 full integration test driving Engine through all 11 states with mocked LLM

## Test plan

- [x] `pytest tests/ -v` — all 168 tests pass
- [x] `examples/blis/campaign.yaml` validates against `campaign.schema.yaml`
- [x] All prompt templates render without errors with BLIS context
- [x] LLMDispatcher satisfies `Dispatcher` protocol (`isinstance` check passes)
- [x] Schema validation retry: first response invalid → retry → second response valid
- [x] Schema validation exhaustion: both responses invalid → `RuntimeError` raised
- [x] Full orchestrator loop (INIT → DONE) completes with mocked LLM responses
- [x] Campaign config validation catches typos at init time
- [x] Missing artifacts raise contextual `FileNotFoundError`
- [x] Code review and silent-failure-hunter agents run; all findings addressed

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)