### PR TITLE
feat: Phase 4 — Multi-iteration campaigns with compounding knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ Then set `repo_path` in `examples/blis/campaign.yaml` to your BLIS checkout path
 python run_iteration.py examples/blis/campaign.yaml
 ```
 
+### 5. Run a multi-iteration campaign
+
+```bash
+python run_campaign.py examples/blis/campaign.yaml --max-iterations 5
+```
+
+The campaign loops through iterations, pausing at human gates (design, findings, and continue gates). After each iteration, it generates an investigation summary that feeds into the next design prompt. See [docs/quickstart.md](docs/quickstart.md) for details.
+
 ### What to expect
 
 The script walks through these phases, printing progress:
@@ -140,6 +148,7 @@ schemas/                 JSON Schema definitions (Draft 2020-12)
   campaign.schema.yaml     Campaign configuration (target system, reviewers, prompts)
   experiment_plan.schema.json  Executor experiment commands (real execution)
   findings.schema.json     Prediction-vs-outcome results
+  investigation_summary.schema.json  Bounded iteration summary for cross-iteration learning
   principles.schema.json   Living principle store
   state.schema.json        Orchestrator checkpoint
   ledger.schema.json       Append-only iteration log
@@ -162,6 +171,7 @@ orchestrator/            Python orchestrator (deterministic, not an LLM)
   prompt_loader.py         Template loading with {{placeholder}} rendering
   gates.py                 Human approval gates
   fastfail.py              Fast-fail rule evaluation
+  ledger.py                Deterministic ledger append (no LLM)
   worktree.py              Git worktree isolation for experiments
   protocols.py             Dispatcher and Gate interface contracts
   util.py                  Shared utilities (atomic_write)
@@ -176,6 +186,7 @@ prompts/                 Methodology prompt templates
     review_design.md       Design review from a perspective (reviewer)
     review_findings.md     Findings review from a perspective (reviewer)
     extract.md             Principle extraction (extractor)
+    summarize.md           Investigation summary (extractor)
 
 examples/
   blis/                    Reference campaign for BLIS inference simulator
@@ -211,9 +222,11 @@ See [docs/contributing/workflow.md](docs/contributing/workflow.md) for the Claud
 
 **Phase 2 (complete):** Agent prompts and real LLM dispatch. `LLMDispatcher` replaces stubs with LLM-driven agents via the OpenAI SDK (works with any OpenAI-compatible endpoint). Methodology prompt templates, schema validation with retry, and a BLIS example campaign.
 
-**Phase 3 (current):** Real experiment execution. The executor runs actual experiments via shell commands, collects real metrics, and analyzes results. Two-phase executor dispatch (plan commands → run → analyze), git worktree isolation for experiments, configurable timeouts, and backward-compatible `execution` config in `campaign.yaml`. Systems without execution config fall back to analysis mode.
+**Phase 3 (complete):** Real experiment execution. The executor runs actual experiments via shell commands, collects real metrics, and analyzes results. Two-phase executor dispatch (plan commands → run → analyze), git worktree isolation for experiments, configurable timeouts, and backward-compatible `execution` config in `campaign.yaml`. Systems without execution config fall back to analysis mode.
 
-**Phase 4 (next):** Multi-iteration campaigns — automated iteration loops, ledger tracking, and convergence detection.
+**Phase 4 (complete):** Multi-iteration campaigns. `run_campaign.py` loops through iterations with human continue gates, deterministic ledger tracking, and bounded investigation summaries that feed into each subsequent iteration's design prompt. Knowledge compounds across iterations via principles and summaries.
+
+**Phase 5 (next):** Domain adapter layer, cost tracking, and trace population.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ python run_iteration.py examples/blis/campaign.yaml
 python run_campaign.py examples/blis/campaign.yaml --max-iterations 5
 ```
 
-The campaign loops through iterations, pausing at human gates (design, findings, and continue gates). After each iteration, it generates an investigation summary that feeds into the next design prompt. See [docs/quickstart.md](docs/quickstart.md) for details.
+The campaign loops through iterations, pausing at human gates (design, findings, and continue gates). After each non-final iteration, it generates an investigation summary that feeds into the next design prompt. See [docs/quickstart.md](docs/quickstart.md) for details.
 
 ### What to expect
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,7 @@ This separation exists because:
                     │    bundle.yaml   findings.json       │
                     │    experiment_plan.json (real exec)  │
                     │    experiment_results.json (real exec)│
+                    │    investigation_summary.json         │
                     │    metrics/      reviews/            │
                     │                  summary.json        │
                     └─────────────────────────────────────┘
@@ -99,7 +100,7 @@ The dispatcher invokes AI agents by role and phase, passing structured input and
 | **Planner** | FRAMING, DESIGN | `problem.md`, `bundle.yaml` |
 | **Executor** | RUNNING | `experiment_plan.json`, `experiment_results.json`, `findings.json` |
 | **Reviewer** | DESIGN_REVIEW, FINDINGS_REVIEW | `review-*.md` |
-| **Extractor** | EXTRACTION | Updated `principles.json` |
+| **Extractor** | EXTRACTION | Updated `principles.json`, `investigation_summary.json` |
 
 **Implementations:**
 
@@ -178,6 +179,10 @@ dispatcher = LLMDispatcher(..., api_base="https://my-proxy.example.com", api_key
 
 Default model: `aws/claude-opus-4-6`. The `completion_fn` constructor parameter allows test injection without mocking internals.
 
+### Ledger (`orchestrator/ledger.py`)
+
+Deterministic module that appends a schema-conformant row to `ledger.json` after each iteration. Reads `findings.json`, `bundle.yaml`, and `principles.json` to extract: h_main_result, ablation_results, control_result, robustness_result, prediction accuracy, and principle changes. No LLM calls — purely deterministic computation.
+
 ### Gates (`orchestrator/gates.py`)
 
 Human gates are hard stops that cannot be bypassed. They surface the artifact and review summaries, then wait for a decision.
@@ -192,6 +197,7 @@ Human gates are hard stops that cannot be bypassed. They surface the artifact an
 **Where gates appear:**
 1. After DESIGN_REVIEW — human sees the hypothesis bundle and all review summaries
 2. After FINDINGS_REVIEW — human sees the findings and all review summaries
+3. After EXTRACTION (multi-iteration only) — human decides whether to continue to the next iteration
 
 ### Fast-Fail Rules (`orchestrator/fastfail.py`)
 
@@ -271,6 +277,36 @@ principles.json grows and refines over time:
 
 Principles are hard constraints: the Planner must not design bundles that contradict active principles without explicit justification.
 
+### Multi-Iteration Campaign Flow
+
+`run_campaign.py` loops through iterations, adding post-iteration steps between each one:
+
+```
+for i in 1..max_iterations:
+  ┌─────────────────────────────────────────────────────┐
+  │  run_iteration(iteration=i, final=(i==max))         │
+  │    FRAMING → DESIGN → REVIEW → RUNNING → EXTRACTION │
+  └─────────────────────┬───────────────────────────────┘
+                        │
+                  (if not final)
+                        │
+              append_ledger_row(i)
+              dispatch("extractor", "summarize")
+                → investigation_summary.json
+                        │
+              CONTINUE GATE: "Continue to iteration i+1?"
+                        │
+              engine.transition("DESIGN")
+                  (increments iteration counter)
+                        │
+                    next iteration
+                  (summary injected into design prompt)
+```
+
+The investigation summary is bounded — it captures what was tested, key findings, open questions, and suggested next direction. This keeps agent context at O(summary) regardless of how many iterations have run.
+
+The deterministic ledger (`orchestrator/ledger.py`) appends one row per iteration with prediction accuracy and principle changes, without any LLM calls.
+
 ## Schema Contracts
 
 Every artifact exchanged between components is validated against a JSON Schema (Draft 2020-12). This ensures agents produce well-formed output and makes the system testable without LLMs.
@@ -282,6 +318,7 @@ Every artifact exchanged between components is validated against a JSON Schema (
 | `state.schema.json` | JSON | Orchestrator checkpoint (phase, iteration, run_id, config_ref) |
 | `bundle.schema.yaml` | YAML | Hypothesis bundles (arms with predictions, mechanisms, diagnostics) |
 | `findings.schema.json` | JSON | Prediction-vs-outcome tables with error classification |
+| `investigation_summary.schema.json` | JSON | Bounded iteration summary for cross-iteration context |
 | `principles.schema.json` | JSON | Principle store (statement, confidence, regime, evidence, category, status) |
 | `ledger.schema.json` | JSON | Append-only iteration log with prediction accuracy and domain metrics |
 | `summary.schema.json` | JSON | Campaign rollup (cost, tokens, principles extracted) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,14 +39,13 @@ This separation exists because:
                     │                                      │
                     │  campaign.yaml   state.json          │
                     │  ledger.json     principles.json     │
-                    │  problem.md                          │
+                    │  problem.md      summary.json        │
                     │  runs/iter-N/    trace.jsonl         │
                     │    bundle.yaml   findings.json       │
                     │    experiment_plan.json (real exec)  │
                     │    experiment_results.json (real exec)│
                     │    investigation_summary.json         │
                     │    metrics/      reviews/            │
-                    │                  summary.json        │
                     └─────────────────────────────────────┘
 ```
 
@@ -100,7 +99,7 @@ The dispatcher invokes AI agents by role and phase, passing structured input and
 | **Planner** | FRAMING, DESIGN | `problem.md`, `bundle.yaml` |
 | **Executor** | RUNNING | `experiment_plan.json`, `experiment_results.json`, `findings.json` |
 | **Reviewer** | DESIGN_REVIEW, FINDINGS_REVIEW | `review-*.md` |
-| **Extractor** | EXTRACTION | Updated `principles.json`, `investigation_summary.json` |
+| **Extractor** | EXTRACTION, post-iteration | Updated `principles.json`, `investigation_summary.json` |
 
 **Implementations:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,7 +132,7 @@ Prompts have two layers:
 | **Methodology layer** | Ships with Nous (`prompts/methodology/`) | Generic scientific method: "check for confounds", "is the causal mechanism plausible?", "are 3 seeds enough?" |
 | **Domain adapter layer** | Generated per system from `campaign.yaml` | System-specific vocabulary, metrics, knobs, experiment commands |
 
-The methodology layer is 6 prompt templates (one per role+phase combination). At dispatch time, `PromptLoader` renders each template by replacing `{{placeholder}}` markers with domain-specific context from `campaign.yaml`:
+The methodology layer is 9 prompt templates (one per role+phase combination). At dispatch time, `PromptLoader` renders each template by replacing `{{placeholder}}` markers with domain-specific context from `campaign.yaml`:
 
 - `{{target_system}}`, `{{system_description}}` — from `campaign.yaml`
 - `{{observable_metrics}}`, `{{controllable_knobs}}` — from `campaign.yaml`
@@ -362,7 +362,7 @@ The orchestrator is designed for crash-safe operation:
 
 - **Atomic state writes:** `state.json` is written to a temp file, fsynced, then renamed. A crash during write leaves the previous valid state intact.
 - **Checkpoint/resume:** The engine loads state from `state.json` on construction. Kill the process at any point and restart — it resumes from the last committed state.
-- **Append-only ledger:** `ledger.json` is never rewritten, only appended to. Lost writes lose at most the current row.
+- **Append-only ledger:** `ledger.json` is logically append-only — rows are never modified or deleted. Implementation reads, appends, and atomically rewrites the file.
 - **Idempotent extraction:** The extractor reads the existing `principles.json`, appends new principles, and writes back. Re-running extraction for the same iteration produces a duplicate (detectable by ID) rather than corruption.
 
 ## Extending Nous

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,10 +1,10 @@
 # Data Model Guide
 
-Nous uses 8 schema-governed artifacts to drive the investigation loop. This guide explains each one in plain English.
+Nous uses 9 schema-governed artifacts to drive the investigation loop. This guide explains each one in plain English.
 
 ## How They Fit Together
 
-`campaign.yaml` describes the target system and configures the reviewer panel. `state.json` drives the loop. Each iteration produces a `bundle.yaml` (experiment plan) and `findings.json` (results). The `ledger.json` records what happened. `principles.json` accumulates knowledge across iterations. `trace.jsonl` logs everything. `summary.json` wraps it all up at the end.
+`campaign.yaml` describes the target system and configures the reviewer panel. `state.json` drives the loop. Each iteration produces a `bundle.yaml` (experiment plan) and `findings.json` (results). The `ledger.json` records what happened. `principles.json` accumulates knowledge across iterations. After each non-final iteration, `investigation_summary.json` captures a bounded summary that feeds into the next iteration's design prompt. `trace.jsonl` logs everything. `summary.json` wraps it all up at the end.
 
 ```
 campaign.yaml       "What system?"          Target system, reviewers, prompts
@@ -14,12 +14,14 @@ state.json          "Where are we?"         Drives the loop
     │
     ▼
 bundle.yaml         "What are we testing?"  Experiment plan for this iteration
-    │
-    ▼
-findings.json       "What happened?"        Prediction vs outcome, arm by arm
-    │
-    ├──▶ ledger.json       "What happened each iteration?"  Append-only history
-    ├──▶ principles.json   "What have we learned?"          Living knowledge base
+    │                                        ▲
+    ▼                                        │ (injected into design prompt)
+findings.json       "What happened?"         │
+    │                                        │
+    ├──▶ ledger.json                 investigation_summary.json
+    │       "What happened each iteration?"  "What did we learn this round?"
+    │                                        Bounded summary for next iteration
+    ├──▶ principles.json   "What have we learned?"   Living knowledge base
     └──▶ trace.jsonl       "What happened under the hood?"  Activity log
                                                              │
                                                              ▼
@@ -191,7 +193,24 @@ The experiment results. Compares what we predicted to what we observed, arm by a
 - H-control-negative refuted → mechanism confounded, go back to DESIGN
 - Dominant component >80% → simplify the strategy
 
-## 6. trace.jsonl — "What happened under the hood?"
+## 6. investigation_summary.json — "What did we learn this round?"
+
+**Schema:** `schemas/investigation_summary.schema.json`
+
+A bounded summary produced after each non-final iteration by the Extractor agent. It captures the essential learnings from the iteration in a form that can be injected into the next iteration's design prompt. This is what enables cross-iteration learning without growing agent context proportionally to campaign depth.
+
+| Field | What it means |
+|---|---|
+| `iteration` | Which iteration this summarizes |
+| `what_was_tested` | The hypothesis family and key arms tested |
+| `key_findings` | Main results — what was confirmed, refuted, or surprising |
+| `principles_changed` | Which principles were inserted, updated, or pruned |
+| `open_questions` | What remains unanswered — candidate questions for the next iteration |
+| `suggested_next_direction` | Recommended focus area for the next iteration |
+
+Located at `runs/iter-N/investigation_summary.json`. The design prompt for iteration N+1 receives this summary to inform hypothesis bundle creation.
+
+## 7. trace.jsonl — "What happened under the hood?"
 
 **Schema:** `schemas/trace.schema.json`
 
@@ -214,7 +233,7 @@ The orchestrator invokes agents through a dispatcher. Two implementations exist:
 
 `LLMDispatcher` reads `campaign.yaml` at construction time and injects domain-specific context (target system name, metrics, knobs, active principles) into prompt templates from `prompts/methodology/`. For structured outputs (bundle, findings, principles), it extracts content from code fences and validates against the relevant schema before writing. The FRAMING phase dispatches `role="planner", phase="frame"` to produce `problem.md`.
 
-## 7. summary.json — "How did the whole campaign go?"
+## 8. summary.json — "How did the whole campaign go?"
 
 **Schema:** `schemas/summary.schema.json`
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -222,7 +222,7 @@ An activity log. One JSON line per event — every LLM call, tool invocation, st
 | `event_type` | `llm_call`, `tool_call`, `state_transition`, or `gate_decision` |
 | `payload` | Event-specific details (tokens used, from/to state, approval decision, etc.) |
 
-Phase 1 defines the envelope; Phase 4 will tighten per-event-type payload schemas.
+Phase 1 defines the envelope; per-event-type payload schemas are planned for a future phase.
 
 ## Dispatch and Prompt Templates
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -224,7 +224,7 @@ Backward/looping transitions:
 | Planner | Frame, Design | all | `problem.md`, `bundle.yaml` | — |
 | Executor | Run, Tune | all | `findings.json`, `results/` | yes |
 | Reviewer | Design Review, Findings Review | all | `review-*.md` | — |
-| Extractor | Extract | all | `principles.json`, `summary.md` | — |
+| Extractor | Extract | all | `principles.json`, `investigation_summary.json`, `summary.json` | — |
 
 ### File Layout
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -224,7 +224,7 @@ Backward/looping transitions:
 | Planner | Frame, Design | all | `problem.md`, `bundle.yaml` | — |
 | Executor | Run, Tune | all | `findings.json`, `results/` | yes |
 | Reviewer | Design Review, Findings Review | all | `review-*.md` | — |
-| Extractor | Extract | all | `principles.json`, `investigation_summary.json`, `summary.json` | — |
+| Extractor | Extract | all | `principles.json`, `investigation_summary.json` | — |
 
 ### File Layout
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -167,10 +167,11 @@ SUGGESTION-level items do not block advancement. Only CRITICAL findings block th
 
 ## Human Gates
 
-Two hard stops require explicit human approval:
+Three hard stops require explicit human approval:
 
 1. **Design Approval** (after Design Review) — the human sees the hypothesis bundle and all review summaries, then approves, rejects, or aborts the campaign.
 2. **Findings Approval** (after Findings Review) — the human sees the findings and all review summaries, then approves, rejects, or aborts.
+3. **Continue Gate** (after Extraction, multi-iteration only) — the human decides whether to continue to the next iteration or stop the campaign. This gate only appears when using `run_campaign.py`.
 
 Human gates cannot be bypassed. They are the mechanism by which domain expertise enters the loop.
 
@@ -185,6 +186,8 @@ The orchestrator enforces three rules to avoid wasted work:
 ## Stopping Criteria
 
 A campaign stops when:
+- The `--max-iterations` limit is reached (default: 10, configurable via CLI flag or `max_iterations` in `campaign.yaml`)
+- The human chooses to stop at the continue gate after any iteration
 - Consecutive iterations produce null or marginal results (no new principles extracted)
 - The human decides the research question has been sufficiently answered
 - The principle store has stabilized (no inserts, updates, or prunes for N iterations)
@@ -238,6 +241,7 @@ campaign-dir/
       experiment_plan.json   — executor commands (real execution only)
       experiment_results.json — collected metrics (real execution only)
       findings.json    — prediction vs outcome
+      investigation_summary.json — bounded iteration summary
       metrics/        — per-arm metric files (real execution only)
       reviews/        — multi-perspective reviews
   trace.jsonl         — observability log
@@ -246,9 +250,14 @@ campaign-dir/
 
 ## Investigation Summary
 
-After each Extraction phase, the Extractor produces a bounded investigation summary. The next iteration's Design prompt receives:
-- Research question
-- Investigation summary (what's been tried, what principles hold, open questions)
-- Last iteration outcome
+After each non-final Extraction phase, the Extractor produces a bounded investigation summary (`investigation_summary.json`). This summary captures:
 
-This keeps agent context at O(summary) regardless of campaign depth. The full ledger remains on disk for audit purposes but is not passed to agents.
+- **What was tested** — the hypothesis family and arms
+- **Key findings** — what was confirmed, refuted, or unexpected
+- **Principles changed** — which principles were inserted, updated, or pruned
+- **Open questions** — what remains unanswered
+- **Suggested next direction** — where the next iteration should focus
+
+The next iteration's Design prompt receives this summary alongside the active principles and campaign context. This keeps agent context at O(summary) regardless of campaign depth — the Planner does not need to read the full history of all prior iterations.
+
+The full ledger (`ledger.json`) remains on disk for audit and analysis but is not passed to agents. The deterministic ledger module (`orchestrator/ledger.py`) appends one row per iteration with prediction accuracy and principle changes, without any LLM calls.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -224,7 +224,7 @@ Backward/looping transitions:
 | Planner | Frame, Design | all | `problem.md`, `bundle.yaml` | — |
 | Executor | Run, Tune | all | `findings.json`, `results/` | yes |
 | Reviewer | Design Review, Findings Review | all | `review-*.md` | — |
-| Extractor | Extract | all | `principles.json`, `investigation_summary.json` | — |
+| Extractor | Extract, Summarize | all | `principles.json`, `investigation_summary.json` | — |
 
 ### File Layout
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -143,7 +143,7 @@ For investigations that require more than one iteration, use `run_campaign.py`:
 python run_campaign.py campaign.yaml --max-iterations 5
 ```
 
-This loops through iterations automatically. After each iteration:
+This loops through iterations automatically. After each non-final iteration:
 
 1. A **ledger row** is appended with prediction accuracy and principle changes
 2. An **investigation summary** is generated — a bounded JSON capturing what was tested, key findings, and suggested next direction

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Run a single Nous iteration on any target system.
+Run Nous iterations on any target system — single or multi-iteration campaigns.
 
 ## Prerequisites
 
@@ -134,6 +134,58 @@ Optional execution fields:
 | `timeout` | 300 | Max seconds per command |
 
 Without an `execution` section, the executor operates in **analysis mode** — reasoning about the system without running experiments.
+
+## Run a multi-iteration campaign
+
+For investigations that require more than one iteration, use `run_campaign.py`:
+
+```bash
+python run_campaign.py campaign.yaml --max-iterations 5
+```
+
+This loops through iterations automatically. After each iteration:
+
+1. A **ledger row** is appended with prediction accuracy and principle changes
+2. An **investigation summary** is generated — a bounded JSON capturing what was tested, key findings, and suggested next direction
+3. A **continue gate** pauses for your approval before starting the next iteration
+
+The investigation summary feeds into the next iteration's design prompt, so each hypothesis bundle is informed by all prior learning. The summary is bounded — agent context stays at O(summary) regardless of campaign depth.
+
+Options:
+
+```bash
+python run_campaign.py campaign.yaml --max-iterations 10   # default: 10
+python run_campaign.py campaign.yaml --model gpt-4o        # different model
+python run_campaign.py campaign.yaml --run-id my-campaign   # custom work dir
+python run_campaign.py campaign.yaml -v                     # verbose logging
+```
+
+You can also set `max_iterations` in `campaign.yaml`:
+
+```yaml
+max_iterations: 10  # CLI --max-iterations overrides this
+```
+
+### Campaign output
+
+After a multi-iteration campaign, your working directory contains:
+
+- **`runs/iter-N/`** — artifacts for each iteration (bundle, findings, reviews, etc.)
+- **`runs/iter-N/investigation_summary.json`** — bounded summary for each non-final iteration
+- **`ledger.json`** — append-only log with one row per completed iteration
+- **`principles.json`** — accumulated principles across all iterations
+
+### Three human gates
+
+Each iteration has two gates (design and findings approval). Between iterations, a third **continue gate** asks whether to proceed:
+
+| Gate | When | Question |
+|------|------|----------|
+| Design gate | After design review | Approve the hypothesis bundle? |
+| Findings gate | After findings review | Approve the results? |
+| Continue gate | After extraction | Continue to the next iteration? |
+
+Type `approve` to continue, `abort` to stop the campaign.
 
 ## Next steps
 

--- a/examples/blis/campaign.yaml
+++ b/examples/blis/campaign.yaml
@@ -1,6 +1,8 @@
 research_question: >
   Does increasing the prefix ratio in a workload reduce TTFT under moderate load?
 
+max_iterations: 10
+
 target_system:
   name: "BLIS — LLM Inference Serving Simulator"
   description: >

--- a/orchestrator/dispatch.py
+++ b/orchestrator/dispatch.py
@@ -64,7 +64,10 @@ class StubDispatcher:
             case "reviewer":
                 self._write_review(output_path, perspective or "general")
             case "extractor":
-                self._write_principles(output_path, iteration)
+                if phase == "summarize":
+                    self._write_investigation_summary(output_path, iteration)
+                else:
+                    self._write_principles(output_path, iteration)
             case _:
                 raise ValueError(f"Unknown role: {role}")
 
@@ -136,6 +139,17 @@ class StubDispatcher:
             f"No CRITICAL or IMPORTANT findings.\n"
             f"Stub review from {perspective} perspective.\n",
         )
+
+    def _write_investigation_summary(self, path: Path, iteration: int) -> None:
+        summary = {
+            "iteration": iteration,
+            "what_was_tested": f"Stub: hypothesis family tested in iteration {iteration}.",
+            "key_findings": "Stub: H-main confirmed. No significant discrepancies.",
+            "principles_changed": f"Stub: Inserted stub-principle-{iteration}.",
+            "open_questions": "Stub: No open questions from stub iteration.",
+            "suggested_next_direction": "Stub: Continue with next mechanism family.",
+        }
+        atomic_write(path, json.dumps(summary, indent=2) + "\n")
 
     def _write_principles(self, path: Path, iteration: int) -> None:
         if path.exists():

--- a/orchestrator/fastfail.py
+++ b/orchestrator/fastfail.py
@@ -28,17 +28,23 @@ def check_fast_fail(findings: dict) -> FastFailAction:
     if "arms" not in findings:
         raise ValueError("findings dict missing required 'arms' key")
 
+    # Index arms by type.  h-main and h-control-negative must be unique
+    # (fast-fail rules key on them).  Other types (h-robustness, h-ablation)
+    # can appear multiple times; we keep only the first for indexing purposes
+    # since fast-fail rules don't inspect them individually.
+    _UNIQUE_ARMS = {"h-main", "h-control-negative"}
     arms = {}
     for a in findings["arms"]:
         arm_type = a.get("arm_type")
         if arm_type is None:
             raise ValueError(f"arm entry missing required 'arm_type' key: {a}")
-        if arm_type in arms:
+        if arm_type in arms and arm_type in _UNIQUE_ARMS:
             raise ValueError(
                 f"Duplicate arm_type '{arm_type}' in findings. "
-                f"Each arm type must appear exactly once."
+                f"h-main and h-control-negative must appear exactly once."
             )
-        arms[arm_type] = a
+        if arm_type not in arms:
+            arms[arm_type] = a
 
     # Validate h-main arm exists — fast-fail cannot work without it
     if "h-main" not in arms:

--- a/orchestrator/ledger.py
+++ b/orchestrator/ledger.py
@@ -1,0 +1,150 @@
+"""Deterministic ledger append for the Nous orchestrator.
+
+Reads findings, bundle, and principles from a completed iteration and appends
+a schema-conformant row to ledger.json.  No LLM calls — purely deterministic.
+"""
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from orchestrator.util import atomic_write
+
+logger = logging.getLogger(__name__)
+
+
+def append_ledger_row(work_dir: Path, iteration: int) -> None:
+    """Append a ledger row for the given iteration.
+
+    Reads ``runs/iter-{iteration}/findings.json`` and ``bundle.yaml``,
+    plus the top-level ``principles.json``, to build the row.
+
+    If ``findings.json`` does not exist the call is a no-op (logged as
+    warning) — this lets callers invoke it safely even on aborted iterations.
+    """
+    work_dir = Path(work_dir)
+    iter_dir = work_dir / "runs" / f"iter-{iteration}"
+
+    findings_path = iter_dir / "findings.json"
+    if not findings_path.exists():
+        logger.warning(
+            "No findings.json for iteration %d — skipping ledger append.", iteration,
+        )
+        return
+
+    findings = json.loads(findings_path.read_text())
+    bundle = _read_bundle(iter_dir / "bundle.yaml")
+    principles = _read_principles(work_dir / "principles.json")
+
+    row = _build_row(iteration, findings, bundle, principles)
+
+    ledger_path = work_dir / "ledger.json"
+    if ledger_path.exists():
+        ledger = json.loads(ledger_path.read_text())
+    else:
+        ledger = {"iterations": []}
+
+    ledger["iterations"].append(row)
+    atomic_write(ledger_path, json.dumps(ledger, indent=2) + "\n")
+    logger.info("Appended ledger row for iteration %d.", iteration)
+
+
+def _read_bundle(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _read_principles(path: Path) -> dict:
+    if not path.exists():
+        return {"principles": []}
+    return json.loads(path.read_text())
+
+
+def _build_row(
+    iteration: int,
+    findings: dict,
+    bundle: dict,
+    principles: dict,
+) -> dict:
+    family = bundle.get("metadata", {}).get("family", "unknown")
+    arms = findings.get("arms", [])
+
+    h_main_result = _find_arm_status(arms, "h-main")
+    control_result = _find_arm_status(arms, "h-control-negative")
+    robustness_result = _find_arm_status(arms, "h-robustness")
+    ablation_results = _collect_ablation_results(arms)
+    accuracy = _compute_accuracy(arms)
+    extracted = _detect_principle_changes(principles, iteration)
+
+    return {
+        "iteration": iteration,
+        "family": family,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "candidate_id": f"iter-{iteration}",
+        "h_main_result": h_main_result,
+        "ablation_results": ablation_results,
+        "control_result": control_result,
+        "robustness_result": robustness_result,
+        "prediction_accuracy": accuracy,
+        "principles_extracted": extracted,
+        "frontier_update": None,
+    }
+
+
+def _find_arm_status(arms: list[dict], arm_type: str) -> str | None:
+    """Return the status of the first arm matching *arm_type*, or None."""
+    for arm in arms:
+        if arm.get("arm_type") == arm_type:
+            return arm.get("status")
+    return None
+
+
+def _collect_ablation_results(arms: list[dict]) -> dict[str, str]:
+    """Collect ablation arm results keyed by component or index."""
+    results: dict[str, str] = {}
+    idx = 0
+    for arm in arms:
+        if arm.get("arm_type") == "h-ablation":
+            key = arm.get("component", f"ablation-{idx}")
+            status = arm.get("status", "REFUTED")
+            results[key] = status
+            idx += 1
+    return results
+
+
+def _compute_accuracy(arms: list[dict]) -> dict | None:
+    """Compute prediction accuracy across all arms."""
+    if not arms:
+        return None
+    total = len(arms)
+    correct = sum(1 for a in arms if a.get("status") == "CONFIRMED")
+    return {
+        "arms_correct": correct,
+        "arms_total": total,
+        "accuracy_pct": round(100 * correct / total, 1),
+    }
+
+
+def _detect_principle_changes(
+    principles: dict, iteration: int,
+) -> list[dict]:
+    """Detect which principles were added/changed in this iteration."""
+    extracted: list[dict] = []
+    for p in principles.get("principles", []):
+        ext_iter = p.get("extraction_iteration")
+        if ext_iter != iteration:
+            continue
+        status = p.get("status", "active")
+        if status == "active":
+            action = "INSERT"
+        elif status == "updated":
+            action = "UPDATE"
+        elif status == "pruned":
+            action = "PRUNE"
+        else:
+            action = "INSERT"
+        extracted.append({"id": p.get("id", "unknown"), "action": action})
+    return extracted

--- a/orchestrator/ledger.py
+++ b/orchestrator/ledger.py
@@ -53,12 +53,14 @@ def append_ledger_row(work_dir: Path, iteration: int) -> None:
 
 def _read_bundle(path: Path) -> dict:
     if not path.exists():
+        logger.warning("No bundle.yaml at %s — ledger row will use family='unknown'.", path)
         return {}
     return yaml.safe_load(path.read_text()) or {}
 
 
 def _read_principles(path: Path) -> dict:
     if not path.exists():
+        logger.warning("No principles.json at %s — ledger row will have empty principles.", path)
         return {"principles": []}
     return json.loads(path.read_text())
 

--- a/orchestrator/ledger.py
+++ b/orchestrator/ledger.py
@@ -46,6 +46,11 @@ def append_ledger_row(work_dir: Path, iteration: int) -> None:
     else:
         ledger = {"iterations": []}
 
+    # Idempotency guard: skip if this iteration already has a ledger row
+    if any(r.get("iteration") == iteration for r in ledger["iterations"]):
+        logger.info("Ledger row for iteration %d already exists — skipping.", iteration)
+        return
+
     ledger["iterations"].append(row)
     atomic_write(ledger_path, json.dumps(ledger, indent=2) + "\n")
     logger.info("Appended ledger row for iteration %d.", iteration)

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -212,6 +212,11 @@ class LLMDispatcher:
                 if prev_summary_path.exists():
                     ctx["investigation_summary"] = prev_summary_path.read_text()
                 else:
+                    logger.warning(
+                        "Investigation summary for iteration %d not found at %s. "
+                        "Design prompt will proceed without prior learning context.",
+                        iteration - 1, prev_summary_path,
+                    )
                     ctx["investigation_summary"] = (
                         "No investigation summary available from the previous iteration."
                     )

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -168,6 +168,7 @@ class LLMDispatcher:
         ("reviewer", "review-design"): ("review_design", None, None),
         ("reviewer", "review-findings"): ("review_findings", None, None),
         ("extractor", "extract"): ("extract", "json", "principles.schema.json"),
+        ("extractor", "summarize"): ("summarize", "json", "investigation_summary.schema.json"),
     }
 
     def _route(
@@ -202,7 +203,7 @@ class LLMDispatcher:
         if phase in ("frame", "design"):
             ctx["research_question"] = self._read_research_question(phase, iteration)
 
-        if phase in ("design", "review-design", "run", "run-plan", "run-analyze"):
+        if phase in ("design", "review-design", "run", "run-plan", "run-analyze", "summarize"):
             bundle_path = self.work_dir / "runs" / f"iter-{iteration}" / "bundle.yaml"
             if phase == "design" and not bundle_path.exists():
                 pass  # bundle doesn't exist yet during design — template ignores it
@@ -230,7 +231,7 @@ class LLMDispatcher:
                 )
             ctx["experiment_results"] = results_path.read_text()
 
-        if phase in ("review-findings", "extract"):
+        if phase in ("review-findings", "extract", "summarize"):
             findings_path = (
                 self.work_dir / "runs" / f"iter-{iteration}" / "findings.json"
             )

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -128,10 +128,11 @@ class LLMDispatcher:
             try:
                 data = self._extract_fenced_content(response, fmt)
             except (json.JSONDecodeError, yaml.YAMLError, ValueError) as exc:
-                raise RuntimeError(
-                    f"LLM response for {role}/{phase} could not be parsed as {fmt}. "
-                    f"Response length: {len(response)} chars. Error: {exc}"
-                ) from exc
+                logger.warning(
+                    "Parse failed for %s/%s (%s), retrying with feedback.",
+                    role, phase, exc,
+                )
+                data = self._retry_parse(prompt, response, exc, fmt)
             if schema_name is not None:
                 try:
                     self._validate(data, schema_name)
@@ -368,6 +369,46 @@ class LLMDispatcher:
         if content is None:
             raise RuntimeError("LLM returned None content.")
         return content
+
+    def _retry_parse(
+        self,
+        original_prompt: str,
+        original_response: str,
+        error: Exception,
+        fmt: str,
+    ) -> dict:
+        """Retry when the LLM response couldn't be parsed (missing fence, bad JSON/YAML)."""
+        feedback = (
+            f"Your previous response could not be parsed.\n\n"
+            f"Error: {error}\n\n"
+            f"Please output ONLY a ```{fmt}``` code fence with valid {fmt.upper()} inside. "
+            f"No explanation outside the fence."
+        )
+        messages = [
+            {"role": "system", "content": original_prompt},
+            {"role": "assistant", "content": original_response},
+            {"role": "user", "content": feedback},
+        ]
+        try:
+            response = self._completion(
+                model=self.model, messages=messages, max_tokens=4096,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"LLM API call failed during parse retry "
+                f"(model={self.model}): {type(exc).__name__}: {exc}"
+            ) from exc
+        if not response.choices:
+            raise RuntimeError("LLM returned empty choices list during parse retry.")
+        retry_text = response.choices[0].message.content
+        if retry_text is None:
+            raise RuntimeError("LLM returned None content during parse retry.")
+        try:
+            return self._extract_fenced_content(retry_text, fmt)
+        except (json.JSONDecodeError, yaml.YAMLError, ValueError) as exc:
+            raise RuntimeError(
+                f"LLM retry response could not be parsed as {fmt}: {exc}"
+            ) from exc
 
     def _retry_with_feedback(
         self,

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -356,7 +356,7 @@ class LLMDispatcher:
         ]
         try:
             response = self._completion(
-                model=self.model, messages=messages, max_tokens=4096,
+                model=self.model, messages=messages, max_tokens=16384,
             )
         except Exception as exc:
             raise RuntimeError(
@@ -391,7 +391,7 @@ class LLMDispatcher:
         ]
         try:
             response = self._completion(
-                model=self.model, messages=messages, max_tokens=4096,
+                model=self.model, messages=messages, max_tokens=16384,
             )
         except Exception as exc:
             raise RuntimeError(
@@ -432,7 +432,7 @@ class LLMDispatcher:
         ]
         try:
             response = self._completion(
-                model=self.model, messages=messages, max_tokens=4096,
+                model=self.model, messages=messages, max_tokens=16384,
             )
         except Exception as exc:
             raise RuntimeError(

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -281,7 +281,11 @@ class LLMDispatcher:
         if phase == "frame":
             return self.campaign["research_question"]
         # For design, read from the problem.md produced by framing.
+        # In multi-iteration campaigns, framing only runs for iteration 1;
+        # subsequent iterations reuse iter-1's problem.md.
         problem_path = self.work_dir / "runs" / f"iter-{iteration}" / "problem.md"
+        if not problem_path.exists() and iteration > 1:
+            problem_path = self.work_dir / "runs" / "iter-1" / "problem.md"
         if not problem_path.exists():
             raise FileNotFoundError(
                 f"Expected {problem_path} for design phase. "

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -203,6 +203,23 @@ class LLMDispatcher:
         if phase in ("frame", "design"):
             ctx["research_question"] = self._read_research_question(phase, iteration)
 
+        if phase == "design":
+            if iteration > 1:
+                prev_summary_path = (
+                    self.work_dir / "runs" / f"iter-{iteration - 1}"
+                    / "investigation_summary.json"
+                )
+                if prev_summary_path.exists():
+                    ctx["investigation_summary"] = prev_summary_path.read_text()
+                else:
+                    ctx["investigation_summary"] = (
+                        "No investigation summary available from the previous iteration."
+                    )
+            else:
+                ctx["investigation_summary"] = (
+                    "This is the first iteration. No prior investigation summary."
+                )
+
         if phase in ("design", "review-design", "run", "run-plan", "run-analyze", "summarize"):
             bundle_path = self.work_dir / "runs" / f"iter-{iteration}" / "bundle.yaml"
             if phase == "design" and not bundle_path.exists():

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -21,6 +21,10 @@ This is iteration {{iteration}} of the investigation.
 
 {{active_principles}}
 
+## Investigation Summary (Previous Iteration)
+
+{{investigation_summary}}
+
 ## Instructions
 
 Design a hypothesis bundle with the following structure:

--- a/prompts/methodology/summarize.md
+++ b/prompts/methodology/summarize.md
@@ -1,0 +1,55 @@
+You are a scientific summarizer for the Nous hypothesis-driven experimentation framework.
+
+Your task is to produce a bounded **investigation summary** for the iteration that just completed. This summary will be passed to the planner for the next iteration, so it must be concise and actionable.
+
+## Target System
+
+- **Name:** {{target_system}}
+- **Description:** {{system_description}}
+
+## Iteration
+
+This is the summary for iteration {{iteration}}.
+
+## Hypothesis Bundle Tested
+
+```yaml
+{{bundle_yaml}}
+```
+
+## Findings
+
+```json
+{{findings_json}}
+```
+
+## Current Principles
+
+{{active_principles}}
+
+## Instructions
+
+Produce a JSON summary with these fields:
+
+1. **what_was_tested**: One sentence describing the hypothesis family and mechanism tested.
+2. **key_findings**: 2-3 sentences on what was learned. Include whether H-main was confirmed or refuted, and any notable error types.
+3. **principles_changed**: List which principles were inserted, updated, or pruned this iteration. Reference principle IDs.
+4. **open_questions**: What remains unclear? What was not tested? What surprised you?
+5. **suggested_next_direction**: Based on what was learned, what should the next iteration investigate?
+
+Keep each field under 200 words. The goal is bounded context, not a full replay of the iteration.
+
+## Output Format
+
+```json
+{
+  "iteration": N,
+  "what_was_tested": "...",
+  "key_findings": "...",
+  "principles_changed": "...",
+  "open_questions": "...",
+  "suggested_next_direction": "..."
+}
+```
+
+Output ONLY the JSON code fence. Do not include any explanation outside the code fence.

--- a/prompts/methodology/summarize.md
+++ b/prompts/methodology/summarize.md
@@ -33,7 +33,7 @@ Produce a JSON summary with these fields:
 
 1. **what_was_tested**: One sentence describing the hypothesis family and mechanism tested.
 2. **key_findings**: 2-3 sentences on what was learned. Include whether H-main was confirmed or refuted, and any notable error types.
-3. **principles_changed**: List which principles were inserted, updated, or pruned this iteration. Reference principle IDs.
+3. **principles_changed**: Describe which principles were inserted, updated, or pruned this iteration. Reference principle IDs.
 4. **open_questions**: What remains unclear? What was not tested? What surprised you?
 5. **suggested_next_direction**: Based on what was learned, what should the next iteration investigate?
 

--- a/run_campaign.py
+++ b/run_campaign.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Run a multi-iteration Nous campaign.
+
+Usage:
+    python run_campaign.py examples/blis/campaign.yaml --max-iterations 5
+
+Runs iterations in a loop: each iteration runs the full Nous loop
+(FRAMING → DESIGN → REVIEW → RUNNING → EXTRACTION), then appends a
+ledger row, generates an investigation summary, and prompts whether to
+continue.  The investigation summary is injected into the next iteration's
+design prompt so that each hypothesis bundle is informed by all prior learning.
+
+Set your LLM API key before running:
+    export OPENAI_API_KEY=sk-...
+    (or set OPENAI_BASE_URL for a proxy endpoint)
+"""
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+from orchestrator.engine import Engine
+from orchestrator.gates import HumanGate
+from orchestrator.ledger import append_ledger_row
+from orchestrator.llm_dispatch import LLMDispatcher
+from run_iteration import (
+    IterationOutcome,
+    run_iteration,
+    setup_work_dir,
+    SCHEMAS_DIR,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_campaign(
+    campaign: dict,
+    work_dir: Path,
+    *,
+    max_iterations: int = 10,
+    model: str = "aws/claude-opus-4-6",
+) -> None:
+    """Run a multi-iteration Nous campaign.
+
+    Loops through iterations, calling run_iteration() for each one.
+    After each non-final iteration: appends a ledger row, generates an
+    investigation summary, and prompts the human to continue or stop.
+
+    Args:
+        campaign: Parsed campaign.yaml dict.
+        work_dir: Working directory (must already be initialized).
+        max_iterations: Maximum number of iterations to run.
+        model: LLM model name.
+    """
+    continue_gate = HumanGate()
+
+    for i in range(1, max_iterations + 1):
+        is_last = (i == max_iterations)
+        print(f"\n{'#'*60}")
+        print(f"  CAMPAIGN — Iteration {i} of {max_iterations}")
+        print(f"{'#'*60}")
+
+        outcome = run_iteration(
+            campaign, work_dir, iteration=i, model=model, final=is_last,
+        )
+
+        if outcome == IterationOutcome.COMPLETED:
+            print(f"\n  Campaign complete after {i} iteration(s).")
+            return
+
+        if outcome == IterationOutcome.ABORTED:
+            print(f"\n  Campaign aborted at iteration {i}.")
+            print("  Engine state preserved for potential resume.")
+            return
+
+        if outcome == IterationOutcome.REDESIGN:
+            print(f"\n  Iteration {i} needs redesign. Re-running same iteration.")
+            # The engine is already rewound to the appropriate phase.
+            # Decrement i effectively by not incrementing — but since we're
+            # in a for loop, we continue to the next i. Instead, we just
+            # re-run the same iteration number in the next pass... but a
+            # for-range doesn't allow that. Use a while loop approach.
+            # For simplicity in the for-loop structure: just abort and let
+            # the user re-run. The engine is rewound so resume will work.
+            print("  Re-run the campaign to retry from the rewound phase.")
+            return
+
+        # outcome == CONTINUE — non-final iteration completed extraction
+        assert outcome == IterationOutcome.CONTINUE
+
+        # Post-iteration: ledger + investigation summary
+        append_ledger_row(work_dir, i)
+
+        dispatcher = LLMDispatcher(
+            work_dir=work_dir, campaign=campaign, model=model,
+        )
+        iter_dir = work_dir / "runs" / f"iter-{i}"
+        dispatcher.dispatch(
+            "extractor", "summarize",
+            output_path=iter_dir / "investigation_summary.json",
+            iteration=i,
+        )
+        print(f"  -> {iter_dir / 'investigation_summary.json'}")
+
+        # Human gate: continue?
+        print(f"\n{'='*60}")
+        print(f"  CONTINUE GATE — Iteration {i} complete")
+        print(f"{'='*60}")
+        decision = continue_gate.prompt(
+            f"Continue to iteration {i + 1}?",
+        )
+        if decision != "approve":
+            engine = Engine(work_dir)
+            engine.transition("DONE")
+            print(f"\n  Campaign stopped after {i} iteration(s).")
+            return
+
+        # Advance engine from EXTRACTION → DESIGN (increments iteration)
+        engine = Engine(work_dir)
+        engine.transition("DESIGN")
+        print(f"\n  Advancing to iteration {i + 1}...")
+
+    print(f"\n  Campaign reached max_iterations ({max_iterations}).")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run a multi-iteration Nous campaign.",
+        epilog="Example: python run_campaign.py examples/blis/campaign.yaml --max-iterations 5",
+    )
+    parser.add_argument("campaign", help="Path to campaign.yaml")
+    parser.add_argument("--max-iterations", type=int, default=10,
+                        help="Maximum iterations (default: 10)")
+    parser.add_argument("--model", default="aws/claude-opus-4-6",
+                        help="Model name (default: aws/claude-opus-4-6)")
+    parser.add_argument("--run-id", default=None,
+                        help="Working directory name (default: derived from campaign)")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Enable debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    campaign_path = Path(args.campaign)
+    if not campaign_path.exists():
+        print(f"Error: {campaign_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    campaign = yaml.safe_load(campaign_path.read_text())
+
+    schema = yaml.safe_load((SCHEMAS_DIR / "campaign.schema.yaml").read_text())
+    try:
+        jsonschema.validate(campaign, schema)
+    except jsonschema.ValidationError as exc:
+        print(
+            f"Error: {campaign_path} is not a valid campaign config.\n"
+            f"  {exc.message}\n\n"
+            f"See examples/blis/campaign.yaml for a working example.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    max_iter = campaign.get("max_iterations", args.max_iterations)
+
+    run_id = args.run_id or campaign_path.parent.name + "-run"
+    work_dir = setup_work_dir(run_id)
+    print(f"Working directory: {work_dir.resolve()}")
+    print(f"Max iterations: {max_iter}")
+
+    run_campaign(campaign, work_dir, max_iterations=max_iter, model=args.model)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_campaign.py
+++ b/run_campaign.py
@@ -43,6 +43,7 @@ def run_campaign(
     *,
     max_iterations: int = 10,
     model: str = "aws/claude-opus-4-6",
+    auto_approve: bool = False,
 ) -> None:
     """Run a multi-iteration Nous campaign.
 
@@ -55,8 +56,12 @@ def run_campaign(
         work_dir: Working directory (must already be initialized).
         max_iterations: Maximum number of iterations to run.
         model: LLM model name.
+        auto_approve: If True, all human gates (including continue gate)
+            are automatically approved.
     """
-    continue_gate = HumanGate()
+    continue_gate = (
+        HumanGate(auto_response="approve") if auto_approve else HumanGate()
+    )
 
     for i in range(1, max_iterations + 1):
         is_last = (i == max_iterations)
@@ -66,6 +71,7 @@ def run_campaign(
 
         outcome = run_iteration(
             campaign, work_dir, iteration=i, model=model, final=is_last,
+            auto_approve=auto_approve,
         )
 
         if outcome == IterationOutcome.COMPLETED:
@@ -78,19 +84,13 @@ def run_campaign(
             return
 
         if outcome == IterationOutcome.REDESIGN:
-            print(f"\n  Iteration {i} needs redesign. Re-running same iteration.")
-            # The engine is already rewound to the appropriate phase.
-            # Decrement i effectively by not incrementing — but since we're
-            # in a for loop, we continue to the next i. Instead, we just
-            # re-run the same iteration number in the next pass... but a
-            # for-range doesn't allow that. Use a while loop approach.
-            # For simplicity in the for-loop structure: just abort and let
-            # the user re-run. The engine is rewound so resume will work.
-            print("  Re-run the campaign to retry from the rewound phase.")
+            print(f"\n  Iteration {i} returned REDESIGN.")
+            print("  The engine has been rewound. Re-run the campaign to resume.")
             return
 
         # outcome == CONTINUE — non-final iteration completed extraction
-        assert outcome == IterationOutcome.CONTINUE
+        if outcome != IterationOutcome.CONTINUE:
+            raise ValueError(f"Unexpected outcome: {outcome}")
 
         # Post-iteration: ledger + investigation summary
         append_ledger_row(work_dir, i)
@@ -139,6 +139,8 @@ def main() -> None:
                         help="Model name (default: aws/claude-opus-4-6)")
     parser.add_argument("--run-id", default=None,
                         help="Working directory name (default: derived from campaign)")
+    parser.add_argument("--auto-approve", action="store_true",
+                        help="Auto-approve all human gates (skip interactive prompts)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Enable debug logging")
     args = parser.parse_args()
@@ -167,14 +169,22 @@ def main() -> None:
         )
         sys.exit(1)
 
-    max_iter = campaign.get("max_iterations", args.max_iterations)
+    # CLI --max-iterations overrides campaign.yaml; campaign.yaml is fallback.
+    if args.max_iterations != 10:
+        max_iter = args.max_iterations
+    else:
+        max_iter = campaign.get("max_iterations", args.max_iterations)
 
     run_id = args.run_id or campaign_path.parent.name + "-run"
     work_dir = setup_work_dir(run_id)
     print(f"Working directory: {work_dir.resolve()}")
     print(f"Max iterations: {max_iter}")
 
-    run_campaign(campaign, work_dir, max_iterations=max_iter, model=args.model)
+    run_campaign(
+        campaign, work_dir,
+        max_iterations=max_iter, model=args.model,
+        auto_approve=args.auto_approve,
+    )
 
 
 if __name__ == "__main__":

--- a/run_campaign.py
+++ b/run_campaign.py
@@ -15,7 +15,6 @@ Set your LLM API key before running:
     (or set OPENAI_BASE_URL for a proxy endpoint)
 """
 import argparse
-import json
 import logging
 import sys
 from pathlib import Path

--- a/run_campaign.py
+++ b/run_campaign.py
@@ -133,7 +133,7 @@ def main() -> None:
         epilog="Example: python run_campaign.py examples/blis/campaign.yaml --max-iterations 5",
     )
     parser.add_argument("campaign", help="Path to campaign.yaml")
-    parser.add_argument("--max-iterations", type=int, default=10,
+    parser.add_argument("--max-iterations", type=int, default=None,
                         help="Maximum iterations (default: 10)")
     parser.add_argument("--model", default="aws/claude-opus-4-6",
                         help="Model name (default: aws/claude-opus-4-6)")
@@ -170,10 +170,10 @@ def main() -> None:
         sys.exit(1)
 
     # CLI --max-iterations overrides campaign.yaml; campaign.yaml is fallback.
-    if args.max_iterations != 10:
+    if args.max_iterations is not None:
         max_iter = args.max_iterations
     else:
-        max_iter = campaign.get("max_iterations", args.max_iterations)
+        max_iter = campaign.get("max_iterations", 10)
 
     run_id = args.run_id or campaign_path.parent.name + "-run"
     work_dir = setup_work_dir(run_id)

--- a/run_campaign.py
+++ b/run_campaign.py
@@ -74,6 +74,7 @@ def run_campaign(
         )
 
         if outcome == IterationOutcome.COMPLETED:
+            append_ledger_row(work_dir, i)
             print(f"\n  Campaign complete after {i} iteration(s).")
             return
 

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -144,11 +144,14 @@ def run_experiment_commands(
             executable (derived from campaign run_command). Prevents the
             LLM from generating commands that run arbitrary binaries.
 
-    Returns dict with metrics keyed by label: {"baseline": {...}, "h-main": {...}, ...}
+    Returns dict with metrics keyed by label.  When an arm_type appears
+    once the value is a single dict; when it appears multiple times the
+    value is a list of dicts (one per run, in plan order).
+    Baseline is always a single dict.
     """
     metrics_dir = (iter_dir / "metrics").resolve()
     metrics_dir.mkdir(parents=True, exist_ok=True)
-    results = {}
+    results: dict = {}
 
     # Validate all commands before executing any
     all_entries = [("baseline", plan["baseline"])] + [
@@ -176,15 +179,35 @@ def run_experiment_commands(
     _run_single_command(cmd, work_dir=work_dir, timeout=timeout, label="baseline")
     results["baseline"] = _read_metrics(baseline_metrics_path, label="baseline")
 
-    # Run each arm
+    # Count experiments per arm to decide indexing
+    arm_counts: dict[str, int] = {}
+    for exp in plan["experiments"]:
+        arm_counts[exp["arm_type"]] = arm_counts.get(exp["arm_type"], 0) + 1
+
+    # Run each arm — index the metrics file when >1 run per arm
+    arm_indices: dict[str, int] = {}
     for exp in plan["experiments"]:
         arm = exp["arm_type"]
         if not _ARM_TYPE_RE.match(arm):
             raise RuntimeError(f"Invalid arm_type '{arm}': must match [a-zA-Z0-9_-]+")
-        arm_metrics_path = metrics_dir / f"{arm}.json"
+        idx = arm_indices.get(arm, 0)
+        arm_indices[arm] = idx + 1
+
+        if arm_counts[arm] > 1:
+            arm_metrics_path = metrics_dir / f"{arm}-{idx}.json"
+        else:
+            arm_metrics_path = metrics_dir / f"{arm}.json"
         cmd = exp["command"].replace("{metrics_path}", str(arm_metrics_path))
-        _run_single_command(cmd, work_dir=work_dir, timeout=timeout, label=arm)
-        results[arm] = _read_metrics(arm_metrics_path, label=arm)
+        label_str = f"{arm}-{idx}" if arm_counts[arm] > 1 else arm
+        _run_single_command(cmd, work_dir=work_dir, timeout=timeout, label=label_str)
+        metrics = _read_metrics(arm_metrics_path, label=label_str)
+        metrics["_experiment_description"] = exp.get("description", "")
+        metrics["_config_changes"] = exp.get("config_changes", "")
+
+        if arm_counts[arm] > 1:
+            results.setdefault(arm, []).append(metrics)
+        else:
+            results[arm] = metrics
 
     return results
 

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -280,13 +280,15 @@ def run_iteration(
     iteration: int = 1,
     model: str = "aws/claude-opus-4-6",
     final: bool = True,
-) -> str:
+    auto_approve: bool = False,
+) -> IterationOutcome:
     """Run a single iteration of the Nous loop.
 
     Args:
         final: If True (default), transitions to DONE after extraction.
             If False, stops at EXTRACTION so run_campaign can continue
             with the next iteration.
+        auto_approve: If True, all human gates are automatically approved.
 
     Returns:
         An IterationOutcome value: COMPLETED, CONTINUE, ABORTED, or REDESIGN.
@@ -296,7 +298,7 @@ def run_iteration(
     """
     engine = Engine(work_dir)
     dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model=model)
-    gate = HumanGate()
+    gate = HumanGate(auto_response="approve") if auto_approve else HumanGate()
 
     iter_dir = work_dir / "runs" / f"iter-{iteration}"
 
@@ -480,6 +482,8 @@ def main() -> None:
                         help="Model name (default: aws/claude-opus-4-6)")
     parser.add_argument("--run-id", default=None,
                         help="Working directory name (default: derived from campaign)")
+    parser.add_argument("--auto-approve", action="store_true",
+                        help="Auto-approve all human gates (skip interactive prompts)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Enable debug logging")
     args = parser.parse_args()
@@ -513,7 +517,7 @@ def main() -> None:
     work_dir = setup_work_dir(run_id)
     print(f"Working directory: {work_dir.resolve()}")
 
-    run_iteration(campaign, work_dir, model=args.model)
+    run_iteration(campaign, work_dir, model=args.model, auto_approve=args.auto_approve)
 
 
 if __name__ == "__main__":

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -19,6 +19,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+from enum import Enum
 from pathlib import Path
 
 import jsonschema
@@ -29,6 +30,14 @@ from orchestrator.fastfail import check_fast_fail, FastFailAction
 from orchestrator.gates import HumanGate
 from orchestrator.llm_dispatch import LLMDispatcher
 from orchestrator.util import atomic_write
+
+
+class IterationOutcome(str, Enum):
+    """Outcome of a single iteration — used by run_campaign to decide next step."""
+    COMPLETED = "COMPLETED"    # Final iteration, transitioned to DONE
+    CONTINUE = "CONTINUE"      # Non-final iteration, stopped at EXTRACTION
+    ABORTED = "ABORTED"        # Human aborted at a gate
+    REDESIGN = "REDESIGN"      # Control-negative refuted, needs redesign
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 SCHEMAS_DIR = Path(__file__).parent / "schemas"
@@ -270,8 +279,17 @@ def run_iteration(
     work_dir: Path,
     iteration: int = 1,
     model: str = "aws/claude-opus-4-6",
-) -> None:
+    final: bool = True,
+) -> str:
     """Run a single iteration of the Nous loop.
+
+    Args:
+        final: If True (default), transitions to DONE after extraction.
+            If False, stops at EXTRACTION so run_campaign can continue
+            with the next iteration.
+
+    Returns:
+        An IterationOutcome value: COMPLETED, CONTINUE, ABORTED, or REDESIGN.
 
     Supports resume: if the process crashes, re-running picks up from the
     last committed phase in state.json. Phases already completed are skipped.
@@ -284,7 +302,7 @@ def run_iteration(
 
     if engine.phase == "DONE":
         print(f"Iteration {iteration} already complete.")
-        return
+        return IterationOutcome.COMPLETED
 
     if engine.phase != "INIT":
         print(f"\n  Resuming from {engine.phase}\n")
@@ -337,10 +355,10 @@ def run_iteration(
         if decision == "reject":
             print("Design rejected. Re-run after revising the campaign config.")
             engine.transition("DESIGN")
-            return
+            return IterationOutcome.REDESIGN
         if decision == "abort":
             print("Aborted.")
-            return
+            return IterationOutcome.ABORTED
 
     # RUNNING (executor)
     if _enter_phase(engine, "RUNNING"):
@@ -393,7 +411,7 @@ def run_iteration(
         _enter_phase(engine, "FINDINGS_REVIEW")
         _enter_phase(engine, "HUMAN_FINDINGS_GATE")
         engine.transition("RUNNING")
-        return
+        return IterationOutcome.REDESIGN
     else:
         if ff == FastFailAction.SIMPLIFY:
             print("  ** Dominant component >80% — consider simplifying the model.")
@@ -421,10 +439,10 @@ def run_iteration(
             if decision == "reject":
                 print("Findings rejected. Re-running executor.")
                 engine.transition("RUNNING")
-                return
+                return IterationOutcome.REDESIGN
             if decision == "abort":
                 print("Aborted.")
-                return
+                return IterationOutcome.ABORTED
 
         _enter_phase(engine, "TUNING")
         _enter_phase(engine, "EXTRACTION")
@@ -439,13 +457,17 @@ def run_iteration(
     )
     print(f"  -> {work_dir / 'principles.json'}")
 
-    # DONE
-    engine.transition("DONE")
-    print(f"\n{'='*60}")
-    print(f"  DONE — iteration {iteration} complete")
-    print(f"{'='*60}")
-    print(f"\nOutput in: {iter_dir}")
-    print(f"Principles: {work_dir / 'principles.json'}")
+    if final:
+        engine.transition("DONE")
+        print(f"\n{'='*60}")
+        print(f"  DONE — iteration {iteration} complete")
+        print(f"{'='*60}")
+        print(f"\nOutput in: {iter_dir}")
+        print(f"Principles: {work_dir / 'principles.json'}")
+        return IterationOutcome.COMPLETED
+    else:
+        print(f"\n  Iteration {iteration} extraction complete — ready for next iteration.")
+        return IterationOutcome.CONTINUE
 
 
 def main() -> None:

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -18,6 +18,7 @@ import re
 import shlex
 import shutil
 import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import sys
 from enum import Enum
 from pathlib import Path
@@ -336,13 +337,18 @@ def run_iteration(
         print(f"\n{'='*60}")
         print(f"  DESIGN REVIEW — {len(campaign['review']['design_perspectives'])} reviewers")
         print(f"{'='*60}")
-        for perspective in campaign["review"]["design_perspectives"]:
+        perspectives = campaign["review"]["design_perspectives"]
+        def _run_design_review(p):
             dispatcher.dispatch(
                 "reviewer", "review-design",
-                output_path=iter_dir / "reviews" / f"review-{perspective}.md",
-                iteration=iteration, perspective=perspective,
+                output_path=iter_dir / "reviews" / f"review-{p}.md",
+                iteration=iteration, perspective=p,
             )
-            print(f"  -> review-{perspective}.md")
+            return p
+        with ThreadPoolExecutor(max_workers=len(perspectives)) as pool:
+            futures = [pool.submit(_run_design_review, p) for p in perspectives]
+            for f in as_completed(futures):
+                print(f"  -> review-{f.result()}.md")
 
     # HUMAN DESIGN GATE
     if _enter_phase(engine, "HUMAN_DESIGN_GATE"):
@@ -424,13 +430,18 @@ def run_iteration(
             print(f"\n{'='*60}")
             print(f"  FINDINGS REVIEW — {len(campaign['review']['findings_perspectives'])} reviewers")
             print(f"{'='*60}")
-            for perspective in campaign["review"]["findings_perspectives"]:
+            perspectives = campaign["review"]["findings_perspectives"]
+            def _run_findings_review(p):
                 dispatcher.dispatch(
                     "reviewer", "review-findings",
-                    output_path=iter_dir / "reviews" / f"review-findings-{perspective}.md",
-                    iteration=iteration, perspective=perspective,
+                    output_path=iter_dir / "reviews" / f"review-findings-{p}.md",
+                    iteration=iteration, perspective=p,
                 )
-                print(f"  -> review-findings-{perspective}.md")
+                return p
+            with ThreadPoolExecutor(max_workers=len(perspectives)) as pool:
+                futures = [pool.submit(_run_findings_review, p) for p in perspectives]
+                for f in as_completed(futures):
+                    print(f"  -> review-findings-{f.result()}.md")
 
         # HUMAN FINDINGS GATE
         if _enter_phase(engine, "HUMAN_FINDINGS_GATE"):

--- a/schemas/campaign.schema.yaml
+++ b/schemas/campaign.schema.yaml
@@ -16,6 +16,11 @@ properties:
     minLength: 1
     description: "The guiding research question for this campaign."
 
+  max_iterations:
+    type: integer
+    minimum: 1
+    description: "Maximum number of iterations for run_campaign.py. CLI --max-iterations overrides this. Default: 10."
+
   target_system:
     type: object
     required: [name, description, observable_metrics, controllable_knobs]

--- a/schemas/investigation_summary.schema.json
+++ b/schemas/investigation_summary.schema.json
@@ -9,7 +9,7 @@
   "properties": {
     "iteration": {
       "type": "integer",
-      "minimum": 0,
+      "minimum": 1,
       "description": "Which iteration this summary covers."
     },
     "what_was_tested": {

--- a/schemas/investigation_summary.schema.json
+++ b/schemas/investigation_summary.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/schemas/investigation_summary.schema.json",
+  "title": "Investigation Summary",
+  "description": "Bounded iteration-level summary for context passing to the next iteration's planner. Produced after extraction, consumed by the design prompt.",
+  "type": "object",
+  "required": ["iteration", "what_was_tested", "key_findings", "principles_changed", "open_questions", "suggested_next_direction"],
+  "additionalProperties": false,
+  "properties": {
+    "iteration": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Which iteration this summary covers."
+    },
+    "what_was_tested": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Brief description of the hypothesis tested this iteration."
+    },
+    "key_findings": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What was learned: confirmed, refuted, or partially confirmed results."
+    },
+    "principles_changed": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Which principles were inserted, updated, or pruned."
+    },
+    "open_questions": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What remains unclear or untested."
+    },
+    "suggested_next_direction": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What the next iteration should investigate."
+    }
+  }
+}

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -1,0 +1,202 @@
+"""Tests for multi-iteration campaign loop."""
+import json
+import shutil
+import warnings
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.dispatch import StubDispatcher
+from orchestrator.engine import Engine
+from run_campaign import run_campaign
+from run_iteration import IterationOutcome
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+
+
+def _load_schema(name: str) -> dict:
+    path = SCHEMAS_DIR / name
+    if path.suffix in (".yaml", ".yml"):
+        return yaml.safe_load(path.read_text())
+    return json.loads(path.read_text())
+
+
+SAMPLE_CAMPAIGN = {
+    "research_question": "Does batch size affect latency?",
+    "target_system": {
+        "name": "TestSystem",
+        "description": "A test system.",
+        "observable_metrics": ["latency_ms"],
+        "controllable_knobs": ["batch_size"],
+    },
+    "review": {
+        "design_perspectives": ["rigor"],
+        "findings_perspectives": ["rigor"],
+        "max_review_rounds": 1,
+    },
+    "prompts": {
+        "methodology_layer": "prompts/methodology",
+        "domain_adapter_layer": None,
+    },
+}
+
+
+def _setup_work_dir(tmp_path):
+    """Create an initialized work directory."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    for t in ["state.json", "ledger.json", "principles.json"]:
+        shutil.copy(TEMPLATES_DIR / t, work_dir / t)
+    state = json.loads((work_dir / "state.json").read_text())
+    state["run_id"] = "test-campaign"
+    (work_dir / "state.json").write_text(json.dumps(state, indent=2))
+    return work_dir
+
+
+def _patch_for_stub(monkeypatch):
+    """Monkeypatch LLMDispatcher and HumanGate for stub-based testing."""
+    import run_iteration as ri
+    import run_campaign as rc
+
+    def stub_factory(work_dir, campaign, model=None):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return StubDispatcher(work_dir)
+
+    monkeypatch.setattr(ri, "LLMDispatcher", stub_factory)
+
+    # Also patch the LLMDispatcher in run_campaign (used for summarize)
+    monkeypatch.setattr(rc, "LLMDispatcher", stub_factory)
+
+
+def _patch_gates_approve(monkeypatch):
+    """All gates auto-approve."""
+    import run_iteration as ri
+    import run_campaign as rc
+    gate = MagicMock(prompt=MagicMock(return_value="approve"))
+    monkeypatch.setattr(ri, "HumanGate", lambda: gate)
+    monkeypatch.setattr(rc, "HumanGate", lambda: gate)
+    return gate
+
+
+class TestTwoIterationHappyPath:
+    def test_two_iterations_complete(self, tmp_path, monkeypatch):
+        work_dir = _setup_work_dir(tmp_path)
+        _patch_for_stub(monkeypatch)
+        _patch_gates_approve(monkeypatch)
+
+        run_campaign(SAMPLE_CAMPAIGN, work_dir, max_iterations=2)
+
+        # Engine should be DONE
+        engine = Engine(work_dir)
+        assert engine.phase == "DONE"
+
+        # Ledger should have baseline + 2 iteration rows
+        ledger = json.loads((work_dir / "ledger.json").read_text())
+        # The template has 1 baseline row, we appended 1 row (iter 1 only;
+        # iter 2 is final so it goes to DONE without ledger append)
+        iter_rows = [r for r in ledger["iterations"] if r["iteration"] > 0]
+        assert len(iter_rows) == 1  # only iter-1 gets ledger (iter-2 is final)
+        jsonschema.validate(ledger, _load_schema("ledger.schema.json"))
+
+        # Investigation summary should exist for iter-1
+        summary_path = work_dir / "runs" / "iter-1" / "investigation_summary.json"
+        assert summary_path.exists()
+        summary = json.loads(summary_path.read_text())
+        jsonschema.validate(summary, _load_schema("investigation_summary.schema.json"))
+
+        # Principles should have accumulated across iterations
+        principles = json.loads((work_dir / "principles.json").read_text())
+        assert len(principles["principles"]) == 2
+
+        # Both iter dirs should exist
+        assert (work_dir / "runs" / "iter-1" / "bundle.yaml").exists()
+        assert (work_dir / "runs" / "iter-2" / "bundle.yaml").exists()
+
+
+class TestStopsOnHumanAbort:
+    def test_abort_at_continue_gate(self, tmp_path, monkeypatch):
+        work_dir = _setup_work_dir(tmp_path)
+        _patch_for_stub(monkeypatch)
+
+        import run_iteration as ri
+        import run_campaign as rc
+
+        # Iteration gates approve, but continue gate aborts
+        iter_gate = MagicMock(prompt=MagicMock(return_value="approve"))
+        continue_gate = MagicMock(prompt=MagicMock(return_value="abort"))
+        monkeypatch.setattr(ri, "HumanGate", lambda: iter_gate)
+        monkeypatch.setattr(rc, "HumanGate", lambda: continue_gate)
+
+        run_campaign(SAMPLE_CAMPAIGN, work_dir, max_iterations=5)
+
+        engine = Engine(work_dir)
+        assert engine.phase == "DONE"
+        # Only 1 iteration completed
+        assert (work_dir / "runs" / "iter-1" / "findings.json").exists()
+        assert not (work_dir / "runs" / "iter-2").exists()
+
+
+class TestStopsAtMaxIterations:
+    def test_single_iteration_max(self, tmp_path, monkeypatch):
+        work_dir = _setup_work_dir(tmp_path)
+        _patch_for_stub(monkeypatch)
+        _patch_gates_approve(monkeypatch)
+
+        run_campaign(SAMPLE_CAMPAIGN, work_dir, max_iterations=1)
+
+        engine = Engine(work_dir)
+        assert engine.phase == "DONE"
+        assert (work_dir / "runs" / "iter-1" / "findings.json").exists()
+        # No continue gate should have been invoked (iter 1 is final)
+        assert not (work_dir / "runs" / "iter-2").exists()
+
+
+class TestThreeIterations:
+    def test_three_iterations_accumulate_principles(self, tmp_path, monkeypatch):
+        work_dir = _setup_work_dir(tmp_path)
+        _patch_for_stub(monkeypatch)
+        _patch_gates_approve(monkeypatch)
+
+        run_campaign(SAMPLE_CAMPAIGN, work_dir, max_iterations=3)
+
+        engine = Engine(work_dir)
+        assert engine.phase == "DONE"
+
+        principles = json.loads((work_dir / "principles.json").read_text())
+        assert len(principles["principles"]) == 3
+
+        # Ledger has rows for iter 1 and 2 (iter 3 is final)
+        ledger = json.loads((work_dir / "ledger.json").read_text())
+        iter_rows = [r for r in ledger["iterations"] if r["iteration"] > 0]
+        assert len(iter_rows) == 2
+
+        # Summaries for iter 1 and 2 (not iter 3 since it's final)
+        assert (work_dir / "runs" / "iter-1" / "investigation_summary.json").exists()
+        assert (work_dir / "runs" / "iter-2" / "investigation_summary.json").exists()
+
+
+class TestAbortDuringIteration:
+    def test_abort_during_design_gate(self, tmp_path, monkeypatch):
+        """If the human aborts during iteration's design gate, campaign stops
+        and engine state is preserved for potential resume."""
+        work_dir = _setup_work_dir(tmp_path)
+        _patch_for_stub(monkeypatch)
+
+        import run_iteration as ri
+        import run_campaign as rc
+
+        # Iteration gate aborts
+        gate = MagicMock(prompt=MagicMock(return_value="abort"))
+        monkeypatch.setattr(ri, "HumanGate", lambda: gate)
+        monkeypatch.setattr(rc, "HumanGate", lambda: gate)
+
+        run_campaign(SAMPLE_CAMPAIGN, work_dir, max_iterations=5)
+
+        engine = Engine(work_dir)
+        # Engine is at HUMAN_DESIGN_GATE (preserved for resume)
+        assert engine.phase == "HUMAN_DESIGN_GATE"

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -97,10 +97,8 @@ class TestTwoIterationHappyPath:
 
         # Ledger should have baseline + 2 iteration rows
         ledger = json.loads((work_dir / "ledger.json").read_text())
-        # The template has 1 baseline row, we appended 1 row (iter 1 only;
-        # iter 2 is final so it goes to DONE without ledger append)
         iter_rows = [r for r in ledger["iterations"] if r["iteration"] > 0]
-        assert len(iter_rows) == 1  # only iter-1 gets ledger (iter-2 is final)
+        assert len(iter_rows) == 2  # both iter-1 and iter-2 (final) get ledger rows
         jsonschema.validate(ledger, _load_schema("ledger.schema.json"))
 
         # Investigation summary should exist for iter-1
@@ -170,10 +168,10 @@ class TestThreeIterations:
         principles = json.loads((work_dir / "principles.json").read_text())
         assert len(principles["principles"]) == 3
 
-        # Ledger has rows for iter 1 and 2 (iter 3 is final)
+        # Ledger has rows for all 3 iterations (including final)
         ledger = json.loads((work_dir / "ledger.json").read_text())
         iter_rows = [r for r in ledger["iterations"] if r["iteration"] > 0]
-        assert len(iter_rows) == 2
+        assert len(iter_rows) == 3
 
         # Summaries for iter 1 and 2 (not iter 3 since it's final)
         assert (work_dir / "runs" / "iter-1" / "investigation_summary.json").exists()

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -113,6 +113,18 @@ class TestStubDispatcher:
             )
 
 
+    def test_dispatch_extractor_summarize(self, work_dir):
+        dispatcher = _make_dispatcher(work_dir)
+        output_path = work_dir / "runs" / "iter-1" / "investigation_summary.json"
+        dispatcher.dispatch(
+            "extractor", "summarize", output_path=output_path, iteration=1,
+        )
+        assert output_path.exists()
+        summary = json.loads(output_path.read_text())
+        jsonschema.validate(summary, _load_schema("investigation_summary.schema.json"))
+        assert summary["iteration"] == 1
+
+
 class TestDispatchErrorHandling:
     def test_corrupt_principles_file_raises(self, tmp_path):
         (tmp_path / "principles.json").write_text("{bad json")

--- a/tests/test_fastfail.py
+++ b/tests/test_fastfail.py
@@ -119,7 +119,7 @@ class TestFastFailValidation:
         with pytest.raises(TypeError, match="must be numeric"):
             check_fast_fail(findings)
 
-    def test_duplicate_arm_type_raises(self):
+    def test_duplicate_h_main_raises(self):
         findings = {
             "arms": [
                 {"arm_type": "h-main", "status": "CONFIRMED"},
@@ -128,6 +128,38 @@ class TestFastFailValidation:
         }
         with pytest.raises(ValueError, match="Duplicate arm_type"):
             check_fast_fail(findings)
+
+    def test_duplicate_h_control_negative_raises(self):
+        findings = {
+            "arms": [
+                {"arm_type": "h-main", "status": "CONFIRMED"},
+                {"arm_type": "h-control-negative", "status": "CONFIRMED"},
+                {"arm_type": "h-control-negative", "status": "REFUTED"},
+            ]
+        }
+        with pytest.raises(ValueError, match="Duplicate arm_type"):
+            check_fast_fail(findings)
+
+    def test_multiple_robustness_arms_allowed(self):
+        findings = {
+            "arms": [
+                {"arm_type": "h-main", "status": "REFUTED"},
+                {"arm_type": "h-control-negative", "status": "CONFIRMED"},
+                {"arm_type": "h-robustness", "status": "REFUTED"},
+                {"arm_type": "h-robustness", "status": "REFUTED"},
+            ]
+        }
+        assert check_fast_fail(findings) == FastFailAction.SKIP_TO_EXTRACTION
+
+    def test_multiple_ablation_arms_allowed(self):
+        findings = {
+            "arms": [
+                {"arm_type": "h-main", "status": "CONFIRMED"},
+                {"arm_type": "h-ablation", "status": "CONFIRMED"},
+                {"arm_type": "h-ablation", "status": "REFUTED"},
+            ]
+        }
+        assert check_fast_fail(findings) == FastFailAction.CONTINUE
 
     def test_missing_arm_type_key_raises(self):
         findings = {

--- a/tests/test_integration_real_execution.py
+++ b/tests/test_integration_real_execution.py
@@ -179,6 +179,53 @@ class TestRunExperimentCommands:
         assert results["baseline"]["ttft_p99_ms"] == 250.8
         assert results["h-main"]["ttft_p99_ms"] == 200.0
 
+    def test_multiple_experiments_per_arm(self, fake_simulator, tmp_path):
+        """Multiple experiments for the same arm_type produce a list of results."""
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+
+        plan = {
+            "baseline": {
+                "description": "baseline",
+                "command": f"{sys.executable} {fake_simulator} --metrics-path {{metrics_path}}",
+            },
+            "experiments": [
+                {
+                    "arm_type": "h-main",
+                    "description": "run A",
+                    "config_changes": "config A",
+                    "command": f"{sys.executable} {fake_simulator} --batch-size 64 --metrics-path {{metrics_path}}",
+                },
+                {
+                    "arm_type": "h-main",
+                    "description": "run B",
+                    "config_changes": "config B",
+                    "command": f"{sys.executable} {fake_simulator} --batch-size 128 --metrics-path {{metrics_path}}",
+                },
+                {
+                    "arm_type": "h-control-negative",
+                    "description": "single control",
+                    "command": f"{sys.executable} {fake_simulator} --metrics-path {{metrics_path}}",
+                },
+            ],
+        }
+        results = run_experiment_commands(
+            plan, work_dir=tmp_path, iter_dir=iter_dir, timeout=30,
+        )
+        # h-main appears twice -> list
+        assert isinstance(results["h-main"], list)
+        assert len(results["h-main"]) == 2
+        assert results["h-main"][0]["_experiment_description"] == "run A"
+        assert results["h-main"][1]["_experiment_description"] == "run B"
+        # h-control-negative appears once -> dict
+        assert isinstance(results["h-control-negative"], dict)
+        # Indexed metrics files should exist
+        assert (iter_dir / "metrics" / "h-main-0.json").exists()
+        assert (iter_dir / "metrics" / "h-main-1.json").exists()
+        assert (iter_dir / "metrics" / "h-control-negative.json").exists()
+        # No overwritten h-main.json
+        assert not (iter_dir / "metrics" / "h-main.json").exists()
+
     def test_command_failure_raises(self, tmp_path):
         iter_dir = tmp_path / "runs" / "iter-1"
         iter_dir.mkdir(parents=True)

--- a/tests/test_integration_real_execution.py
+++ b/tests/test_integration_real_execution.py
@@ -543,8 +543,6 @@ def _setup_stub_iteration(tmp_path, monkeypatch):
 
     # Monkeypatch LLMDispatcher -> StubDispatcher in run_iteration module
     import run_iteration as ri
-    original_llm_dispatcher = ri.LLMDispatcher
-
     def stub_factory(work_dir, campaign, model=None):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")

--- a/tests/test_integration_real_execution.py
+++ b/tests/test_integration_real_execution.py
@@ -415,7 +415,10 @@ class TestAnalysisModeFallback:
 # Resume logic tests
 # ---------------------------------------------------------------------------
 
-from run_iteration import _enter_phase, _PHASE_ORDER, _PHASE_INDEX
+from run_iteration import (
+    _enter_phase, _PHASE_ORDER, _PHASE_INDEX,
+    run_iteration, IterationOutcome, setup_work_dir,
+)
 from orchestrator.engine import Engine, Phase
 
 
@@ -496,3 +499,100 @@ class TestEnterPhase:
         # Can advance to next
         assert _enter_phase(engine, "HUMAN_FINDINGS_GATE") is True
         assert engine.phase == "HUMAN_FINDINGS_GATE"
+
+
+# ---------------------------------------------------------------------------
+# IterationOutcome tests
+# ---------------------------------------------------------------------------
+
+from orchestrator.dispatch import StubDispatcher
+import warnings
+
+
+def _setup_stub_iteration(tmp_path, monkeypatch):
+    """Prepare a work_dir with stub dispatcher for testing run_iteration outcomes."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    # Copy templates
+    import shutil
+    templates_dir = Path(__file__).resolve().parent.parent / "templates"
+    for t in ["state.json", "ledger.json", "principles.json"]:
+        shutil.copy(templates_dir / t, work_dir / t)
+    state = json.loads((work_dir / "state.json").read_text())
+    state["run_id"] = "test"
+    (work_dir / "state.json").write_text(json.dumps(state, indent=2))
+
+    campaign = {
+        "research_question": "Test question?",
+        "target_system": {
+            "name": "TestSystem",
+            "description": "Test system.",
+            "observable_metrics": ["latency_ms"],
+            "controllable_knobs": ["config"],
+        },
+        "review": {
+            "design_perspectives": ["rigor"],
+            "findings_perspectives": ["rigor"],
+            "max_review_rounds": 1,
+        },
+        "prompts": {
+            "methodology_layer": "prompts/methodology",
+            "domain_adapter_layer": None,
+        },
+    }
+
+    # Monkeypatch LLMDispatcher -> StubDispatcher in run_iteration module
+    import run_iteration as ri
+    original_llm_dispatcher = ri.LLMDispatcher
+
+    def stub_factory(work_dir, campaign, model=None):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return StubDispatcher(work_dir)
+
+    monkeypatch.setattr(ri, "LLMDispatcher", stub_factory)
+    return work_dir, campaign
+
+
+class TestIterationOutcome:
+    """Test that run_iteration returns correct IterationOutcome values."""
+
+    def test_returns_completed_by_default(self, tmp_path, monkeypatch):
+        work_dir, campaign = _setup_stub_iteration(tmp_path, monkeypatch)
+        import run_iteration as ri
+        monkeypatch.setattr(ri, "HumanGate", lambda: MagicMock(prompt=MagicMock(return_value="approve")))
+
+        result = run_iteration(campaign, work_dir, iteration=1)
+
+        assert result == IterationOutcome.COMPLETED
+        engine = Engine(work_dir)
+        assert engine.phase == "DONE"
+
+    def test_returns_continue_when_not_final(self, tmp_path, monkeypatch):
+        work_dir, campaign = _setup_stub_iteration(tmp_path, monkeypatch)
+        import run_iteration as ri
+        monkeypatch.setattr(ri, "HumanGate", lambda: MagicMock(prompt=MagicMock(return_value="approve")))
+
+        result = run_iteration(campaign, work_dir, iteration=1, final=False)
+
+        assert result == IterationOutcome.CONTINUE
+        engine = Engine(work_dir)
+        assert engine.phase == "EXTRACTION"
+
+    def test_returns_aborted_on_design_gate_abort(self, tmp_path, monkeypatch):
+        work_dir, campaign = _setup_stub_iteration(tmp_path, monkeypatch)
+        import run_iteration as ri
+        monkeypatch.setattr(ri, "HumanGate", lambda: MagicMock(prompt=MagicMock(return_value="abort")))
+
+        result = run_iteration(campaign, work_dir, iteration=1)
+
+        assert result == IterationOutcome.ABORTED
+
+    def test_returns_redesign_on_design_gate_reject(self, tmp_path, monkeypatch):
+        work_dir, campaign = _setup_stub_iteration(tmp_path, monkeypatch)
+        import run_iteration as ri
+        monkeypatch.setattr(ri, "HumanGate", lambda: MagicMock(prompt=MagicMock(return_value="reject")))
+
+        result = run_iteration(campaign, work_dir, iteration=1)
+
+        assert result == IterationOutcome.REDESIGN

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,241 @@
+"""Tests for the deterministic ledger append module."""
+import json
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.ledger import append_ledger_row
+
+
+SCHEMAS_DIR = __import__("pathlib").Path(__file__).resolve().parent.parent / "schemas"
+
+
+def _load_schema(name: str) -> dict:
+    path = SCHEMAS_DIR / name
+    if path.suffix in (".yaml", ".yml"):
+        return yaml.safe_load(path.read_text())
+    return json.loads(path.read_text())
+
+
+def _write_bundle(iter_dir, iteration=1, family="test-family"):
+    bundle = {
+        "metadata": {
+            "iteration": iteration,
+            "family": family,
+            "research_question": "Does X affect Y?",
+        },
+        "arms": [
+            {
+                "type": "h-main",
+                "prediction": "Y increases by 10%",
+                "mechanism": "X causes Y",
+                "diagnostic": "Check X->Y path",
+            },
+            {
+                "type": "h-control-negative",
+                "prediction": "no effect without X",
+                "mechanism": "no X means no Y change",
+                "diagnostic": "verify baseline",
+            },
+        ],
+    }
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    (iter_dir / "bundle.yaml").write_text(
+        yaml.safe_dump(bundle, default_flow_style=False, sort_keys=False)
+    )
+
+
+def _write_findings(iter_dir, iteration=1, h_main="CONFIRMED", control="CONFIRMED"):
+    findings = {
+        "iteration": iteration,
+        "bundle_ref": f"runs/iter-{iteration}/bundle.yaml",
+        "arms": [
+            {
+                "arm_type": "h-main",
+                "predicted": "Y increases by 10%",
+                "observed": "Y increased by 12%",
+                "status": h_main,
+                "error_type": None if h_main == "CONFIRMED" else "direction",
+                "diagnostic_note": None,
+            },
+            {
+                "arm_type": "h-control-negative",
+                "predicted": "no effect without X",
+                "observed": "no significant change",
+                "status": control,
+                "error_type": None,
+                "diagnostic_note": None,
+            },
+        ],
+        "discrepancy_analysis": "All arms within expected range.",
+    }
+    (iter_dir / "findings.json").write_text(json.dumps(findings, indent=2))
+
+
+def _write_principles(work_dir, principles_list):
+    (work_dir / "principles.json").write_text(
+        json.dumps({"principles": principles_list}, indent=2)
+    )
+
+
+class TestAppendLedgerRow:
+    def test_append_basic(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        _write_bundle(iter_dir)
+        _write_findings(iter_dir)
+        _write_principles(tmp_path, [
+            {
+                "id": "P-1",
+                "statement": "X causes Y",
+                "confidence": "medium",
+                "regime": "all",
+                "evidence": ["iteration-1-h-main"],
+                "contradicts": [],
+                "extraction_iteration": 1,
+                "mechanism": "direct causation",
+                "applicability_bounds": "when X present",
+                "superseded_by": None,
+                "category": "domain",
+                "status": "active",
+            }
+        ])
+
+        append_ledger_row(tmp_path, 1)
+
+        ledger = json.loads((tmp_path / "ledger.json").read_text())
+        jsonschema.validate(ledger, _load_schema("ledger.schema.json"))
+        assert len(ledger["iterations"]) == 1
+        row = ledger["iterations"][0]
+        assert row["iteration"] == 1
+        assert row["family"] == "test-family"
+        assert row["h_main_result"] == "CONFIRMED"
+        assert row["control_result"] == "CONFIRMED"
+        assert row["prediction_accuracy"]["arms_correct"] == 2
+        assert row["prediction_accuracy"]["arms_total"] == 2
+        assert row["prediction_accuracy"]["accuracy_pct"] == 100.0
+        assert len(row["principles_extracted"]) == 1
+        assert row["principles_extracted"][0] == {"id": "P-1", "action": "INSERT"}
+
+    def test_append_no_findings_is_noop(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        _write_bundle(iter_dir)
+        # No findings.json
+
+        append_ledger_row(tmp_path, 1)
+
+        assert not (tmp_path / "ledger.json").exists()
+
+    def test_append_preserves_existing(self, tmp_path):
+        # Pre-populate ledger with baseline row
+        ledger = {
+            "iterations": [
+                {
+                    "iteration": 0,
+                    "family": "baseline",
+                    "timestamp": "1970-01-01T00:00:00Z",
+                    "candidate_id": "baseline",
+                    "h_main_result": None,
+                    "ablation_results": {},
+                    "control_result": None,
+                    "robustness_result": None,
+                    "prediction_accuracy": None,
+                    "principles_extracted": [],
+                    "frontier_update": None,
+                }
+            ]
+        }
+        (tmp_path / "ledger.json").write_text(json.dumps(ledger, indent=2))
+
+        iter_dir = tmp_path / "runs" / "iter-1"
+        _write_bundle(iter_dir)
+        _write_findings(iter_dir)
+        _write_principles(tmp_path, [])
+
+        append_ledger_row(tmp_path, 1)
+
+        result = json.loads((tmp_path / "ledger.json").read_text())
+        jsonschema.validate(result, _load_schema("ledger.schema.json"))
+        assert len(result["iterations"]) == 2
+        assert result["iterations"][0]["family"] == "baseline"
+        assert result["iterations"][1]["family"] == "test-family"
+
+    def test_prediction_accuracy(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        _write_bundle(iter_dir)
+        _write_findings(iter_dir, h_main="REFUTED", control="CONFIRMED")
+        _write_principles(tmp_path, [])
+
+        append_ledger_row(tmp_path, 1)
+
+        ledger = json.loads((tmp_path / "ledger.json").read_text())
+        row = ledger["iterations"][0]
+        assert row["h_main_result"] == "REFUTED"
+        assert row["prediction_accuracy"]["arms_correct"] == 1
+        assert row["prediction_accuracy"]["arms_total"] == 2
+        assert row["prediction_accuracy"]["accuracy_pct"] == 50.0
+
+    def test_ablation_results_collected(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        _write_bundle(iter_dir)
+        # Findings with ablation arms
+        findings = {
+            "iteration": 1,
+            "bundle_ref": "runs/iter-1/bundle.yaml",
+            "arms": [
+                {
+                    "arm_type": "h-main",
+                    "predicted": "p", "observed": "o",
+                    "status": "CONFIRMED",
+                    "error_type": None, "diagnostic_note": None,
+                },
+                {
+                    "arm_type": "h-ablation",
+                    "predicted": "p", "observed": "o",
+                    "status": "REFUTED",
+                    "error_type": "direction", "diagnostic_note": None,
+                },
+                {
+                    "arm_type": "h-control-negative",
+                    "predicted": "p", "observed": "o",
+                    "status": "CONFIRMED",
+                    "error_type": None, "diagnostic_note": None,
+                },
+            ],
+            "discrepancy_analysis": "Ablation refuted.",
+        }
+        (iter_dir / "findings.json").write_text(json.dumps(findings, indent=2))
+        _write_principles(tmp_path, [])
+
+        append_ledger_row(tmp_path, 1)
+
+        ledger = json.loads((tmp_path / "ledger.json").read_text())
+        jsonschema.validate(ledger, _load_schema("ledger.schema.json"))
+        row = ledger["iterations"][0]
+        assert row["ablation_results"] == {"ablation-0": "REFUTED"}
+
+    def test_no_principles_file_handled(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        _write_bundle(iter_dir)
+        _write_findings(iter_dir)
+        # No principles.json
+
+        append_ledger_row(tmp_path, 1)
+
+        ledger = json.loads((tmp_path / "ledger.json").read_text())
+        jsonschema.validate(ledger, _load_schema("ledger.schema.json"))
+        assert ledger["iterations"][0]["principles_extracted"] == []
+
+    def test_no_bundle_still_works(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        _write_findings(iter_dir)
+        _write_principles(tmp_path, [])
+        # No bundle.yaml — family defaults to "unknown"
+
+        append_ledger_row(tmp_path, 1)
+
+        ledger = json.loads((tmp_path / "ledger.json").read_text())
+        jsonschema.validate(ledger, _load_schema("ledger.schema.json"))
+        assert ledger["iterations"][0]["family"] == "unknown"

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -226,6 +226,18 @@ class TestAppendLedgerRow:
         jsonschema.validate(ledger, _load_schema("ledger.schema.json"))
         assert ledger["iterations"][0]["principles_extracted"] == []
 
+    def test_idempotent_no_duplicate(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        _write_bundle(iter_dir)
+        _write_findings(iter_dir)
+        _write_principles(tmp_path, [])
+
+        append_ledger_row(tmp_path, 1)
+        append_ledger_row(tmp_path, 1)  # Second call for same iteration
+
+        ledger = json.loads((tmp_path / "ledger.json").read_text())
+        assert len(ledger["iterations"]) == 1
+
     def test_no_bundle_still_works(self, tmp_path):
         iter_dir = tmp_path / "runs" / "iter-1"
         iter_dir.mkdir(parents=True)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -2,7 +2,6 @@
 import json
 
 import jsonschema
-import pytest
 import yaml
 
 from orchestrator.ledger import append_ledger_row

--- a/tests/test_llm_dispatch.py
+++ b/tests/test_llm_dispatch.py
@@ -579,6 +579,29 @@ class TestInvestigationSummaryContext:
         prompt = mock_fn.call_log[0]["messages"][0]["content"]
         assert "No investigation summary available" in prompt
 
+    def test_design_iter2_falls_back_to_iter1_problem_md(self, work_dir: Path) -> None:
+        """Iteration 2+ skips framing, so design falls back to iter-1's problem.md."""
+        # Only iter-1 has problem.md (framing only runs once)
+        iter1 = work_dir / "runs" / "iter-1"
+        iter1.mkdir(parents=True, exist_ok=True)
+        (iter1 / "problem.md").write_text(
+            "# Problem Framing\n\n## Research Question\n"
+            "Does prefix caching reduce TTFT?\n"
+        )
+        # iter-2 exists but has no problem.md
+        iter2 = work_dir / "runs" / "iter-2"
+        iter2.mkdir(parents=True)
+
+        resp = f"```yaml\n{VALID_BUNDLE_YAML}```"
+        mock_fn = make_mock_completion([resp])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = iter2 / "bundle.yaml"
+        d.dispatch("planner", "design", output_path=out, iteration=2)
+        prompt = mock_fn.call_log[0]["messages"][0]["content"]
+        assert "prefix caching" in prompt.lower()
+
 
 class TestSummarizeDispatch:
     """Verify the summarize route works end-to-end via LLMDispatcher."""

--- a/tests/test_llm_dispatch.py
+++ b/tests/test_llm_dispatch.py
@@ -298,13 +298,23 @@ class TestLLMDispatcher:
         # The mock response has CONFIRMED — proving h_main_result was ignored
         assert findings["arms"][0]["status"] == "CONFIRMED"
 
-    def test_no_code_fence_raises(self, work_dir: Path) -> None:
-        # Raw JSON without code fence should raise, not silently parse
-        d = _make_dispatcher(work_dir, [VALID_FINDINGS_JSON])
+    def test_no_code_fence_retries_then_raises(self, work_dir: Path) -> None:
+        # Raw JSON without code fence triggers retry; if retry also fails, raises
+        d = _make_dispatcher(work_dir, [VALID_FINDINGS_JSON, VALID_FINDINGS_JSON])
         out = work_dir / "runs" / "iter-1" / "findings_raw.json"
 
-        with pytest.raises(RuntimeError, match="No ```json``` code fence found"):
+        with pytest.raises(RuntimeError, match="retry response could not be parsed"):
             d.dispatch("executor", "run", output_path=out, iteration=1)
+
+    def test_no_code_fence_retry_succeeds(self, work_dir: Path) -> None:
+        # First response has no fence, retry returns a proper fenced response
+        fenced = f"```json\n{VALID_FINDINGS_JSON}\n```"
+        d = _make_dispatcher(work_dir, [VALID_FINDINGS_JSON, fenced])
+        out = work_dir / "runs" / "iter-1" / "findings_retry.json"
+
+        d.dispatch("executor", "run", output_path=out, iteration=1)
+        findings = json.loads(out.read_text())
+        assert "arms" in findings
 
     def test_multiple_code_fences_uses_last(self, work_dir: Path) -> None:
         first_json = json.dumps({"bad": True})

--- a/tests/test_llm_dispatch.py
+++ b/tests/test_llm_dispatch.py
@@ -511,3 +511,106 @@ class TestRunAnalyzeDispatch:
         findings = json.loads(out.read_text())
         schema = load_schema("findings.schema.json")
         jsonschema.validate(findings, schema)
+
+
+class TestInvestigationSummaryContext:
+    """Verify investigation_summary is injected into design prompts."""
+
+    def test_design_iter1_gets_first_iteration_default(self, work_dir: Path) -> None:
+        resp = f"```yaml\n{VALID_BUNDLE_YAML}```"
+        mock_fn = make_mock_completion([resp])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = work_dir / "runs" / "iter-1" / "bundle_ctx.yaml"
+        d.dispatch("planner", "design", output_path=out, iteration=1)
+        prompt = mock_fn.call_log[0]["messages"][0]["content"]
+        assert "first iteration" in prompt.lower()
+
+    def test_design_iter2_includes_previous_summary(self, work_dir: Path) -> None:
+        # Set up iter-2 directory with bundle + problem.md
+        iter2 = work_dir / "runs" / "iter-2"
+        iter2.mkdir(parents=True)
+        (iter2 / "problem.md").write_text(
+            "# Problem Framing\n\n## Research Question\n"
+            "Does worker_count affect throughput?\n"
+        )
+        (iter2 / "bundle.yaml").write_text(VALID_BUNDLE_YAML)
+        # Write investigation summary for iter-1
+        summary = {
+            "iteration": 1,
+            "what_was_tested": "Batch size amortization",
+            "key_findings": "H-main confirmed at 18% improvement",
+            "principles_changed": "Inserted RP-1",
+            "open_questions": "Does this hold under high load?",
+            "suggested_next_direction": "Test with worker_count scaling",
+        }
+        summary_path = work_dir / "runs" / "iter-1" / "investigation_summary.json"
+        summary_path.write_text(json.dumps(summary, indent=2))
+
+        resp = f"```yaml\n{VALID_BUNDLE_YAML}```"
+        mock_fn = make_mock_completion([resp])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = iter2 / "bundle_ctx.yaml"
+        d.dispatch("planner", "design", output_path=out, iteration=2)
+        prompt = mock_fn.call_log[0]["messages"][0]["content"]
+        assert "Batch size amortization" in prompt
+        assert "H-main confirmed" in prompt
+
+    def test_design_iter2_missing_summary_gets_default(self, work_dir: Path) -> None:
+        # Set up iter-2 without a summary for iter-1
+        iter2 = work_dir / "runs" / "iter-2"
+        iter2.mkdir(parents=True)
+        (iter2 / "problem.md").write_text(
+            "# Problem Framing\n\n## Research Question\n"
+            "Does worker_count affect throughput?\n"
+        )
+        (iter2 / "bundle.yaml").write_text(VALID_BUNDLE_YAML)
+
+        resp = f"```yaml\n{VALID_BUNDLE_YAML}```"
+        mock_fn = make_mock_completion([resp])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = iter2 / "bundle_ctx.yaml"
+        d.dispatch("planner", "design", output_path=out, iteration=2)
+        prompt = mock_fn.call_log[0]["messages"][0]["content"]
+        assert "No investigation summary available" in prompt
+
+
+class TestSummarizeDispatch:
+    """Verify the summarize route works end-to-end via LLMDispatcher."""
+
+    VALID_SUMMARY_JSON = json.dumps({
+        "iteration": 1,
+        "what_was_tested": "Batch size amortization hypothesis",
+        "key_findings": "H-main confirmed with 18% latency reduction",
+        "principles_changed": "Inserted RP-1: batch amortization",
+        "open_questions": "Does this hold under high contention?",
+        "suggested_next_direction": "Test with concurrent workers",
+    }, indent=2)
+
+    def test_dispatch_summarize_produces_valid_summary(self, work_dir: Path) -> None:
+        resp = f"```json\n{self.VALID_SUMMARY_JSON}\n```"
+        d = _make_dispatcher(work_dir, [resp])
+        out = work_dir / "runs" / "iter-1" / "investigation_summary.json"
+        d.dispatch("extractor", "summarize", output_path=out, iteration=1)
+        assert out.exists()
+        summary = json.loads(out.read_text())
+        schema = load_schema("investigation_summary.schema.json")
+        jsonschema.validate(summary, schema)
+
+    def test_summarize_context_includes_bundle_and_findings(self, work_dir: Path) -> None:
+        resp = f"```json\n{self.VALID_SUMMARY_JSON}\n```"
+        mock_fn = make_mock_completion([resp])
+        d = LLMDispatcher(
+            work_dir=work_dir, campaign=SAMPLE_CAMPAIGN, completion_fn=mock_fn,
+        )
+        out = work_dir / "runs" / "iter-1" / "investigation_summary.json"
+        d.dispatch("extractor", "summarize", output_path=out, iteration=1)
+        prompt = mock_fn.call_log[0]["messages"][0]["content"]
+        # Should contain bundle and findings content
+        assert "h-main" in prompt
+        assert "CONFIRMED" in prompt

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -630,6 +630,47 @@ class TestCampaignSchema:
         with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
             jsonschema.validate(instance, schema)
 
+    def test_max_iterations_accepted(self, load_schema):
+        schema = load_schema("campaign.schema.yaml")
+        instance = {
+            "research_question": "What affects latency?",
+            "max_iterations": 5,
+            "target_system": {
+                "name": "x",
+                "description": "x",
+                "observable_metrics": ["m"],
+                "controllable_knobs": ["k"],
+            },
+            "review": {
+                "design_perspectives": ["general"],
+                "findings_perspectives": ["general"],
+                "max_review_rounds": 1,
+            },
+            "prompts": {"methodology_layer": "prompts/"},
+        }
+        jsonschema.validate(instance, schema)
+
+    def test_max_iterations_zero_rejected(self, load_schema):
+        schema = load_schema("campaign.schema.yaml")
+        instance = {
+            "research_question": "What affects latency?",
+            "max_iterations": 0,
+            "target_system": {
+                "name": "x",
+                "description": "x",
+                "observable_metrics": ["m"],
+                "controllable_knobs": ["k"],
+            },
+            "review": {
+                "design_perspectives": ["general"],
+                "findings_perspectives": ["general"],
+                "max_review_rounds": 1,
+            },
+            "prompts": {"methodology_layer": "prompts/"},
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance, schema)
+
 
 class TestPrinciplesCategoryField:
     def test_domain_category_accepted(self, load_schema):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -881,6 +881,59 @@ class TestCampaignExecutionConfig:
             jsonschema.validate(instance, schema)
 
 
+class TestInvestigationSummarySchema:
+    """Tests for investigation_summary.schema.json."""
+
+    def test_valid_summary(self, load_schema):
+        schema = load_schema("investigation_summary.schema.json")
+        instance = {
+            "iteration": 1,
+            "what_was_tested": "Prefix token sharing mechanism for KV-cache reuse.",
+            "key_findings": "H-main refuted: BLIS does not implement prefix reuse.",
+            "principles_changed": "Inserted RP-1 (no prefix reuse), MP-1 (verify features).",
+            "open_questions": "Does the scheduler affect TTFT under load?",
+            "suggested_next_direction": "Investigate scheduling policy effects.",
+        }
+        jsonschema.validate(instance, schema)
+
+    def test_missing_field_rejected(self, load_schema):
+        schema = load_schema("investigation_summary.schema.json")
+        instance = {
+            "iteration": 1,
+            "what_was_tested": "test",
+            # missing key_findings and others
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance, schema)
+
+    def test_empty_string_rejected(self, load_schema):
+        schema = load_schema("investigation_summary.schema.json")
+        instance = {
+            "iteration": 1,
+            "what_was_tested": "",
+            "key_findings": "x",
+            "principles_changed": "x",
+            "open_questions": "x",
+            "suggested_next_direction": "x",
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance, schema)
+
+    def test_extra_field_rejected(self, load_schema):
+        schema = load_schema("investigation_summary.schema.json")
+        instance = {
+            "iteration": 1,
+            "what_was_tested": "x",
+            "key_findings": "x",
+            "principles_changed": "x",
+            "open_questions": "x",
+            "suggested_next_direction": "x",
+            "extra": "nope",
+        }
+        with pytest.raises(jsonschema.ValidationError, match="Additional properties"):
+            jsonschema.validate(instance, schema)
+
+
 class TestExperimentPlanSchema:
     """Tests for experiment_plan.schema.json."""
 


### PR DESCRIPTION
## Summary

Implements Phase 4 of the Nous framework (closes #9): multi-iteration campaigns where principles and investigation summaries compound across iterations.

- **`run_campaign.py`** — new entry point that loops `run_iteration()`, appending ledger rows and generating bounded investigation summaries between iterations
- **`IterationOutcome` enum** — `run_iteration()` now returns COMPLETED/CONTINUE/ABORTED/REDESIGN so the campaign loop can branch
- **Investigation summary** — LLM-generated JSON after each extraction, injected into the next iteration's design prompt via `{{investigation_summary}}`
- **Deterministic ledger** — `orchestrator/ledger.py` appends one row per iteration with prediction accuracy and principle changes (no LLM calls)
- **`--auto-approve` flag** — bypasses all human gates (design, findings, continue) for automated/CI runs
- **`max_iterations`** — configurable via campaign.yaml or CLI `--max-iterations` (CLI overrides)
- **3 human gates** — design approval, findings approval, continue gate (new)

### Commits (9)

1. `d42a9f5` — Investigation summary schema + prompt template
2. `9ee7a65` — Summarize route in LLM and stub dispatchers
3. `c47e48b` — Investigation summary context injection in design prompt
4. `b052715` — Deterministic ledger append module
5. `c77bc84` — `run_iteration()` returns `IterationOutcome`
6. `ef1c062` — `run_campaign.py` multi-iteration entry point
7. `aa844f4` — Campaign schema `max_iterations` field
8. `1691062` — Documentation updates (protocol, architecture, data-model, quickstart, README)
9. `5cbab6e` — PR review fixes + `--auto-approve` flag

## Test plan

- [x] All 234 tests pass (`pytest tests/ -v`)
- [x] Schema validation for `investigation_summary.schema.json`
- [x] Stub dispatcher summarize route
- [x] LLM dispatcher investigation summary context (iteration 1 vs 2+)
- [x] Ledger append: basic, no-op on missing findings, preserves existing rows, accuracy calculation
- [x] IterationOutcome: completed (default), continue (non-final), aborted (gate abort)
- [x] Campaign loop: 2-iter happy path, abort at continue gate, max iterations, 3 iterations, abort during iteration
- [x] Backward compatibility: `run_iteration.py` still works standalone (single iteration → DONE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)