### PR TITLE
feat: nous validate CLI + executor writes artifacts directly

### DIFF
--- a/orchestrator/cli_dispatch.py
+++ b/orchestrator/cli_dispatch.py
@@ -77,10 +77,10 @@ class CLIDispatcher(LLMDispatcher):
         self._current_phase = phase
 
         template, fmt, schema_name = self._route(role, phase)
-        # For execute-analyze via CLI, the agent writes files directly to iter_dir.
-        # We save the raw response as a log. Caller MUST run validate_execution()
-        # after this dispatch — no artifact validation happens here.
-        if phase == "execute-analyze":
+        # For design and execute-analyze via CLI, the agent writes files directly
+        # to iter_dir. We save the raw response as a log. Caller MUST run
+        # validate_design() or validate_execution() after dispatch.
+        if phase in ("design", "execute-analyze"):
             fmt = None
             schema_name = None
         context = self._build_context(role, phase, iteration, perspective)

--- a/orchestrator/cli_dispatch.py
+++ b/orchestrator/cli_dispatch.py
@@ -77,6 +77,11 @@ class CLIDispatcher(LLMDispatcher):
         self._current_phase = phase
 
         template, fmt, schema_name = self._route(role, phase)
+        # For execute-analyze via CLI, the agent writes files directly.
+        # We just save the raw response as a log — no JSON parsing needed.
+        if phase == "execute-analyze":
+            fmt = None
+            schema_name = None
         context = self._build_context(role, phase, iteration, perspective)
         prompt = self.loader.load(template, context)
 

--- a/orchestrator/cli_dispatch.py
+++ b/orchestrator/cli_dispatch.py
@@ -77,8 +77,9 @@ class CLIDispatcher(LLMDispatcher):
         self._current_phase = phase
 
         template, fmt, schema_name = self._route(role, phase)
-        # For execute-analyze via CLI, the agent writes files directly.
-        # We just save the raw response as a log — no JSON parsing needed.
+        # For execute-analyze via CLI, the agent writes files directly to iter_dir.
+        # We save the raw response as a log. Caller MUST run validate_execution()
+        # after this dispatch — no artifact validation happens here.
         if phase == "execute-analyze":
             fmt = None
             schema_name = None

--- a/orchestrator/dispatch.py
+++ b/orchestrator/dispatch.py
@@ -159,12 +159,10 @@ class StubDispatcher:
                         {
                             "name": "baseline",
                             "cmd": "echo '{\"latency_ms\": 50}'",
-                            "output": "results/h-main/baseline.json",
                         },
                         {
                             "name": "treatment",
                             "cmd": "echo '{\"latency_ms\": 40}'",
-                            "output": "results/h-main/treatment.json",
                         },
                     ],
                 },
@@ -174,7 +172,6 @@ class StubDispatcher:
                         {
                             "name": "control",
                             "cmd": "echo '{\"latency_ms\": 50}'",
-                            "output": "results/h-control-negative/control.json",
                         },
                     ],
                 },

--- a/orchestrator/dispatch.py
+++ b/orchestrator/dispatch.py
@@ -79,7 +79,10 @@ class StubDispatcher:
         logger.info("Dispatched role=%s phase=%s -> %s", role, phase, output_path)
 
     def _write_design_output(self, path: Path, iteration: int) -> None:
-        """Write merged design output: problem framing markdown + yaml bundle fence."""
+        """Write design artifacts directly to iter_dir (mimics agent writing files)."""
+        iter_dir = path.parent
+        iter_dir.mkdir(parents=True, exist_ok=True)
+
         bundle = {
             "metadata": {
                 "iteration": iteration,
@@ -101,7 +104,6 @@ class StubDispatcher:
                 },
             ],
         }
-        bundle_yaml = yaml.safe_dump(bundle, default_flow_style=False, sort_keys=False)
         problem_md = (
             "## Research Question\n\n"
             "Stub: does the mechanism work?\n\n"
@@ -116,24 +118,26 @@ class StubDispatcher:
             "Test whether the stub mechanism reduces latency under contention.\n\n"
             "### Key Discoveries\n"
             "- Mechanism is implemented at `src/stub.py:42` — toggles batch amortization\n"
-            "- Baseline latency at default load: 50ms mean\n"
-            "- Effect only manifests above 80% saturation (verified via probe)\n\n"
+            "- Baseline latency at default load: 50ms mean\n\n"
             "### System Interface\n"
             "- **Build:** `echo 'stub build'`\n"
-            "- **Run baseline:** `echo 'stub baseline'`\n"
-            "- **Output format:** stdout JSON\n"
-            "- **Baseline result:** latency_ms=50\n\n"
+            "- **Run baseline:** `echo 'stub baseline'`\n\n"
             "### Code Map\n"
-            "- `src/stub.py:42` — mechanism toggle. Check here if treatment has no effect.\n\n"
-            "### Code Targets\n"
-            "- h-main: modify `src/stub.py:42` to enable mechanism\n\n"
-            "### What I Tried That Didn't Work\n"
-            "- `--legacy-mode` flag does not exist despite docs mentioning it\n\n"
+            "- `src/stub.py:42` — mechanism toggle.\n\n"
             "### Warnings & Constraints\n"
-            "- First request always cold (cache empty) — use N>=50 for stable means\n"
+            "- First request always cold.\n"
         )
-        raw = f"{problem_md}\n---\n\n```yaml\n{bundle_yaml}```\n\n---\n\n{handoff_md}"
-        atomic_write(path, raw)
+        atomic_write(iter_dir / "problem.md", problem_md)
+        atomic_write(
+            iter_dir / "bundle.yaml",
+            yaml.safe_dump(bundle, default_flow_style=False, sort_keys=False),
+        )
+        atomic_write(iter_dir / "handoff_snapshot.md", handoff_md)
+        # Campaign-level handoff
+        campaign_dir = iter_dir.parent.parent
+        atomic_write(campaign_dir / "handoff.md", handoff_md)
+        # Write a log to output_path
+        atomic_write(path, "Stub designer: artifacts written directly to iter_dir.\n")
 
     def _write_execute_analyze(self, path: Path, iteration: int, h_main_result: str) -> None:
         """Write executor artifacts directly to iter_dir (mimics agent writing files)."""

--- a/orchestrator/dispatch.py
+++ b/orchestrator/dispatch.py
@@ -136,94 +136,109 @@ class StubDispatcher:
         atomic_write(path, raw)
 
     def _write_execute_analyze(self, path: Path, iteration: int, h_main_result: str) -> None:
-        """Write combined execute+analyze output: plan, findings, principle_updates."""
-        combined = {
-            "plan": {
-                "metadata": {
-                    "iteration": iteration,
-                    "bundle_ref": f"runs/iter-{iteration}/bundle.yaml",
-                },
-                "setup": [
-                    {"cmd": "echo 'stub build'", "description": "Stub setup"},
-                ],
-                "arms": [
-                    {
-                        "arm_id": "h-main",
-                        "conditions": [
-                            {
-                                "name": "baseline",
-                                "cmd": "echo '{\"latency_ms\": 50}'",
-                                "output": "results/h-main/baseline.json",
-                            },
-                            {
-                                "name": "treatment",
-                                "cmd": "echo '{\"latency_ms\": 40}'",
-                                "output": "results/h-main/treatment.json",
-                            },
-                        ],
-                    },
-                    {
-                        "arm_id": "h-control-negative",
-                        "conditions": [
-                            {
-                                "name": "control",
-                                "cmd": "echo '{\"latency_ms\": 50}'",
-                                "output": "results/h-control-negative/control.json",
-                            },
-                        ],
-                    },
-                ],
-            },
-            "findings": {
+        """Write executor artifacts directly to iter_dir (mimics agent writing files)."""
+        iter_dir = path.parent
+        iter_dir.mkdir(parents=True, exist_ok=True)
+
+        plan = {
+            "metadata": {
                 "iteration": iteration,
                 "bundle_ref": f"runs/iter-{iteration}/bundle.yaml",
-                "arms": [
-                    {
-                        "arm_type": "h-main",
-                        "predicted": ">10% improvement",
-                        "observed": "12.3% improvement"
-                        if h_main_result == "CONFIRMED"
-                        else "-2.1% regression",
-                        "status": h_main_result,
-                        "error_type": None
-                        if h_main_result == "CONFIRMED"
-                        else "direction",
-                        "diagnostic_note": None
-                        if h_main_result == "CONFIRMED"
-                        else "Mechanism does not hold",
-                    },
-                    {
-                        "arm_type": "h-control-negative",
-                        "predicted": "no effect at low load",
-                        "observed": "no significant effect",
-                        "status": "CONFIRMED",
-                        "error_type": None,
-                        "diagnostic_note": None,
-                    },
-                ],
-                "experiment_valid": True,
-                "discrepancy_analysis": "Stub analysis: all predictions within expected range."
-                if h_main_result == "CONFIRMED"
-                else "Stub analysis: H-main refuted, mechanism does not hold.",
             },
-            "principle_updates": [
+            "setup": [
+                {"cmd": "echo 'stub build'", "description": "Stub setup"},
+            ],
+            "arms": [
                 {
-                    "id": f"stub-principle-{iteration}",
-                    "statement": f"Stub principle extracted from iteration {iteration}",
-                    "confidence": "medium",
-                    "regime": "all",
-                    "evidence": [f"iteration-{iteration}-h-main"],
-                    "contradicts": [],
-                    "extraction_iteration": iteration,
-                    "mechanism": "Stub mechanism",
-                    "applicability_bounds": "stub",
-                    "superseded_by": None,
-                    "category": "domain",
-                    "status": "active",
+                    "arm_id": "h-main",
+                    "conditions": [
+                        {
+                            "name": "baseline",
+                            "cmd": "echo '{\"latency_ms\": 50}'",
+                            "output": "results/h-main/baseline.json",
+                        },
+                        {
+                            "name": "treatment",
+                            "cmd": "echo '{\"latency_ms\": 40}'",
+                            "output": "results/h-main/treatment.json",
+                        },
+                    ],
+                },
+                {
+                    "arm_id": "h-control-negative",
+                    "conditions": [
+                        {
+                            "name": "control",
+                            "cmd": "echo '{\"latency_ms\": 50}'",
+                            "output": "results/h-control-negative/control.json",
+                        },
+                    ],
                 },
             ],
         }
-        atomic_write(path, json.dumps(combined, indent=2) + "\n")
+        findings = {
+            "iteration": iteration,
+            "bundle_ref": f"runs/iter-{iteration}/bundle.yaml",
+            "arms": [
+                {
+                    "arm_type": "h-main",
+                    "predicted": ">10% improvement",
+                    "observed": "12.3% improvement"
+                    if h_main_result == "CONFIRMED"
+                    else "-2.1% regression",
+                    "status": h_main_result,
+                    "error_type": None
+                    if h_main_result == "CONFIRMED"
+                    else "direction",
+                    "diagnostic_note": None
+                    if h_main_result == "CONFIRMED"
+                    else "Mechanism does not hold",
+                },
+                {
+                    "arm_type": "h-control-negative",
+                    "predicted": "no effect at low load",
+                    "observed": "no significant effect",
+                    "status": "CONFIRMED",
+                    "error_type": None,
+                    "diagnostic_note": None,
+                },
+            ],
+            "experiment_valid": True,
+            "discrepancy_analysis": "Stub analysis: all predictions within expected range."
+            if h_main_result == "CONFIRMED"
+            else "Stub analysis: H-main refuted, mechanism does not hold.",
+        }
+        principle_updates = [
+            {
+                "id": f"stub-principle-{iteration}",
+                "statement": f"Stub principle extracted from iteration {iteration}",
+                "confidence": "medium",
+                "regime": "all",
+                "evidence": [f"iteration-{iteration}-h-main"],
+                "contradicts": [],
+                "extraction_iteration": iteration,
+                "mechanism": "Stub mechanism",
+                "applicability_bounds": "stub",
+                "superseded_by": None,
+                "category": "domain",
+                "status": "active",
+            },
+        ]
+
+        atomic_write(
+            iter_dir / "experiment_plan.yaml",
+            yaml.safe_dump(plan, default_flow_style=False, sort_keys=False),
+        )
+        atomic_write(
+            iter_dir / "findings.json",
+            json.dumps(findings, indent=2) + "\n",
+        )
+        atomic_write(
+            iter_dir / "principle_updates.json",
+            json.dumps(principle_updates, indent=2) + "\n",
+        )
+        # Write a log to the output_path (what the orchestrator captures)
+        atomic_write(path, "Stub executor: artifacts written directly to iter_dir.\n")
 
     def write_execution_results(self, path: Path, iteration: int) -> None:
         """Write stub execution results for integration tests."""

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -207,6 +207,9 @@ class LLMDispatcher:
 
         if phase == "design":
             ctx["research_question"] = self.campaign["research_question"]
+            iter_dir = self.work_dir / "runs" / f"iter-{iteration}"
+            ctx["iter_dir"] = str(iter_dir.resolve())
+            ctx["nous_dir"] = str(Path(__file__).resolve().parent.parent)
 
         if phase == "design":
             # Campaign-level handoff — the living document updated each iteration
@@ -296,6 +299,10 @@ class LLMDispatcher:
                 ctx["problem_md"] = problem_path.read_text()
             else:
                 ctx["problem_md"] = "No problem framing available."
+
+            iter_dir = self.work_dir / "runs" / f"iter-{iteration}"
+            ctx["iter_dir"] = str(iter_dir.resolve())
+            ctx["nous_dir"] = str(Path(__file__).resolve().parent.parent)
 
             # Campaign-level handoff — the living document
             handoff_path = self.work_dir / "handoff.md"

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -207,6 +207,9 @@ class LLMDispatcher:
 
         if phase == "design":
             ctx["research_question"] = self.campaign["research_question"]
+            iter_dir = self.work_dir / "runs" / f"iter-{iteration}"
+            ctx["iter_dir"] = str(iter_dir.resolve())
+            ctx["nous_dir"] = str(Path(__file__).resolve().parent.parent)
 
         if phase == "design":
             # Campaign-level handoff — the living document updated each iteration

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -207,9 +207,6 @@ class LLMDispatcher:
 
         if phase == "design":
             ctx["research_question"] = self.campaign["research_question"]
-            iter_dir = self.work_dir / "runs" / f"iter-{iteration}"
-            ctx["iter_dir"] = str(iter_dir.resolve())
-            ctx["nous_dir"] = str(Path(__file__).resolve().parent.parent)
 
         if phase == "design":
             # Campaign-level handoff — the living document updated each iteration

--- a/orchestrator/validate.py
+++ b/orchestrator/validate.py
@@ -137,8 +137,10 @@ def validate_execution(iter_dir: Path) -> dict:
                             errors.append(f"patches/{arm_type}.patch not found")
                         elif patch_file.stat().st_size == 0:
                             errors.append(f"patches/{arm_type}.patch is empty")
-        except (yaml.YAMLError, KeyError):
-            pass  # bundle issues already caught above or by design validation
+        except yaml.YAMLError:
+            pass  # bundle parse issues already caught by design validation
+        except KeyError as exc:
+            errors.append(f"bundle.yaml arm missing required field: {exc}")
 
     if errors:
         return {"status": "fail", "errors": errors}

--- a/orchestrator/validate.py
+++ b/orchestrator/validate.py
@@ -1,0 +1,172 @@
+"""Validation gates for Nous artifacts.
+
+Usage:
+    python -m orchestrator.validate design --dir runs/iter-1/
+    python -m orchestrator.validate execution --dir runs/iter-1/
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+
+
+def _load_yaml_schema(name: str) -> dict:
+    return yaml.safe_load((SCHEMAS_DIR / name).read_text())
+
+
+def _load_json_schema(name: str) -> dict:
+    return json.loads((SCHEMAS_DIR / name).read_text())
+
+
+def validate_design(iter_dir: Path) -> dict:
+    """Check design artifacts exist and conform to schemas."""
+    iter_dir = Path(iter_dir)
+    errors = []
+
+    # problem.md
+    problem_path = iter_dir / "problem.md"
+    if not problem_path.exists():
+        errors.append("problem.md not found")
+    elif problem_path.stat().st_size == 0:
+        errors.append("problem.md is empty")
+
+    # bundle.yaml
+    bundle_path = iter_dir / "bundle.yaml"
+    if not bundle_path.exists():
+        errors.append("bundle.yaml not found")
+    else:
+        try:
+            bundle = yaml.safe_load(bundle_path.read_text())
+            schema = _load_yaml_schema("bundle.schema.yaml")
+            jsonschema.validate(bundle, schema)
+        except yaml.YAMLError as exc:
+            errors.append(f"bundle.yaml is not valid YAML: {exc}")
+        except jsonschema.ValidationError as exc:
+            errors.append(f"bundle.yaml schema error: {exc.message}")
+
+    # handoff_snapshot.md
+    handoff_path = iter_dir / "handoff_snapshot.md"
+    if not handoff_path.exists():
+        errors.append("handoff_snapshot.md not found")
+    elif handoff_path.stat().st_size == 0:
+        errors.append("handoff_snapshot.md is empty")
+
+    if errors:
+        return {"status": "fail", "errors": errors}
+    return {"status": "pass"}
+
+
+def validate_execution(iter_dir: Path) -> dict:
+    """Check execution artifacts exist, conform to schemas, and patches are valid."""
+    iter_dir = Path(iter_dir)
+    errors = []
+
+    # experiment_plan.yaml
+    plan_path = iter_dir / "experiment_plan.yaml"
+    if not plan_path.exists():
+        errors.append("experiment_plan.yaml not found")
+    else:
+        try:
+            plan = yaml.safe_load(plan_path.read_text())
+            schema = _load_yaml_schema("experiment_plan.schema.yaml")
+            jsonschema.validate(plan, schema)
+        except yaml.YAMLError as exc:
+            errors.append(f"experiment_plan.yaml is not valid YAML: {exc}")
+        except jsonschema.ValidationError as exc:
+            errors.append(f"experiment_plan.yaml schema error: {exc.message}")
+
+    # findings.json
+    findings_path = iter_dir / "findings.json"
+    if not findings_path.exists():
+        errors.append("findings.json not found")
+    else:
+        try:
+            findings = json.loads(findings_path.read_text())
+            schema = _load_json_schema("findings.schema.json")
+            jsonschema.validate(findings, schema)
+        except json.JSONDecodeError as exc:
+            errors.append(f"findings.json is not valid JSON: {exc}")
+        except jsonschema.ValidationError as exc:
+            errors.append(f"findings.json schema error: {exc.message}")
+
+    # principle_updates.json
+    principles_path = iter_dir / "principle_updates.json"
+    if not principles_path.exists():
+        errors.append("principle_updates.json not found")
+    else:
+        try:
+            updates = json.loads(principles_path.read_text())
+            if not isinstance(updates, list):
+                errors.append(
+                    f"principle_updates.json should be a list, got {type(updates).__name__}"
+                )
+            else:
+                for i, entry in enumerate(updates):
+                    if not isinstance(entry, dict) or "id" not in entry:
+                        errors.append(
+                            f"principle_updates.json entry {i} missing 'id'"
+                        )
+        except json.JSONDecodeError as exc:
+            errors.append(f"principle_updates.json is not valid JSON: {exc}")
+
+    # patches — only required when bundle has code_changes
+    bundle_path = iter_dir / "bundle.yaml"
+    if bundle_path.exists():
+        try:
+            bundle = yaml.safe_load(bundle_path.read_text())
+            arms_with_code = [
+                arm for arm in bundle.get("arms", [])
+                if arm.get("code_changes")
+            ]
+            if arms_with_code:
+                patches_dir = iter_dir / "patches"
+                if not patches_dir.is_dir():
+                    errors.append(
+                        "patches/ directory not found but bundle has arms with code_changes"
+                    )
+                else:
+                    for arm in arms_with_code:
+                        arm_type = arm["type"]
+                        patch_file = patches_dir / f"{arm_type}.patch"
+                        if not patch_file.exists():
+                            errors.append(f"patches/{arm_type}.patch not found")
+                        elif patch_file.stat().st_size == 0:
+                            errors.append(f"patches/{arm_type}.patch is empty")
+        except (yaml.YAMLError, KeyError):
+            pass  # bundle issues already caught above or by design validation
+
+    if errors:
+        return {"status": "fail", "errors": errors}
+    return {"status": "pass"}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate Nous artifacts for a given phase.",
+    )
+    parser.add_argument(
+        "phase", choices=["design", "execution"],
+        help="Which phase to validate",
+    )
+    parser.add_argument(
+        "--dir", required=True, type=Path,
+        help="Path to the iteration directory (e.g., runs/iter-1/)",
+    )
+    args = parser.parse_args()
+
+    if args.phase == "design":
+        result = validate_design(args.dir)
+    else:
+        result = validate_execution(args.dir)
+
+    print(json.dumps(result, indent=2))
+    sys.exit(0 if result["status"] == "pass" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator/validate.py
+++ b/orchestrator/validate.py
@@ -114,6 +114,25 @@ def validate_execution(iter_dir: Path) -> dict:
         except json.JSONDecodeError as exc:
             errors.append(f"principle_updates.json is not valid JSON: {exc}")
 
+    # output files — check that files referenced in plan conditions exist
+    if plan_path.exists() and not errors:
+        try:
+            plan = yaml.safe_load(plan_path.read_text())
+            for arm in plan.get("arms", []):
+                for cond in arm.get("conditions", []):
+                    output = cond.get("output")
+                    if output:
+                        output_file = Path(output)
+                        if not output_file.is_absolute():
+                            output_file = iter_dir / output
+                        if not output_file.exists():
+                            errors.append(
+                                f"output file {cond['output']} referenced in "
+                                f"{arm['arm_id']}/{cond['name']} not found"
+                            )
+        except (yaml.YAMLError, KeyError):
+            pass  # plan parse issues already caught above
+
     # patches — only required when bundle has code_changes
     bundle_path = iter_dir / "bundle.yaml"
     if bundle_path.exists():

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -2,6 +2,12 @@ You are a scientific planner for the Nous hypothesis-driven experimentation fram
 
 Your task is to **explore the target system, frame the problem, and design a hypothesis bundle** — all in one pass. You have full code access and shell tools. Use them.
 
+## Artifact Directory
+
+Write all artifacts to: `{{iter_dir}}`
+
+The Nous project is at: `{{nous_dir}}`
+
 ## Target System
 
 - **Name:** {{target_system}}
@@ -148,15 +154,15 @@ Now design a hypothesis bundle based on what you actually observed and verified:
 - **No `sed`/`awk` for code changes.** When describing code modifications in problem framing or bundle arms, describe the *intent* (what to change and why). The executor agent will implement changes properly via file edits, verify they compile, and create reusable `git diff` patches. Never suggest inline shell regex as an implementation strategy.
 - **Worktree isolation assumed.** The executor runs in a clean git worktree. Each condition starts from clean state (`git checkout -- .` runs between conditions). Design your experimental conditions assuming this — don't include manual cleanup steps.
 
-## Output Format
+## Output — Write Files Directly
 
-Output the problem framing markdown FIRST, then a `---` separator, then the hypothesis bundle as YAML in a code fence, then a `---` separator, then the executor handoff.
+Write three files to `{{iter_dir}}`:
 
-Structure your response as:
+### Step 1: Write problem.md
+Write your problem framing to `{{iter_dir}}/problem.md`. Include: Research Question, System Interface, Baseline Command, Baseline Validation, Experimental Conditions, Success Criteria, Constraints, Prior Knowledge.
 
-[problem framing markdown here]
-
----
+### Step 2: Write bundle.yaml
+Write your hypothesis bundle to `{{iter_dir}}/bundle.yaml`:
 
 ```yaml
 metadata:
@@ -173,6 +179,21 @@ arms:
         intent: "Plain-English description of the change"
         rationale: "Why this change tests the hypothesis"
 ```
+
+### Step 3: Write handoff_snapshot.md
+Write the handoff (see Handoff section below) to `{{iter_dir}}/handoff_snapshot.md`.
+Also write a copy to `{{iter_dir}}/../../handoff.md` (the campaign-level living document).
+
+### Step 4: Validate
+Run:
+```bash
+python {{nous_dir}}/orchestrator/validate.py design --dir {{iter_dir}}
+```
+
+- If it returns `{"status": "pass"}` — you are done. Output a brief summary.
+- If it returns `{"status": "fail", "errors": [...]}` — read the errors, fix the files, and run validation again. Repeat until it passes.
+
+**You are NOT done until validation passes.**
 
 ---
 

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -83,7 +83,7 @@ Before designing anything, ground yourself in the real system:
 
 4. **Run to learn** — execute quick commands to observe current behavior. Run a short baseline to check output format, validate that commands work, and probe system capacity or behavior bounds. For example, if your experiment depends on a capacity threshold, measure it now with a quick probe rather than guessing.
 
-5. **Ground claims in code with `file:line`** — for each flag or mechanism relevant to your experiment, cite the exact source location as `file/path.ext:line_number`. Example: "Rejection threshold checked at `sim/admission.go:264`". Do not describe behavior without a file:line reference.
+5. **Ground claims in code with `file:line`** — for each flag or mechanism relevant to your experiment, cite the exact source location as `file/path.ext:line_number`. Do not describe behavior without a file:line reference.
 
 6. **Identify key source files** — find the files implementing the mechanism under study.
 
@@ -244,10 +244,10 @@ Example: `sim/cache.go:126` — GetCachedBlocks hash lookup. Check here if cache
 [Commands that failed, flags that don't exist, parameter ranges that produced null results, paths that looked promising but weren't. This prevents the next agent from repeating your dead ends.]
 
 ### What I Excluded and Why
-[Areas you explored but deliberately left out of the experiment. Example: "Looked at multi-instance routing but excluded because the research question focuses on single-instance KV cache behavior." This helps the next iteration's designer decide where to expand.]
+[Areas you explored but deliberately left out of the experiment, and why. This helps the next iteration's designer decide where to expand.]
 
 ### Evolution of Thinking
-[How your understanding shifted during exploration. Example: "Initially assumed preemption was the bottleneck, but probes showed scheduling delay < 1ms — the real bottleneck is prefill compute." This prevents the next designer from starting with the same wrong assumption.]
+[How your understanding shifted during exploration. This prevents the next designer from starting with the same wrong assumption.]
 
 ### Current Status
 - **Validated:** [what's confirmed and working]

--- a/prompts/methodology/execute_analyze.md
+++ b/prompts/methodology/execute_analyze.md
@@ -81,21 +81,23 @@ metadata:
   iteration: 1
   bundle_ref: "runs/iter-1/bundle.yaml"
 setup:
-  - cmd: "go build -o blis main.go"
+  - cmd: "<build command from handoff>"
     description: "Build the system"
 arms:
   - arm_id: "h-main"
     conditions:
       - name: "baseline-seed42"
-        cmd: "./blis run --seed 42 --prefix-tokens 0 --metrics-path results/h-main/baseline-s42.json"
-        output: "results/h-main/baseline-s42.json"
+        cmd: "<baseline command with --seed 42 --output {{iter_dir}}/results/h-main/baseline-s42.json>"
+        output: "{{iter_dir}}/results/h-main/baseline-s42.json"
       - name: "treatment-seed42"
-        cmd: "git apply patches/h-main.patch && go build -o blis main.go && ./blis run --seed 42 --metrics-path results/h-main/treatment-s42.json"
-        output: "results/h-main/treatment-s42.json"
+        cmd: "git apply {{iter_dir}}/patches/h-main.patch && <build> && <run with --output {{iter_dir}}/results/h-main/treatment-s42.json>"
+        output: "{{iter_dir}}/results/h-main/treatment-s42.json"
 ```
 
+**Important:** All output paths MUST use absolute paths under `{{iter_dir}}/results/`. Do NOT use relative paths — the experiment runs in a worktree that gets cleaned up.
+
 ### Step 5: Create output directories
-For every output path in your plan, ensure the parent directory exists.
+For every output path in your plan, ensure the parent directory exists (`mkdir -p {{iter_dir}}/results/<arm_id>`).
 
 ## Phase 2: Execute
 
@@ -127,8 +129,8 @@ Write findings to `{{iter_dir}}/findings.json`:
   "arms": [
     {
       "arm_type": "h-main",
-      "predicted": "Increasing prefix fraction reduces TTFT by >20%",
-      "observed": "TTFT reduced by 43.5% (26.59ms → 15.03ms)",
+      "predicted": "<your directional prediction from the bundle>",
+      "observed": "<actual metric values from your runs>",
       "status": "CONFIRMED",
       "error_type": null,
       "diagnostic_note": null
@@ -153,14 +155,14 @@ Based on your findings, identify principle updates and write to `{{iter_dir}}/pr
 [
   {
     "id": "RP-1",
-    "statement": "Prefix caching reduces TTFT linearly with cache fraction",
+    "statement": "<concise principle discovered from this experiment>",
     "confidence": "high",
-    "regime": "single-instance, roofline model, rate=15",
+    "regime": "<conditions under which this holds>",
     "evidence": ["iteration-1-h-main"],
     "contradicts": [],
     "extraction_iteration": 1,
-    "mechanism": "Cached prefix blocks reduce NumNewPrefillTokens in FormBatch",
-    "applicability_bounds": "Applies when N_new > 128 tokens",
+    "mechanism": "<causal explanation grounded in code>",
+    "applicability_bounds": "<when this applies and when it doesn't>",
     "superseded_by": null,
     "category": "domain",
     "status": "active"

--- a/prompts/methodology/execute_analyze.md
+++ b/prompts/methodology/execute_analyze.md
@@ -99,15 +99,18 @@ arms:
 ### Step 5: Create output directories
 For every output path in your plan, ensure the parent directory exists (`mkdir -p {{iter_dir}}/results/<arm_id>`).
 
-## Phase 2: Execute
+## Phase 2: Execute the plan
 
-Run ALL conditions for ALL arms across ALL seeds. For each condition:
+Run the experiment plan you wrote in Step 4 — execute every command exactly as written. The plan is the source of truth.
+
+For each condition:
 1. Reset worktree: `git checkout -- .`
-2. For treatment: `git apply {{iter_dir}}/patches/<arm_type>.patch && <build> && <run>`
-3. For baseline: just `<run>`
-4. Record stdout metrics for each run.
+2. Run the `cmd` from the plan
+3. Verify the `output` file was created at the expected path
 
 After each baseline+treatment pair with the same seed, compare key metrics. If they are byte-identical, STOP and investigate — the patch may not be affecting the code path.
+
+**All results must land in `{{iter_dir}}/results/`.** The worktree is temporary — anything written there will be lost.
 
 ## Phase 3: Analyze and Write Findings
 

--- a/prompts/methodology/execute_analyze.md
+++ b/prompts/methodology/execute_analyze.md
@@ -2,13 +2,14 @@ You are a scientific executor for the Nous hypothesis-driven experimentation fra
 
 You have **shell access**. You are running inside an isolated git worktree of the target system. You own this worktree — reset it yourself with `git checkout -- .` between conditions.
 
-Your job has FOUR phases — all in one session with full context:
+Your job has FIVE phases — all in one session with full context:
 1. **Prepare** — build, create patches, validate ALL commands
 2. **Execute** — run all conditions across seeds, capture results
-3. **Analyze** — compare results to predictions, produce findings
-4. **Extract** — identify principle updates from findings
+3. **Analyze** — compare results to predictions, write findings
+4. **Extract** — identify principle updates
+5. **Validate** — run `nous validate` to confirm all artifacts are correct
 
-You have {{max_turns}} turns. Use them. Do NOT emit output until you have run all commands and analyzed results.
+You have {{max_turns}} turns. Use them.
 
 ## Target System
 
@@ -37,7 +38,15 @@ This is iteration {{iteration}}.
 
 ## Designer Handoff
 
+The designer already explored the system and provided the context below. Use it — only explore further when you hit something the handoff doesn't cover.
+
 {{design_handoff}}
+
+## Artifact Directory
+
+Write all artifacts to: `{{iter_dir}}`
+
+The Nous project is at: `{{nous_dir}}`
 
 ## Pre-gathered Repo Context
 
@@ -48,37 +57,57 @@ This is iteration {{iteration}}.
 ## Phase 1: Prepare
 
 ### Step 1: Build the system
-Run the build command. Verify it succeeds.
+Use the build command from the designer handoff. Verify it succeeds.
 
 ### Step 2: Validate the baseline command
-Run the baseline command with reduced scale. Verify it exits 0 and produces output with expected metric fields. Fix until it works.
+Run the baseline command from the handoff with reduced scale. Verify it exits 0 and produces output with expected metric fields. Fix until it works.
 
 ### Step 3: Create patches for code-change arms
 For each arm with `code_changes` in the bundle:
 1. Edit the file — make the change described in `intent`. Use file editing tools, NOT `sed`/`awk`.
 2. Build — verify it compiles.
 3. Smoke-test — run treatment command once. Verify it exits 0.
-4. Save patch — `mkdir -p patches && git diff > patches/<arm_id>.patch`
+4. Save patch — `mkdir -p {{iter_dir}}/patches && git diff > {{iter_dir}}/patches/<arm_type>.patch`
 5. Reset — `git checkout -- .`
-6. Verify — `git apply --check patches/<arm_id>.patch`
+6. Verify — `git apply --check {{iter_dir}}/patches/<arm_type>.patch`
 
-### Step 4: Create output directories
-For every `--metrics-path` or `--output` path in your commands, ensure the parent directory exists. Add `mkdir -p results/<arm_id>` to your setup commands.
+If the bundle has NO `code_changes` (observe mode), skip this step entirely.
 
-### Step 5: Validate data files
-If the experiment needs workload specs or configs, read an existing example first, then create and validate.
+### Step 4: Write experiment_plan.yaml
+Write the experiment plan to `{{iter_dir}}/experiment_plan.yaml`. This must contain every command you will run, so someone can replay the entire experiment from this file alone.
+
+```yaml
+metadata:
+  iteration: 1
+  bundle_ref: "runs/iter-1/bundle.yaml"
+setup:
+  - cmd: "go build -o blis main.go"
+    description: "Build the system"
+arms:
+  - arm_id: "h-main"
+    conditions:
+      - name: "baseline-seed42"
+        cmd: "./blis run --seed 42 --prefix-tokens 0 --metrics-path results/h-main/baseline-s42.json"
+        output: "results/h-main/baseline-s42.json"
+      - name: "treatment-seed42"
+        cmd: "git apply patches/h-main.patch && go build -o blis main.go && ./blis run --seed 42 --metrics-path results/h-main/treatment-s42.json"
+        output: "results/h-main/treatment-s42.json"
+```
+
+### Step 5: Create output directories
+For every output path in your plan, ensure the parent directory exists.
 
 ## Phase 2: Execute
 
 Run ALL conditions for ALL arms across ALL seeds. For each condition:
 1. Reset worktree: `git checkout -- .`
-2. For treatment: `git apply patches/<arm_id>.patch && <build> && <run>`
+2. For treatment: `git apply {{iter_dir}}/patches/<arm_type>.patch && <build> && <run>`
 3. For baseline: just `<run>`
 4. Record stdout metrics for each run.
 
 After each baseline+treatment pair with the same seed, compare key metrics. If they are byte-identical, STOP and investigate — the patch may not be affecting the code path.
 
-## Phase 3: Analyze
+## Phase 3: Analyze and Write Findings
 
 Compare the predictions in the hypothesis bundle against the metrics you observed.
 
@@ -87,91 +116,69 @@ For each arm, determine:
 - **REFUTED** — the direction is wrong, or the mechanism does not engage at all.
 - **PARTIALLY_CONFIRMED** — evidence is mixed across seeds.
 
-A hypothesis is CONFIRMED if the directional effect is consistent, even if magnitude is smaller than expected. Magnitude differences are findings to report, not grounds for REFUTED.
+A hypothesis is CONFIRMED if the directional effect is consistent, even if magnitude is smaller than expected.
 
-## Phase 4: Extract Principles
-
-Based on your findings, identify principle updates:
-- New principles discovered (domain or meta)
-- Existing principles that need confidence updates
-- Principles that are now contradicted or superseded
-
-Each principle needs: id, statement, confidence (low/medium/high), regime, evidence, mechanism, applicability_bounds, category (domain/meta), status (active/updated/pruned).
-
----
-
-## Output Format
-
-Output a single JSON code fence containing all three artifacts:
+Write findings to `{{iter_dir}}/findings.json`:
 
 ```json
 {
-  "plan": {
-    "metadata": {
-      "iteration": 1,
-      "bundle_ref": "runs/iter-1/bundle.yaml"
-    },
-    "setup": [
-      {"cmd": "...", "description": "..."}
-    ],
-    "arms": [
-      {
-        "arm_id": "h-main",
-        "conditions": [
-          {"name": "baseline-seed42", "cmd": "...", "output": "..."},
-          {"name": "treatment-seed42", "cmd": "...", "output": "..."}
-        ]
-      }
-    ]
-  },
-  "findings": {
-    "iteration": 1,
-    "bundle_ref": "runs/iter-1/bundle.yaml",
-    "arms": [
-      {
-        "arm_type": "h-main",
-        "predicted": "...",
-        "observed": "... (cite specific numbers from your runs)",
-        "status": "CONFIRMED",
-        "error_type": null,
-        "diagnostic_note": "..."
-      }
-    ],
-    "experiment_valid": true,
-    "discrepancy_analysis": "...",
-    "dominant_component_pct": null
-  },
-  "principle_updates": [
+  "iteration": 1,
+  "bundle_ref": "runs/iter-1/bundle.yaml",
+  "arms": [
     {
-      "id": "RP-1",
-      "statement": "...",
-      "confidence": "high",
-      "regime": "...",
-      "evidence": ["iteration-1-h-main"],
-      "contradicts": [],
-      "extraction_iteration": 1,
-      "mechanism": "...",
-      "applicability_bounds": "...",
-      "superseded_by": null,
-      "category": "domain",
-      "status": "active"
+      "arm_type": "h-main",
+      "predicted": "Increasing prefix fraction reduces TTFT by >20%",
+      "observed": "TTFT reduced by 43.5% (26.59ms → 15.03ms)",
+      "status": "CONFIRMED",
+      "error_type": null,
+      "diagnostic_note": null
     }
-  ]
+  ],
+  "experiment_valid": true,
+  "discrepancy_analysis": "All predictions confirmed within expected range.",
+  "dominant_component_pct": null
 }
 ```
-
-**Rules for the plan section:**
-- Every command must be something you already ran successfully.
-- Do NOT redirect stdout/stderr. Use the system's native output flag.
-- Treatment conditions: `git apply patches/<arm_id>.patch && <build> && <run>`
-- Baseline conditions: just `<run>` on clean code.
-- Emit `cmd` values as strings (not YAML block scalars — this is JSON).
 
 **Rules for findings:**
 - `error_type`: one of `direction`, `magnitude`, `regime`, or `null`.
 - `experiment_valid`: false ONLY if h-main setup was misconfigured.
 - Cite specific metric values from your runs in `observed`.
 
-Output ONLY the JSON code fence. Do not include explanation outside the fence.
+## Phase 4: Extract Principles
+
+Based on your findings, identify principle updates and write to `{{iter_dir}}/principle_updates.json`:
+
+```json
+[
+  {
+    "id": "RP-1",
+    "statement": "Prefix caching reduces TTFT linearly with cache fraction",
+    "confidence": "high",
+    "regime": "single-instance, roofline model, rate=15",
+    "evidence": ["iteration-1-h-main"],
+    "contradicts": [],
+    "extraction_iteration": 1,
+    "mechanism": "Cached prefix blocks reduce NumNewPrefillTokens in FormBatch",
+    "applicability_bounds": "Applies when N_new > 128 tokens",
+    "superseded_by": null,
+    "category": "domain",
+    "status": "active"
+  }
+]
+```
+
+## Phase 5: Validate
+
+Run the validation command to confirm all artifacts are correct:
+
+```bash
+python {{nous_dir}}/orchestrator/validate.py execution --dir {{iter_dir}}
+```
+
+- If it returns `{"status": "pass"}` — you are done. Output a brief summary of your findings.
+- If it returns `{"status": "fail", "errors": [...]}` — read the errors, fix the artifacts, and run validation again. Repeat until it passes.
+
+**You are NOT done until validation passes.**
 
 {{human_feedback}}

--- a/run_campaign.py
+++ b/run_campaign.py
@@ -310,7 +310,8 @@ def main() -> None:
         max_iter = campaign.get("max_iterations", 10)
 
     run_id = args.run_id or campaign.get("run_id") or campaign_path.parent.name + "-run"
-    work_dir = setup_work_dir(run_id)
+    repo_path = campaign.get("target_system", {}).get("repo_path")
+    work_dir = setup_work_dir(run_id, repo_path=repo_path)
     print(f"Working directory: {work_dir.resolve()}")
     print(f"Max iterations: {max_iter}")
 

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -423,9 +423,10 @@ def run_iteration(
         if result["status"] == "pass":
             print("  Validation passed.")
         else:
-            for err in result["errors"]:
-                print(f"  [!] {err}")
-            print("  Validation completed with warnings.")
+            raise RuntimeError(
+                f"Post-check validation failed:\n"
+                + "\n".join(f"  - {e}" for e in result["errors"])
+            )
 
     # Validate findings and check fast-fail rules
     findings_path = iter_dir / "findings.json"
@@ -531,7 +532,8 @@ def main() -> None:
         sys.exit(1)
 
     run_id = args.run_id or campaign.get("run_id") or campaign_path.parent.name + "-run"
-    work_dir = setup_work_dir(run_id)
+    repo_path = campaign.get("target_system", {}).get("repo_path")
+    work_dir = setup_work_dir(run_id, repo_path=repo_path)
     print(f"Working directory: {work_dir.resolve()}")
 
     run_iteration(

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -347,20 +347,15 @@ def run_iteration(
                 )
                 (iter_dir / ".experiment_id").write_text(experiment_id)
                 print(f"  Experiment worktree: {experiment_dir}")
-            if cli_dispatcher and experiment_dir:
-                # CLI path: agent writes files directly to iter_dir
-                with cli_dispatcher.override_cwd(experiment_dir):
+            if cli_dispatcher:
+                import contextlib
+                ctx = cli_dispatcher.override_cwd(experiment_dir) if experiment_dir else contextlib.nullcontext()
+                with ctx:
                     exec_dispatcher.dispatch(
                         "executor", "execute-analyze",
                         output_path=iter_dir / "executor_log.md",
                         iteration=iteration,
                     )
-            elif cli_dispatcher:
-                exec_dispatcher.dispatch(
-                    "executor", "execute-analyze",
-                    output_path=iter_dir / "executor_log.md",
-                    iteration=iteration,
-                )
             else:
                 # LLM API path or stub: dispatch and check if files were written directly
                 output_file = iter_dir / "execute_analyze_output.json"
@@ -405,28 +400,33 @@ def run_iteration(
             raise
 
     # ─── VALIDATE ─────────────────────────────────────────────────────────
+    # This re-runs validation for the resume-from-checkpoint path.
+    # In normal flow, EXECUTE_ANALYZE already validated.
     if _enter_phase(engine, "VALIDATE"):
         print(f"\n{'='*60}")
         print(f"  VALIDATE — post-check artifact validation")
         print(f"{'='*60}")
-        # Clean up experiment worktree if it exists
+        # Recover worktree reference on resume
         if not experiment_dir and repo_path:
             eid_path = iter_dir / ".experiment_id"
             if eid_path.exists():
                 experiment_id = eid_path.read_text().strip()
-        if repo_path and experiment_id:
-            from orchestrator.worktree import remove_experiment_worktree
-            remove_experiment_worktree(Path(repo_path), experiment_id)
 
-        from orchestrator.validate import validate_execution
-        result = validate_execution(iter_dir)
-        if result["status"] == "pass":
-            print("  Validation passed.")
-        else:
-            raise RuntimeError(
-                f"Post-check validation failed:\n"
-                + "\n".join(f"  - {e}" for e in result["errors"])
-            )
+        # Validate first, then clean up worktree (so it's available for debugging on failure)
+        try:
+            from orchestrator.validate import validate_execution
+            result = validate_execution(iter_dir)
+            if result["status"] == "pass":
+                print("  Validation passed.")
+            else:
+                raise RuntimeError(
+                    f"Post-check validation failed:\n"
+                    + "\n".join(f"  - {e}" for e in result["errors"])
+                )
+        finally:
+            if repo_path and experiment_id:
+                from orchestrator.worktree import remove_experiment_worktree
+                remove_experiment_worktree(Path(repo_path), experiment_id)
 
     # Validate findings and check fast-fail rules
     findings_path = iter_dir / "findings.json"

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -288,16 +288,26 @@ def run_iteration(
         print(f"  DESIGN — exploring system and creating hypothesis bundle")
         print(f"{'='*60}")
         design_dispatcher = cli_dispatcher or llm_dispatcher
-        design_dispatcher.dispatch(
-            "planner", "design",
-            output_path=iter_dir / "design_raw.md", iteration=iteration,
-        )
-        raw_response = (iter_dir / "design_raw.md").read_text()
-        _split_design_output(raw_response, iter_dir)
-        (iter_dir / "design_raw.md").unlink()
-        print(f"  -> {iter_dir / 'problem.md'}")
-        print(f"  -> {iter_dir / 'bundle.yaml'}")
-        # Post-check design artifacts
+        if cli_dispatcher:
+            # CLI path: agent writes files directly to iter_dir
+            design_dispatcher.dispatch(
+                "planner", "design",
+                output_path=iter_dir / "design_log.md", iteration=iteration,
+            )
+        else:
+            # LLM API path or stub: dispatch and check if files were written directly
+            output_file = iter_dir / "design_raw.md"
+            design_dispatcher.dispatch(
+                "planner", "design",
+                output_path=output_file, iteration=iteration,
+            )
+            # If the dispatcher wrote individual files (StubDispatcher),
+            # skip the text split. Otherwise parse the merged output.
+            if not (iter_dir / "bundle.yaml").exists():
+                raw_response = output_file.read_text()
+                _split_design_output(raw_response, iter_dir)
+                output_file.unlink()
+        # Validate design artifacts regardless of dispatch path
         from orchestrator.validate import validate_design
         result = validate_design(iter_dir)
         if result["status"] == "fail":
@@ -305,6 +315,8 @@ def run_iteration(
                 f"Design artifacts failed validation:\n"
                 + "\n".join(f"  - {e}" for e in result["errors"])
             )
+        print(f"  -> {iter_dir / 'problem.md'}")
+        print(f"  -> {iter_dir / 'bundle.yaml'}")
 
     # ─── HUMAN DESIGN GATE ────────────────────────────────────────────────
     if _enter_phase(engine, "HUMAN_DESIGN_GATE"):

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -183,10 +183,18 @@ def _merge_principles(work_dir: Path, iter_dir: Path) -> None:
     atomic_write(principles_path, json.dumps(store, indent=2) + "\n")
 
 
-def setup_work_dir(run_id: str) -> Path:
-    """Create and initialize a working directory from templates."""
-    work_dir = Path(run_id)
-    work_dir.mkdir(exist_ok=True)
+def setup_work_dir(run_id: str, repo_path: str | None = None) -> Path:
+    """Create and initialize a working directory from templates.
+
+    If repo_path is provided, the campaign directory is created inside
+    the target repo at .nous/<run_id>/. Otherwise falls back to creating
+    <run_id>/ in the current directory.
+    """
+    if repo_path:
+        work_dir = Path(repo_path) / ".nous" / run_id
+    else:
+        work_dir = Path(run_id)
+    work_dir.mkdir(parents=True, exist_ok=True)
     for t in ["state.json", "ledger.json", "principles.json"]:
         dest = work_dir / t
         if not dest.exists():
@@ -289,6 +297,14 @@ def run_iteration(
         (iter_dir / "design_raw.md").unlink()
         print(f"  -> {iter_dir / 'problem.md'}")
         print(f"  -> {iter_dir / 'bundle.yaml'}")
+        # Post-check design artifacts
+        from orchestrator.validate import validate_design
+        result = validate_design(iter_dir)
+        if result["status"] == "fail":
+            raise RuntimeError(
+                f"Design artifacts failed validation:\n"
+                + "\n".join(f"  - {e}" for e in result["errors"])
+            )
 
     # ─── HUMAN DESIGN GATE ────────────────────────────────────────────────
     if _enter_phase(engine, "HUMAN_DESIGN_GATE"):
@@ -331,43 +347,57 @@ def run_iteration(
                 )
                 (iter_dir / ".experiment_id").write_text(experiment_id)
                 print(f"  Experiment worktree: {experiment_dir}")
-            if experiment_dir and cli_dispatcher:
+            if cli_dispatcher and experiment_dir:
+                # CLI path: agent writes files directly to iter_dir
                 with cli_dispatcher.override_cwd(experiment_dir):
                     exec_dispatcher.dispatch(
                         "executor", "execute-analyze",
-                        output_path=iter_dir / "execute_analyze_output.json",
+                        output_path=iter_dir / "executor_log.md",
                         iteration=iteration,
                     )
-            else:
+            elif cli_dispatcher:
                 exec_dispatcher.dispatch(
                     "executor", "execute-analyze",
-                    output_path=iter_dir / "execute_analyze_output.json",
+                    output_path=iter_dir / "executor_log.md",
                     iteration=iteration,
                 )
-            # Split combined output into separate artifacts
-            combined = json.loads((iter_dir / "execute_analyze_output.json").read_text())
-            missing = {"plan", "findings", "principle_updates"} - set(combined.keys())
-            if missing:
-                raise RuntimeError(
-                    f"execute-analyze agent output missing keys: {sorted(missing)}. "
-                    f"Got: {sorted(combined.keys())}. See {iter_dir / 'execute_analyze_output.json'}"
+            else:
+                # LLM API path or stub: dispatch and check if files were written directly
+                output_file = iter_dir / "execute_analyze_output.json"
+                exec_dispatcher.dispatch(
+                    "executor", "execute-analyze",
+                    output_path=output_file,
+                    iteration=iteration,
                 )
-            plan_data = combined["plan"]
-            atomic_write(
-                iter_dir / "experiment_plan.yaml",
-                yaml.safe_dump(plan_data, default_flow_style=False, sort_keys=False),
-            )
-            atomic_write(
-                iter_dir / "findings.json",
-                json.dumps(combined["findings"], indent=2) + "\n",
-            )
-            atomic_write(
-                iter_dir / "principle_updates.json",
-                json.dumps(combined["principle_updates"], indent=2) + "\n",
-            )
-            print(f"  -> {iter_dir / 'experiment_plan.yaml'}")
-            print(f"  -> {iter_dir / 'findings.json'}")
-            print(f"  -> {iter_dir / 'principle_updates.json'}")
+                # If the dispatcher wrote individual files (StubDispatcher),
+                # skip the JSON split. Otherwise parse the combined blob.
+                if not (iter_dir / "findings.json").exists():
+                    combined = json.loads(output_file.read_text())
+                    missing = {"plan", "findings", "principle_updates"} - set(combined.keys())
+                    if missing:
+                        raise RuntimeError(
+                            f"execute-analyze output missing keys: {sorted(missing)}"
+                        )
+                    atomic_write(
+                        iter_dir / "experiment_plan.yaml",
+                        yaml.safe_dump(combined["plan"], default_flow_style=False, sort_keys=False),
+                    )
+                    atomic_write(
+                        iter_dir / "findings.json",
+                        json.dumps(combined["findings"], indent=2) + "\n",
+                    )
+                    atomic_write(
+                        iter_dir / "principle_updates.json",
+                        json.dumps(combined["principle_updates"], indent=2) + "\n",
+                    )
+            # Validate artifacts regardless of dispatch path
+            from orchestrator.validate import validate_execution
+            result = validate_execution(iter_dir)
+            if result["status"] == "fail":
+                raise RuntimeError(
+                    f"Executor artifacts failed validation:\n"
+                    + "\n".join(f"  - {e}" for e in result["errors"])
+                )
         except BaseException:
             if repo_path and experiment_id:
                 from orchestrator.worktree import remove_experiment_worktree
@@ -377,29 +407,25 @@ def run_iteration(
     # ─── VALIDATE ─────────────────────────────────────────────────────────
     if _enter_phase(engine, "VALIDATE"):
         print(f"\n{'='*60}")
-        print(f"  VALIDATE — replaying plan for reproducibility")
+        print(f"  VALIDATE — post-check artifact validation")
         print(f"{'='*60}")
-        # Recover worktree reference on resume
+        # Clean up experiment worktree if it exists
         if not experiment_dir and repo_path:
             eid_path = iter_dir / ".experiment_id"
             if eid_path.exists():
                 experiment_id = eid_path.read_text().strip()
-                experiment_dir = Path(repo_path) / ".nous-experiments" / experiment_id
+        if repo_path and experiment_id:
+            from orchestrator.worktree import remove_experiment_worktree
+            remove_experiment_worktree(Path(repo_path), experiment_id)
 
-        try:
-            from orchestrator.executor import execute_plan
-            plan = yaml.safe_load((iter_dir / "experiment_plan.yaml").read_text())
-            execute_plan(
-                plan,
-                cwd=experiment_dir or Path(repo_path) if repo_path else iter_dir,
-                iter_dir=iter_dir,
-                reset_cmd="git checkout -- ." if experiment_dir else None,
-            )
-            print(f"  -> {iter_dir / 'execution_results.json'}")
-        finally:
-            if repo_path and experiment_id:
-                from orchestrator.worktree import remove_experiment_worktree
-                remove_experiment_worktree(Path(repo_path), experiment_id)
+        from orchestrator.validate import validate_execution
+        result = validate_execution(iter_dir)
+        if result["status"] == "pass":
+            print("  Validation passed.")
+        else:
+            for err in result["errors"]:
+                print(f"  [!] {err}")
+            print("  Validation completed with warnings.")
 
     # Validate findings and check fast-fail rules
     findings_path = iter_dir / "findings.json"

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -141,31 +141,12 @@ class TestCLIDispatcherUnit:
         assert "Experiment Design" in content
         assert "Research Question" in content
 
-    def test_dispatch_executor_execute_analyze_produces_valid_output(self, work_dir: Path, campaign: dict) -> None:
+    def test_dispatch_executor_execute_analyze_saves_raw_output(self, work_dir: Path, campaign: dict) -> None:
         from orchestrator.cli_dispatch import CLIDispatcher
 
-        valid_json = json.dumps({
-            "plan": {
-                "metadata": {"iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml"},
-                "arms": [{"arm_id": "h-main", "conditions": [{"name": "baseline", "cmd": "echo baseline"}]}],
-            },
-            "findings": {
-                "iteration": 1,
-                "bundle_ref": "runs/iter-1/bundle.yaml",
-                "arms": [{"arm_type": "h-main", "predicted": "lower latency", "observed": "10ms reduction", "status": "CONFIRMED", "error_type": None, "diagnostic_note": None}],
-                "experiment_valid": True,
-                "discrepancy_analysis": "None.",
-            },
-            "principle_updates": [{
-                "id": "RP-1", "statement": "Test principle", "confidence": "medium",
-                "regime": "all", "evidence": ["iteration-1-h-main"], "contradicts": [],
-                "extraction_iteration": 1, "mechanism": "test", "applicability_bounds": "test",
-                "superseded_by": None, "category": "domain", "status": "active",
-            }],
-        })
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stdout = f"```json\n{valid_json}\n```\n"
+        mock_result.stdout = "All experiments completed. Artifacts written to iter_dir."
         mock_result.stderr = ""
 
         # Create bundle.yaml (required by context builder)
@@ -174,14 +155,11 @@ class TestCLIDispatcherUnit:
 
         with patch("orchestrator.cli_dispatch.subprocess.run", return_value=mock_result):
             d = CLIDispatcher(work_dir=work_dir, campaign=campaign)
-            out = work_dir / "runs" / "iter-1" / "execute_analyze_output.json"
+            out = work_dir / "runs" / "iter-1" / "executor_log.md"
             d.dispatch("executor", "execute-analyze", output_path=out, iteration=1)
 
         assert out.exists()
-        data = json.loads(out.read_text())
-        assert "plan" in data
-        assert "findings" in data
-        assert "principle_updates" in data
+        assert "Artifacts written" in out.read_text()
 
     def test_dispatch_planner_design_writes_response_text(self, work_dir: Path, campaign: dict) -> None:
         from orchestrator.cli_dispatch import CLIDispatcher

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -50,33 +50,33 @@ class TestStubDispatcher:
         bundle = yaml.safe_load(match.group(1))
         jsonschema.validate(bundle, _load_schema("bundle.schema.yaml"))
 
-    def test_dispatch_executor_execute_analyze_produces_valid_output(self, work_dir):
+    def test_dispatch_executor_writes_individual_files(self, work_dir):
         dispatcher = _make_dispatcher(work_dir)
-        output_path = work_dir / "runs" / "iter-1" / "execute_analyze_output.json"
+        iter_dir = work_dir / "runs" / "iter-1"
+        output_path = iter_dir / "executor_log.md"
         dispatcher.dispatch("executor", "execute-analyze", output_path=output_path, iteration=1)
-        assert output_path.exists()
-        combined = json.loads(output_path.read_text())
-        assert "plan" in combined
-        assert "findings" in combined
-        assert "principle_updates" in combined
-        # Validate findings sub-schema
-        jsonschema.validate(combined["findings"], _load_schema("findings.schema.json"))
-        # Validate plan sub-schema
-        jsonschema.validate(combined["plan"], _load_schema("experiment_plan.schema.yaml"))
-        # Check principle_updates have expected fields
-        assert len(combined["principle_updates"]) >= 1
-        assert combined["principle_updates"][0]["category"] == "domain"
+        assert (iter_dir / "experiment_plan.yaml").exists()
+        assert (iter_dir / "findings.json").exists()
+        assert (iter_dir / "principle_updates.json").exists()
+        findings = json.loads((iter_dir / "findings.json").read_text())
+        jsonschema.validate(findings, _load_schema("findings.schema.json"))
+        plan = yaml.safe_load((iter_dir / "experiment_plan.yaml").read_text())
+        jsonschema.validate(plan, _load_schema("experiment_plan.schema.yaml"))
+        principles = json.loads((iter_dir / "principle_updates.json").read_text())
+        assert len(principles) >= 1
+        assert principles[0]["category"] == "domain"
 
     def test_dispatch_executor_refuted(self, work_dir):
         dispatcher = _make_dispatcher(work_dir)
-        output_path = work_dir / "runs" / "iter-1" / "execute_analyze_output.json"
+        iter_dir = work_dir / "runs" / "iter-1"
+        output_path = iter_dir / "executor_log.md"
         dispatcher.dispatch(
             "executor", "execute-analyze",
             output_path=output_path, iteration=1, h_main_result="REFUTED",
         )
-        combined = json.loads(output_path.read_text())
-        assert combined["findings"]["arms"][0]["status"] == "REFUTED"
-        jsonschema.validate(combined["findings"], _load_schema("findings.schema.json"))
+        findings = json.loads((iter_dir / "findings.json").read_text())
+        assert findings["arms"][0]["status"] == "REFUTED"
+        jsonschema.validate(findings, _load_schema("findings.schema.json"))
 
     def test_dispatch_unknown_role_rejected(self, work_dir):
         dispatcher = _make_dispatcher(work_dir)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -34,21 +34,20 @@ class TestStubDispatcher:
         (tmp_path / "runs" / "iter-1" / "reviews").mkdir(parents=True)
         return tmp_path
 
-    def test_dispatch_planner_produces_valid_design_output(self, work_dir):
+    def test_dispatch_planner_writes_individual_files(self, work_dir):
         dispatcher = _make_dispatcher(work_dir)
-        output_path = work_dir / "runs" / "iter-1" / "design_raw.md"
+        iter_dir = work_dir / "runs" / "iter-1"
+        output_path = iter_dir / "design_log.md"
         dispatcher.dispatch("planner", "design", output_path=output_path, iteration=1)
-        assert output_path.exists()
-        raw = output_path.read_text()
-        # Should contain problem framing markdown and a yaml code fence
-        assert "## Research Question" in raw
-        assert "```yaml" in raw
-        # Extract and validate the bundle from the yaml fence
-        import re
-        match = re.search(r"```yaml\s*\n(.*?)```", raw, re.DOTALL)
-        assert match is not None
-        bundle = yaml.safe_load(match.group(1))
+        # Stub writes files directly
+        assert (iter_dir / "problem.md").exists()
+        assert "## Research Question" in (iter_dir / "problem.md").read_text()
+        assert (iter_dir / "bundle.yaml").exists()
+        bundle = yaml.safe_load((iter_dir / "bundle.yaml").read_text())
         jsonschema.validate(bundle, _load_schema("bundle.schema.yaml"))
+        assert (iter_dir / "handoff_snapshot.md").exists()
+        # Campaign-level handoff
+        assert (work_dir / "handoff.md").exists()
 
     def test_dispatch_executor_writes_individual_files(self, work_dir):
         dispatcher = _make_dispatcher(work_dir)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,7 +12,7 @@ from orchestrator.engine import Engine
 from orchestrator.dispatch import StubDispatcher
 from orchestrator.fastfail import check_fast_fail, FastFailAction
 from orchestrator.gates import HumanGate
-from run_iteration import _split_design_output, _merge_principles
+from run_iteration import _merge_principles
 
 
 SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
@@ -66,9 +66,9 @@ class TestSingleIterationHappyPath:
         # INIT -> DESIGN
         engine.transition("DESIGN")
         dispatcher.dispatch(
-            "planner", "design", output_path=iter_dir / "design_raw.md", iteration=1
+            "planner", "design", output_path=iter_dir / "design_log.md", iteration=1
         )
-        _split_design_output((iter_dir / "design_raw.md").read_text(), iter_dir)
+        # Stub writes files directly — just validate them
         bundle = yaml.safe_load((iter_dir / "bundle.yaml").read_text())
         jsonschema.validate(bundle, load_schema("bundle.schema.yaml"))
 
@@ -116,9 +116,9 @@ class TestSingleIterationHappyPath:
 
         engine.transition("DESIGN")
         dispatcher.dispatch(
-            "planner", "design", output_path=iter_dir / "design_raw.md", iteration=1
+            "planner", "design", output_path=iter_dir / "design_log.md", iteration=1
         )
-        _split_design_output((iter_dir / "design_raw.md").read_text(), iter_dir)
+
 
         engine.transition("HUMAN_DESIGN_GATE")
 
@@ -160,9 +160,9 @@ class TestSingleIterationHappyPath:
         engine.transition("DESIGN")
         iter_dir = campaign_dir / "runs" / "iter-1"
         dispatcher.dispatch(
-            "planner", "design", output_path=iter_dir / "design_raw.md", iteration=1
+            "planner", "design", output_path=iter_dir / "design_log.md", iteration=1
         )
-        _split_design_output((iter_dir / "design_raw.md").read_text(), iter_dir)
+
         engine.transition("HUMAN_DESIGN_GATE")
         engine.transition("EXECUTE_ANALYZE")
         dispatcher.dispatch(
@@ -182,9 +182,9 @@ class TestSingleIterationHappyPath:
         # Iteration 2: refuted
         iter_dir2 = campaign_dir / "runs" / "iter-2"
         dispatcher.dispatch(
-            "planner", "design", output_path=iter_dir2 / "design_raw.md", iteration=2
+            "planner", "design", output_path=iter_dir2 / "design_log.md", iteration=2
         )
-        _split_design_output((iter_dir2 / "design_raw.md").read_text(), iter_dir2)
+
         engine.transition("HUMAN_DESIGN_GATE")
         engine.transition("EXECUTE_ANALYZE")
         dispatcher.dispatch(
@@ -225,9 +225,9 @@ class TestGateSummaries:
 
         engine.transition("DESIGN")
         dispatcher.dispatch(
-            "planner", "design", output_path=iter_dir / "design_raw.md", iteration=1,
+            "planner", "design", output_path=iter_dir / "design_log.md", iteration=1,
         )
-        _split_design_output((iter_dir / "design_raw.md").read_text(), iter_dir)
+
 
         # Generate gate summary (what run_iteration.py would do before the gate)
         dispatcher.dispatch(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -80,19 +80,10 @@ class TestSingleIterationHappyPath:
         engine.transition("EXECUTE_ANALYZE")
         dispatcher.dispatch(
             "executor", "execute-analyze",
-            output_path=iter_dir / "execute_analyze_output.json", iteration=1,
+            output_path=iter_dir / "executor_log.md", iteration=1,
         )
-        # Split combined output
-        combined = json.loads((iter_dir / "execute_analyze_output.json").read_text())
-        (iter_dir / "experiment_plan.yaml").write_text(
-            yaml.safe_dump(combined["plan"], default_flow_style=False, sort_keys=False)
-        )
-        (iter_dir / "findings.json").write_text(json.dumps(combined["findings"], indent=2))
-        (iter_dir / "principle_updates.json").write_text(
-            json.dumps(combined["principle_updates"], indent=2)
-        )
-
-        findings = combined["findings"]
+        # Stub now writes files directly — just read them
+        findings = json.loads((iter_dir / "findings.json").read_text())
         jsonschema.validate(findings, load_schema("findings.schema.json"))
 
         # Check fast-fail
@@ -135,16 +126,10 @@ class TestSingleIterationHappyPath:
         engine.transition("EXECUTE_ANALYZE")
         dispatcher.dispatch(
             "executor", "execute-analyze",
-            output_path=iter_dir / "execute_analyze_output.json",
+            output_path=iter_dir / "executor_log.md",
             iteration=1, h_main_result="REFUTED",
         )
-        combined = json.loads((iter_dir / "execute_analyze_output.json").read_text())
-        (iter_dir / "findings.json").write_text(json.dumps(combined["findings"], indent=2))
-        (iter_dir / "principle_updates.json").write_text(
-            json.dumps(combined["principle_updates"], indent=2)
-        )
-
-        findings = combined["findings"]
+        findings = json.loads((iter_dir / "findings.json").read_text())
 
         # Fast-fail triggers
         ff = check_fast_fail(findings)
@@ -182,12 +167,7 @@ class TestSingleIterationHappyPath:
         engine.transition("EXECUTE_ANALYZE")
         dispatcher.dispatch(
             "executor", "execute-analyze",
-            output_path=iter_dir / "execute_analyze_output.json", iteration=1,
-        )
-        combined = json.loads((iter_dir / "execute_analyze_output.json").read_text())
-        (iter_dir / "findings.json").write_text(json.dumps(combined["findings"], indent=2))
-        (iter_dir / "principle_updates.json").write_text(
-            json.dumps(combined["principle_updates"], indent=2)
+            output_path=iter_dir / "executor_log.md", iteration=1,
         )
         engine.transition("VALIDATE")
         engine.transition("HUMAN_FINDINGS_GATE")
@@ -209,13 +189,8 @@ class TestSingleIterationHappyPath:
         engine.transition("EXECUTE_ANALYZE")
         dispatcher.dispatch(
             "executor", "execute-analyze",
-            output_path=iter_dir2 / "execute_analyze_output.json",
+            output_path=iter_dir2 / "executor_log.md",
             iteration=2, h_main_result="REFUTED",
-        )
-        combined2 = json.loads((iter_dir2 / "execute_analyze_output.json").read_text())
-        (iter_dir2 / "findings.json").write_text(json.dumps(combined2["findings"], indent=2))
-        (iter_dir2 / "principle_updates.json").write_text(
-            json.dumps(combined2["principle_updates"], indent=2)
         )
         engine.transition("VALIDATE")
         engine.transition("HUMAN_FINDINGS_GATE")

--- a/tests/test_integration_real_execution.py
+++ b/tests/test_integration_real_execution.py
@@ -253,14 +253,16 @@ class TestExecutePlanResetCmdKwargs:
         run_iteration(campaign, work_dir, iteration=1)
         return captured
 
-    def test_reset_cmd_is_git_checkout_when_in_worktree(self, tmp_path, monkeypatch):
+    def test_validate_runs_as_post_check_with_repo(self, tmp_path, monkeypatch):
         captured = self._capture_execute_plan_kwargs(
             tmp_path, monkeypatch, with_repo_path=True,
         )
-        assert captured["reset_cmd"] == "git checkout -- ."
+        # VALIDATE no longer replays — execute_plan is not called by VALIDATE
+        # The stub writes artifacts directly, and validate_execution checks them
+        assert "reset_cmd" not in captured or captured == {}
 
-    def test_reset_cmd_is_none_without_worktree(self, tmp_path, monkeypatch):
+    def test_validate_runs_as_post_check_without_repo(self, tmp_path, monkeypatch):
         captured = self._capture_execute_plan_kwargs(
             tmp_path, monkeypatch, with_repo_path=False,
         )
-        assert captured["reset_cmd"] is None
+        assert "reset_cmd" not in captured or captured == {}

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -205,3 +205,44 @@ class TestValidateExecution:
         result = validate_execution(d)
         assert result["status"] == "fail"
         assert any("id" in e for e in result["errors"])
+
+    def test_missing_output_file_referenced_in_plan(self, tmp_path: Path) -> None:
+        """Plan references output files that don't exist."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        plan_with_output = {
+            "metadata": {"iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml"},
+            "arms": [{"arm_id": "h-main", "conditions": [
+                {"name": "baseline", "cmd": "echo test",
+                 "output": str(d / "results" / "baseline.json")},
+            ]}],
+        }
+        (d / "experiment_plan.yaml").write_text(yaml.safe_dump(plan_with_output))
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("output file" in e for e in result["errors"])
+
+    def test_output_file_exists_passes(self, tmp_path: Path) -> None:
+        """Plan references output files that exist — should pass."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        results_dir = d / "results"
+        results_dir.mkdir()
+        (results_dir / "baseline.json").write_text('{"metric": 42}')
+        plan_with_output = {
+            "metadata": {"iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml"},
+            "arms": [{"arm_id": "h-main", "conditions": [
+                {"name": "baseline", "cmd": "echo test",
+                 "output": str(results_dir / "baseline.json")},
+            ]}],
+        }
+        (d / "experiment_plan.yaml").write_text(yaml.safe_dump(plan_with_output))
+        result = validate_execution(d)
+        assert result["status"] == "pass"
+
+    def test_no_output_field_skips_check(self, tmp_path: Path) -> None:
+        """Conditions without output field — no check needed."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        result = validate_execution(d)
+        assert result["status"] == "pass"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,207 @@
+"""Tests for orchestrator.validate — design and execution validation gates."""
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from orchestrator.validate import validate_design, validate_execution
+
+
+VALID_BUNDLE = {
+    "metadata": {"iteration": 1, "family": "test", "research_question": "Does X work?"},
+    "arms": [
+        {"type": "h-main", "prediction": "+20%", "mechanism": "cause", "diagnostic": "check"},
+        {"type": "h-control-negative", "prediction": "no effect", "mechanism": "none", "diagnostic": "check"},
+    ],
+}
+
+VALID_BUNDLE_WITH_CODE = {
+    "metadata": {"iteration": 1, "family": "test", "research_question": "Does X work?"},
+    "arms": [
+        {
+            "type": "h-main", "prediction": "+20%", "mechanism": "cause", "diagnostic": "check",
+            "code_changes": [{"file": "src/engine.go", "intent": "enable batch mode", "rationale": "test"}],
+        },
+        {"type": "h-control-negative", "prediction": "no effect", "mechanism": "none", "diagnostic": "check"},
+    ],
+}
+
+VALID_FINDINGS = {
+    "iteration": 1,
+    "bundle_ref": "runs/iter-1/bundle.yaml",
+    "arms": [
+        {"arm_type": "h-main", "predicted": "+20%", "observed": "+22%",
+         "status": "CONFIRMED", "error_type": None, "diagnostic_note": None},
+    ],
+    "experiment_valid": True,
+    "discrepancy_analysis": "All confirmed.",
+    "dominant_component_pct": None,
+}
+
+VALID_PLAN = {
+    "metadata": {"iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml"},
+    "arms": [
+        {"arm_id": "h-main", "conditions": [
+            {"name": "baseline", "cmd": "echo baseline"},
+        ]},
+    ],
+}
+
+VALID_PRINCIPLES = [
+    {
+        "id": "RP-1", "statement": "X works", "confidence": "high",
+        "regime": "all", "evidence": ["iter-1"], "contradicts": [],
+        "extraction_iteration": 1, "mechanism": "cause",
+        "applicability_bounds": "test", "superseded_by": None,
+        "category": "domain", "status": "active",
+    },
+]
+
+
+def _setup_design(d: Path) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "problem.md").write_text("## Research Question\nDoes X work?\n")
+    (d / "bundle.yaml").write_text(yaml.safe_dump(VALID_BUNDLE))
+    (d / "handoff_snapshot.md").write_text("## Handoff\n### Goal\nTest X.\n")
+
+
+def _setup_execution(d: Path, bundle: dict | None = None) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "bundle.yaml").write_text(yaml.safe_dump(bundle or VALID_BUNDLE))
+    (d / "experiment_plan.yaml").write_text(yaml.safe_dump(VALID_PLAN))
+    (d / "findings.json").write_text(json.dumps(VALID_FINDINGS, indent=2))
+    (d / "principle_updates.json").write_text(json.dumps(VALID_PRINCIPLES, indent=2))
+
+
+class TestValidateDesign:
+    def test_pass(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_design(d)
+        result = validate_design(d)
+        assert result["status"] == "pass"
+
+    def test_missing_problem(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_design(d)
+        (d / "problem.md").unlink()
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        assert any("problem.md" in e for e in result["errors"])
+
+    def test_empty_problem(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_design(d)
+        (d / "problem.md").write_text("")
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        assert any("empty" in e for e in result["errors"])
+
+    def test_missing_bundle(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_design(d)
+        (d / "bundle.yaml").unlink()
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        assert any("bundle.yaml" in e for e in result["errors"])
+
+    def test_invalid_bundle_schema(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_design(d)
+        (d / "bundle.yaml").write_text(yaml.safe_dump({"bad": "data"}))
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        assert any("schema" in e for e in result["errors"])
+
+    def test_missing_handoff(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_design(d)
+        (d / "handoff_snapshot.md").unlink()
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        assert any("handoff" in e for e in result["errors"])
+
+
+class TestValidateExecution:
+    def test_pass_observe_mode(self, tmp_path: Path) -> None:
+        """Observe mode: no code_changes, no patches needed."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        result = validate_execution(d)
+        assert result["status"] == "pass"
+
+    def test_pass_evolve_mode(self, tmp_path: Path) -> None:
+        """Evolve mode: code_changes present, patches required."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d, bundle=VALID_BUNDLE_WITH_CODE)
+        patches = d / "patches"
+        patches.mkdir()
+        (patches / "h-main.patch").write_text("diff --git a/src/engine.go\n+batch=true\n")
+        result = validate_execution(d)
+        assert result["status"] == "pass"
+
+    def test_missing_findings(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        (d / "findings.json").unlink()
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("findings.json" in e for e in result["errors"])
+
+    def test_invalid_findings_schema(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        (d / "findings.json").write_text(json.dumps({"bad": "data"}))
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("schema" in e for e in result["errors"])
+
+    def test_missing_principles(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        (d / "principle_updates.json").unlink()
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("principle_updates" in e for e in result["errors"])
+
+    def test_missing_patches_when_code_changes(self, tmp_path: Path) -> None:
+        """Evolve mode: bundle has code_changes but no patches directory."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d, bundle=VALID_BUNDLE_WITH_CODE)
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("patches" in e for e in result["errors"])
+
+    def test_empty_patch_file(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_execution(d, bundle=VALID_BUNDLE_WITH_CODE)
+        patches = d / "patches"
+        patches.mkdir()
+        (patches / "h-main.patch").write_text("")
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("empty" in e for e in result["errors"])
+
+    def test_missing_experiment_plan(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        (d / "experiment_plan.yaml").unlink()
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("experiment_plan" in e for e in result["errors"])
+
+    def test_principles_not_a_list(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        (d / "principle_updates.json").write_text(json.dumps({"not": "a list"}))
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("list" in e for e in result["errors"])
+
+    def test_principle_missing_id(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        (d / "principle_updates.json").write_text(json.dumps([{"statement": "no id"}]))
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("id" in e for e in result["errors"])


### PR DESCRIPTION
## Summary
- New `orchestrator/validate.py` with `validate_design` and `validate_execution` CLI commands
- Campaign dir can be created inside target repo (`.nous/<run_id>/`) when `repo_path` is set
- CLI dispatcher: executor agent writes artifacts directly to iter_dir (no JSON blob)
- LLM dispatcher: backward-compatible JSON blob splitting preserved
- Executor prompt rewritten: writes files incrementally, runs validate before claiming success
- VALIDATE phase simplified to lightweight post-check (no replay — agent already validated)
- Handles both observe mode (no patches) and evolve mode (patches required)

## Key Design Decisions
1. **Dual dispatch paths**: CLI agents write files directly; LLM API agents still use the JSON blob approach. Both paths run `validate_execution()` as safety net.
2. **Agent self-correction**: executor prompt says "run `nous validate execution`, fix errors, repeat until pass." Hard enforcement via hooks comes in #53.
3. **VALIDATE is now a post-check**: raises on failure (not warnings), but no replay since the agent already validated.

## Related Issue
Closes #50, closes #57

## Test Plan
- [x] 290 tests pass (16 new for validate_design/validate_execution)
- [x] Design validation: pass, missing problem/bundle/handoff, invalid schema
- [x] Execution validation: pass, missing findings/principles/plan, observe vs evolve mode
- [x] Campaign integration tests updated for new file-based output
- [ ] Manual: run real campaign with updated executor prompt

🤖 Generated with [Claude Code](https://claude.ai/claude-code)