### PR TITLE
docs: update for validate CLI and file-based agent output

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Two LLM calls per iteration, both via `claude -p`:
 | DESIGN | Opus | Planner — explores, frames, designs |
 | EXECUTE_ANALYZE | Sonnet | Executor — builds, patches, runs, analyzes |
 
-VALIDATE and principle merge are Python-only (no LLM calls).
+VALIDATE is a lightweight post-check (no LLM calls). Principle merge is Python-only.
+
+Both agents write their artifacts directly to disk and run `nous validate` before claiming done. If validation fails, the agent reads the errors, fixes the artifacts, and retries.
 
 ### 4. Create a campaign
 
@@ -114,6 +116,8 @@ target_system:
     What the system does and its architecture.
   repo_path: /path/to/your/repo
 ```
+
+When `repo_path` is set, the campaign directory is created inside the target repo at `.nous/<run_id>/`. All artifacts live there.
 
 The planner explores the codebase to discover metrics, knobs, and execution methods. You can optionally provide `observable_metrics` and `controllable_knobs` as hints — see [examples/campaign.yaml](examples/campaign.yaml) for all options.
 
@@ -144,26 +148,29 @@ python run_campaign.py campaign.yaml --auto-approve --max-iterations 1  # quick 
 
 ```bash
 git clone https://github.com/inference-sim/inference-sim.git blis
-cd blis && go build -o blis . && cd ..
 # Edit examples/campaign.yaml: set repo_path to your blis/ path
 python run_campaign.py examples/campaign.yaml --max-iterations 3
 ```
 
+Campaign artifacts will be created at `blis/.nous/<run_id>/`.
+
 ### Output
 
 ```
-blis-run/
+your-repo/.nous/<run_id>/
   state.json              # orchestrator checkpoint
   principles.json         # accumulated principles
   ledger.json             # one row per iteration
+  handoff.md              # living exploration context (updated each iteration)
   runs/iter-N/
     problem.md            # problem framing
     bundle.yaml           # hypothesis bundle
+    handoff_snapshot.md   # iteration snapshot of handoff
     experiment_plan.yaml  # exact commands per arm
-    execution_results.json # raw output per condition
     findings.json         # prediction vs outcome
     principle_updates.json # proposed principle changes
-    gate_summary_*.json   # human-readable summaries
+    patches/              # code diffs (evolve mode only)
+    results/              # experiment output files
 ```
 
 ### Run tests
@@ -179,6 +186,7 @@ schemas/                 JSON Schema definitions (Draft 2020-12)
 templates/               Starter files for new campaigns
 orchestrator/            Python orchestrator (deterministic, not an LLM)
   engine.py                State machine with atomic checkpoint/resume
+  validate.py              Artifact validation CLI (nous validate design/execution)
   dispatch.py              Stub agent dispatch (for testing without LLM)
   cli_dispatch.py          Code-access agent dispatch via claude -p
   prompt_loader.py         Template loading with {{placeholder}} rendering

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,14 +100,20 @@ The dispatcher invokes AI agents by role and phase, passing structured input and
 
 | Role | Invoked During | Produces |
 |---|---|---|
-| **Planner** (Opus, `claude -p`) | DESIGN | `problem.md`, `bundle.yaml` |
-| **Executor** (Sonnet, `claude -p`) | EXECUTE_ANALYZE | `experiment_plan.yaml`, `execution_results.json`, `findings.json`, `principle_updates.json` |
-| **Python orchestrator** | VALIDATE | Replays `experiment_plan.yaml`, merges principles by ID into `principles.json` (no LLM) |
+| **Planner** (Opus, `claude -p`) | DESIGN | `problem.md`, `bundle.yaml`, `handoff_snapshot.md` |
+| **Executor** (Sonnet, `claude -p`) | EXECUTE_ANALYZE | `experiment_plan.yaml`, `findings.json`, `principle_updates.json`, `patches/`, `results/` |
+| **Python orchestrator** | VALIDATE | Post-check: validates artifacts exist and pass schemas, merges principles (no LLM) |
+
+Both agents write artifacts directly to the campaign directory (`iter_dir`) and run `nous validate` before claiming done. If validation fails, the agent reads the errors, fixes the artifacts, and retries. The orchestrator runs a post-check as a safety net.
+
+**Validation CLI** (`orchestrator/validate.py`):
+- `nous validate design --dir <iter_dir>` — checks problem.md, bundle.yaml (schema), handoff_snapshot.md
+- `nous validate execution --dir <iter_dir>` — checks experiment_plan.yaml (schema), findings.json (schema), principle_updates.json, patches (when code_changes exist), output files referenced in plan
 
 **Implementations:**
 
 - `StubDispatcher` (`dispatch.py`) produces valid, schema-conformant artifacts without calling any LLM. Used for testing the orchestrator loop.
-- `CLIDispatcher` (`cli_dispatch.py`) invokes `claude -p` as a subprocess, giving agents code access and shell tools. Used for both the planner (DESIGN, Opus) and executor (EXECUTE_ANALYZE, Sonnet) roles. Sends prompts via stdin to the Claude CLI. The agent can read files, grep code, and run commands in the target repo. Supports `override_cwd()` context manager for temporarily pointing the executor at a git worktree.
+- `CLIDispatcher` (`cli_dispatch.py`) invokes `claude -p` as a subprocess, giving agents code access and shell tools. Agents write files directly to `iter_dir`. Supports `override_cwd()` context manager for pointing the executor at a git worktree.
 
 **Dispatch interface:**
 ```python

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -153,7 +153,15 @@ The experiment plan. Produced by the executor during EXECUTE_ANALYZE. Contains e
 | `arms[].conditions[].output` | Optional: path to output file to capture |
 | `arms[].conditions[].description` | Optional human description |
 
-Located at `runs/iter-N/experiment_plan.yaml`. Commands are validated by the executor agent before emission.
+Located at `runs/iter-N/experiment_plan.yaml`. The agent writes the plan first, then executes it. All output paths use absolute paths to `runs/iter-N/results/` so files persist after worktree cleanup.
+
+## 4b2. patches/ — "What code changes were made?"
+
+Directory at `runs/iter-N/patches/`. Only present in evolve mode (when bundle arms have `code_changes`). Each file is a git diff named by arm type (e.g., `h-main.patch`). The agent creates patches, saves them here, and references them in the experiment plan.
+
+## 4b3. results/ — "What did the experiments produce?"
+
+Directory at `runs/iter-N/results/`. Contains experiment output files organized by arm (e.g., `results/h-main/baseline-s42.json`). The agent writes results here using absolute paths so they survive worktree cleanup.
 
 ## 4c. execution_results.json — "What did the commands produce?"
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -26,11 +26,11 @@ All four preconditions must hold for a system to be investigated with Nous:
 
 Each iteration follows 7 phases: INIT → DESIGN → HUMAN_DESIGN_GATE → EXECUTE_ANALYZE → VALIDATE → HUMAN_FINDINGS_GATE → DONE.
 
-Two LLM calls per iteration (both via `claude -p`): Opus for DESIGN, Sonnet for EXECUTE_ANALYZE. VALIDATE and principle merge are Python-only.
+Two LLM calls per iteration (both via `claude -p`): Opus for DESIGN, Sonnet for EXECUTE_ANALYZE. Both agents write artifacts directly to the campaign directory and run `nous validate` before claiming done. VALIDATE is a lightweight post-check (no LLM).
 
 ### DESIGN (Planner, Opus)
 
-The Planner agent explores the target system, validates assumptions, then produces two artifacts:
+The Planner agent explores the target system, validates assumptions, then produces three artifacts:
 
 **Problem framing** (`problem.md`):
 - Research question — what mechanism or behavior is under investigation
@@ -43,6 +43,11 @@ The Planner agent explores the target system, validates assumptions, then produc
 **Hypothesis bundle** (`bundle.yaml`):
 The agent decomposes the investigation into a structured set of falsifiable predictions — a hypothesis bundle.
 
+**Handoff** (`handoff_snapshot.md`):
+A structured context document for the executor and the next iteration's designer. Contains key discoveries, code map, dead ends, exclusion reasoning, and current status. This is a living document — each iteration's designer reads the previous handoff and curates it (keeps relevant entries, removes outdated ones, adds new findings).
+
+The agent runs `nous validate design` before finishing. If validation fails, it reads the errors and fixes the artifacts.
+
 ### HUMAN_DESIGN_GATE
 
 Human approval gate (hard stop). The human sees the hypothesis bundle. If the human rejects, the Planner revises (loops back to DESIGN). If approved, the bundle advances to execution.
@@ -51,14 +56,15 @@ Human approval gate (hard stop). The human sees the hypothesis bundle. If the hu
 
 A single `claude -p` session handles the entire execution pipeline:
 
-1. Receives the approved hypothesis bundle
-2. Explores the target repo, discovers build commands
-3. Produces `experiment_plan.yaml` with exact shell commands per arm
-4. Runs the commands in an isolated git worktree, captures stdout/stderr per condition
+1. Reads the designer's handoff — uses validated commands and code map instead of re-exploring
+2. Writes `experiment_plan.yaml` with exact commands per arm (plan first, execute second)
+3. Creates patches for code-change arms (evolve mode), saves to `patches/`
+4. Runs the plan in an isolated git worktree, writes results to `results/`
 5. Compares observed metrics against predictions
-6. Produces `findings.json` and `principle_updates.json`
+6. Writes `findings.json` and `principle_updates.json`
+7. Runs `nous validate execution` — retries until all artifacts pass
 
-When `repo_path` is set, execution runs in an isolated git worktree. The worktree ID is persisted to `.experiment_id` for crash recovery.
+All output files use absolute paths to the campaign directory so they persist after worktree cleanup.
 
 **Key artifacts:**
 - `experiment_plan.yaml` — exact commands per arm

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -76,7 +76,9 @@ prompts:
 python run_campaign.py campaign.yaml --max-iterations 3
 ```
 
-This loops through iterations. Each iteration runs the full Nous loop (design, execute+analyze, validate) and pauses at two human gates for your approval.
+When `repo_path` is set in `campaign.yaml`, the campaign directory is created inside the target repo at `.nous/<run_id>/`.
+
+Each iteration runs the full Nous loop (design → execute+analyze → validate) and pauses at two human gates. Both agents write artifacts directly to disk and run `nous validate` before claiming done — if validation fails, the agent fixes and retries.
 
 Options:
 
@@ -110,15 +112,17 @@ Each gate shows a formatted summary before asking for your decision. Type `appro
 
 After a campaign, your working directory contains:
 
+- **`handoff.md`** — Living exploration context (updated each iteration)
+- **`principles.json`** — Accumulated principles across all iterations
+- **`ledger.json`** — One row per completed iteration
 - **`runs/iter-N/problem.md`** — How the problem was framed
 - **`runs/iter-N/bundle.yaml`** — The hypothesis bundle
-- **`handoff.md`** — Living exploration context (campaign-level, updated each iteration)
-- **`runs/iter-N/handoff_snapshot.md`** — Per-iteration handoff snapshot for audit
+- **`runs/iter-N/handoff_snapshot.md`** — Iteration snapshot of handoff for audit
+- **`runs/iter-N/experiment_plan.yaml`** — Exact commands per arm
 - **`runs/iter-N/findings.json`** — Prediction vs. outcome analysis
-- **`runs/iter-N/gate_summary_*.json`** — Human-readable gate summaries
 - **`runs/iter-N/principle_updates.json`** — Proposed principle changes
-- **`ledger.json`** — One row per completed iteration
-- **`principles.json`** — Accumulated principles across all iterations
+- **`runs/iter-N/patches/`** — Code diffs (evolve mode only)
+- **`runs/iter-N/results/`** — Experiment output files
 
 ## Choosing a model
 


### PR DESCRIPTION
## Summary
- Update README, quickstart, architecture, protocol, and data-model docs
- Reflect: campaign dir in target repo, agents write files directly, validate CLI, handoff as living document, patches/ and results/ directories

## Related Issue
Closes #61

## Test Plan
- [x] 293 tests pass (docs only, no code changes)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)