### PR TITLE
feat: persist agent-created input files in iter_dir/inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ your-repo/.nous/<run_id>/
     findings.json         # prediction vs outcome
     principle_updates.json # proposed principle changes
     patches/              # code diffs (evolve mode only)
+    inputs/               # agent-created input files (configs, workloads)
     results/              # experiment output files
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,7 @@ Both agents write artifacts directly to the campaign directory (`iter_dir`) and 
 
 **Validation CLI** (`orchestrator/validate.py`):
 - `nous validate design --dir <iter_dir>` — checks problem.md, bundle.yaml (schema), handoff_snapshot.md
-- `nous validate execution --dir <iter_dir>` — checks experiment_plan.yaml (schema), findings.json (schema), principle_updates.json, patches (when code_changes exist), output files referenced in plan
+- `nous validate execution --dir <iter_dir>` — checks experiment_plan.yaml (schema), findings.json (schema), principle_updates.json, patches (when code_changes exist), input and output files referenced in plan
 
 **Implementations:**
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -151,6 +151,7 @@ The experiment plan. Produced by the executor during EXECUTE_ANALYZE. Contains e
 | `arms[].conditions[].name` | Condition name (e.g., "baseline-seed42") |
 | `arms[].conditions[].cmd` | Exact shell command to execute |
 | `arms[].conditions[].output` | Optional: path to output file to capture |
+| `arms[].conditions[].inputs` | Optional: array of input file paths created by the agent |
 | `arms[].conditions[].description` | Optional human description |
 
 Located at `runs/iter-N/experiment_plan.yaml`. The agent writes the plan first, then executes it. All output paths use absolute paths to `runs/iter-N/results/` so files persist after worktree cleanup.
@@ -159,7 +160,11 @@ Located at `runs/iter-N/experiment_plan.yaml`. The agent writes the plan first, 
 
 Directory at `runs/iter-N/patches/`. Only present in evolve mode (when bundle arms have `code_changes`). Each file is a git diff named by arm type (e.g., `h-main.patch`). The agent creates patches, saves them here, and references them in the experiment plan.
 
-## 4b3. results/ — "What did the experiments produce?"
+## 4b3. inputs/ — "What input files did the agent create?"
+
+Directory at `runs/iter-N/inputs/`. Contains agent-created input files needed by experiment commands (config files, workload specs, policy definitions). The agent writes these here instead of `/tmp/` so the experiment is reproducible. Referenced in the plan's `inputs` array per condition.
+
+## 4b4. results/ — "What did the experiments produce?"
 
 Directory at `runs/iter-N/results/`. Contains experiment output files organized by arm (e.g., `results/h-main/baseline-s42.json`). The agent writes results here using absolute paths so they survive worktree cleanup.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -57,14 +57,15 @@ Human approval gate (hard stop). The human sees the hypothesis bundle. If the hu
 A single `claude -p` session handles the entire execution pipeline:
 
 1. Reads the designer's handoff — uses validated commands and code map instead of re-exploring
-2. Writes `experiment_plan.yaml` with exact commands per arm (plan first, execute second)
-3. Creates patches for code-change arms (evolve mode), saves to `patches/`
-4. Runs the plan in an isolated git worktree, writes results to `results/`
-5. Compares observed metrics against predictions
-6. Writes `findings.json` and `principle_updates.json`
-7. Runs `nous validate execution` — retries until all artifacts pass
+2. Creates any input files needed by commands (configs, workloads) in `inputs/`
+3. Writes `experiment_plan.yaml` with exact commands per arm (plan first, execute second)
+4. Creates patches for code-change arms (evolve mode), saves to `patches/`
+5. Runs the plan in an isolated git worktree, writes results to `results/`
+6. Compares observed metrics against predictions
+7. Writes `findings.json` and `principle_updates.json`
+8. Runs `nous validate execution` — retries until all artifacts pass
 
-All output files use absolute paths to the campaign directory so they persist after worktree cleanup.
+All file paths (inputs, outputs) use absolute paths to the campaign directory so they persist after worktree cleanup.
 
 **Key artifacts:**
 - `experiment_plan.yaml` — exact commands per arm

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -122,6 +122,7 @@ After a campaign, your working directory contains:
 - **`runs/iter-N/findings.json`** — Prediction vs. outcome analysis
 - **`runs/iter-N/principle_updates.json`** — Proposed principle changes
 - **`runs/iter-N/patches/`** — Code diffs (evolve mode only)
+- **`runs/iter-N/inputs/`** — Agent-created input files (configs, workloads)
 - **`runs/iter-N/results/`** — Experiment output files
 
 ## Choosing a model

--- a/orchestrator/executor.py
+++ b/orchestrator/executor.py
@@ -45,6 +45,7 @@ def execute_plan(
     iter_dir = Path(iter_dir)
     results_dir = iter_dir / "results"
     results_dir.mkdir(parents=True, exist_ok=True)
+    (iter_dir / "inputs").mkdir(parents=True, exist_ok=True)
 
     # Run setup (fails fast — prerequisite for all arms)
     try:
@@ -165,6 +166,28 @@ def _run_arm(
                     "output_content": None,
                 })
                 continue
+
+        # Verify declared input files exist before running
+        input_paths = cond.get("inputs", [])
+        missing = [
+            p for p in input_paths
+            if not (Path(p) if Path(p).is_absolute() else cwd / p).exists()
+        ]
+        if missing:
+            msg = f"Missing input files: {missing}"
+            logger.warning("Condition %s/%s skipped: %s", arm_id, name, msg)
+            print(f"    [{arm_id}] {name}: [missing inputs, skipping]", flush=True)
+            (arm_dir / f"{name}.stdout").write_text("")
+            (arm_dir / f"{name}.stderr").write_text(msg)
+            conditions.append({
+                "name": name,
+                "cmd": cmd,
+                "exit_code": -2,
+                "stdout_tail": "",
+                "stderr_tail": msg,
+                "output_content": None,
+            })
+            continue
 
         print(f"    [{arm_id}] {name}: {cmd}", flush=True)
         result = _run_cmd(cmd, cwd, timeout)

--- a/orchestrator/validate.py
+++ b/orchestrator/validate.py
@@ -114,8 +114,8 @@ def validate_execution(iter_dir: Path) -> dict:
         except json.JSONDecodeError as exc:
             errors.append(f"principle_updates.json is not valid JSON: {exc}")
 
-    # output files — check that files referenced in plan conditions exist
-    if plan_path.exists() and not errors:
+    # file references — check that output and input files in plan conditions exist
+    if plan_path.exists():
         try:
             plan = yaml.safe_load(plan_path.read_text())
             for arm in plan.get("arms", []):
@@ -128,6 +128,15 @@ def validate_execution(iter_dir: Path) -> dict:
                         if not output_file.exists():
                             errors.append(
                                 f"output file {cond['output']} referenced in "
+                                f"{arm['arm_id']}/{cond['name']} not found"
+                            )
+                    for input_path in cond.get("inputs", []):
+                        input_file = Path(input_path)
+                        if not input_file.is_absolute():
+                            input_file = iter_dir / input_path
+                        if not input_file.exists():
+                            errors.append(
+                                f"input file {input_path} referenced in "
                                 f"{arm['arm_id']}/{cond['name']} not found"
                             )
         except (yaml.YAMLError, KeyError):

--- a/prompts/methodology/execute_analyze.md
+++ b/prompts/methodology/execute_analyze.md
@@ -89,15 +89,21 @@ arms:
       - name: "baseline-seed42"
         cmd: "<baseline command with --seed 42 --output {{iter_dir}}/results/h-main/baseline-s42.json>"
         output: "{{iter_dir}}/results/h-main/baseline-s42.json"
+        inputs:
+          - "{{iter_dir}}/inputs/workload.yaml"
       - name: "treatment-seed42"
         cmd: "git apply {{iter_dir}}/patches/h-main.patch && <build> && <run with --output {{iter_dir}}/results/h-main/treatment-s42.json>"
         output: "{{iter_dir}}/results/h-main/treatment-s42.json"
+        inputs:
+          - "{{iter_dir}}/inputs/workload.yaml"
 ```
 
-**Important:** All output paths MUST use absolute paths under `{{iter_dir}}/results/`. Do NOT use relative paths — the experiment runs in a worktree that gets cleaned up.
+**Important:**
+- All output paths MUST use absolute paths under `{{iter_dir}}/results/`. Do NOT use relative paths — the experiment runs in a worktree that gets cleaned up.
+- If you create ANY input files for the experiment (config files, workload specs, policy definitions, parameter files), write them to `{{iter_dir}}/inputs/` and list them in the condition's `inputs` array. Do NOT write input files to `/tmp/` or other temporary locations — they will be lost and the experiment will not be reproducible.
 
-### Step 5: Create output directories
-For every output path in your plan, ensure the parent directory exists (`mkdir -p {{iter_dir}}/results/<arm_id>`).
+### Step 5: Create output and input directories
+For every output path in your plan, ensure the parent directory exists (`mkdir -p {{iter_dir}}/results/<arm_id>`). Also create the inputs directory: `mkdir -p {{iter_dir}}/inputs`.
 
 ## Phase 2: Execute the plan
 

--- a/schemas/experiment_plan.schema.yaml
+++ b/schemas/experiment_plan.schema.yaml
@@ -60,5 +60,9 @@ properties:
                 minLength: 1
               output:
                 type: string
+              inputs:
+                type: array
+                items:
+                  type: string
               description:
                 type: string

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -101,6 +101,54 @@ class TestExecutePlanHappyPath:
         assert results["plan_ref"] == "runs/iter-1/experiment_plan.yaml"
 
 
+    def test_inputs_directory_created(self, tmp_path):
+        iter_dir = tmp_path / "iter-1"
+        iter_dir.mkdir()
+        execute_plan(SIMPLE_PLAN, cwd=tmp_path, iter_dir=iter_dir)
+        assert (iter_dir / "inputs").is_dir()
+
+    def test_missing_input_file_skips_condition(self, tmp_path):
+        iter_dir = tmp_path / "iter-1"
+        iter_dir.mkdir()
+        plan = {
+            "metadata": {"iteration": 1, "bundle_ref": "x"},
+            "arms": [{
+                "arm_id": "h-main",
+                "conditions": [{
+                    "name": "needs-input",
+                    "cmd": "echo should-not-run",
+                    "inputs": [str(tmp_path / "nonexistent.yaml")],
+                }],
+            }],
+        }
+        results = execute_plan(plan, cwd=tmp_path, iter_dir=iter_dir)
+        cond = results["arms"][0]["conditions"][0]
+        assert cond["exit_code"] == -2
+        assert "Missing input" in cond["stderr_tail"]
+
+    def test_existing_input_file_allows_run(self, tmp_path):
+        iter_dir = tmp_path / "iter-1"
+        iter_dir.mkdir()
+        input_file = iter_dir / "inputs" / "config.yaml"
+        input_file.parent.mkdir(parents=True)
+        input_file.write_text("key: value")
+        plan = {
+            "metadata": {"iteration": 1, "bundle_ref": "x"},
+            "arms": [{
+                "arm_id": "h-main",
+                "conditions": [{
+                    "name": "has-input",
+                    "cmd": "echo ok",
+                    "inputs": [str(input_file)],
+                }],
+            }],
+        }
+        results = execute_plan(plan, cwd=tmp_path, iter_dir=iter_dir)
+        cond = results["arms"][0]["conditions"][0]
+        assert cond["exit_code"] == 0
+        assert "ok" in cond["stdout_tail"]
+
+
 class TestExecutePlanFailures:
     def test_arm_failure_recorded_not_raised(self, tmp_path):
         iter_dir = tmp_path / "iter-1"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -246,3 +246,73 @@ class TestValidateExecution:
         _setup_execution(d)
         result = validate_execution(d)
         assert result["status"] == "pass"
+
+    def test_missing_input_file_referenced_in_plan(self, tmp_path: Path) -> None:
+        """Plan references input files that don't exist."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        plan_with_inputs = {
+            "metadata": {"iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml"},
+            "arms": [{"arm_id": "h-main", "conditions": [
+                {"name": "baseline", "cmd": "echo test",
+                 "inputs": [str(d / "inputs" / "workload.yaml")]},
+            ]}],
+        }
+        (d / "experiment_plan.yaml").write_text(yaml.safe_dump(plan_with_inputs))
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("input file" in e for e in result["errors"])
+
+    def test_input_file_exists_passes(self, tmp_path: Path) -> None:
+        """Plan references input files that exist — should pass."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        inputs_dir = d / "inputs"
+        inputs_dir.mkdir()
+        (inputs_dir / "workload.yaml").write_text("rate: 80")
+        plan_with_inputs = {
+            "metadata": {"iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml"},
+            "arms": [{"arm_id": "h-main", "conditions": [
+                {"name": "baseline", "cmd": "echo test",
+                 "inputs": [str(inputs_dir / "workload.yaml")]},
+            ]}],
+        }
+        (d / "experiment_plan.yaml").write_text(yaml.safe_dump(plan_with_inputs))
+        result = validate_execution(d)
+        assert result["status"] == "pass"
+
+    def test_relative_input_path_resolved(self, tmp_path: Path) -> None:
+        """Relative input paths are resolved against iter_dir."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        inputs_dir = d / "inputs"
+        inputs_dir.mkdir()
+        (inputs_dir / "config.json").write_text("{}")
+        plan_with_inputs = {
+            "metadata": {"iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml"},
+            "arms": [{"arm_id": "h-main", "conditions": [
+                {"name": "baseline", "cmd": "echo test",
+                 "inputs": ["inputs/config.json"]},
+            ]}],
+        }
+        (d / "experiment_plan.yaml").write_text(yaml.safe_dump(plan_with_inputs))
+        result = validate_execution(d)
+        assert result["status"] == "pass"
+
+    def test_input_check_runs_despite_other_errors(self, tmp_path: Path) -> None:
+        """Input file check runs even when other validation errors exist."""
+        d = tmp_path / "iter-1"
+        _setup_execution(d)
+        (d / "findings.json").unlink()  # cause a prior error
+        plan_with_inputs = {
+            "metadata": {"iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml"},
+            "arms": [{"arm_id": "h-main", "conditions": [
+                {"name": "baseline", "cmd": "echo test",
+                 "inputs": [str(d / "inputs" / "missing.yaml")]},
+            ]}],
+        }
+        (d / "experiment_plan.yaml").write_text(yaml.safe_dump(plan_with_inputs))
+        result = validate_execution(d)
+        assert result["status"] == "fail"
+        assert any("input file" in e for e in result["errors"])
+        assert any("findings" in e for e in result["errors"])


### PR DESCRIPTION
## Summary
- Agent-created input files (configs, workloads, policies) were written to `/tmp/` and lost after experiments, making them non-reproducible
- Added `inputs` array field to experiment plan conditions, `inputs/` directory in iter_dir, and validation that referenced input files exist
- Updated executor prompt to instruct agent to use `iter_dir/inputs/` for all created input files

## Related Issue
Closes #60

## Changes
- **Schema** (`experiment_plan.schema.yaml`): optional `inputs` array on conditions
- **Executor** (`executor.py`): creates `inputs/` dir, verifies input files exist before running each condition (skips with exit_code -2 if missing)
- **Validation** (`validate.py`): checks input file paths exist, decoupled file-reference checks from error guard so they run regardless of prior errors
- **Prompt** (`execute_analyze.md`): instructs agent to write input files to `{{iter_dir}}/inputs/` and list them in the `inputs` field
- **Tests**: 7 new tests covering validation and executor behavior for input files

## Test Plan
- [x] All 300 existing tests pass
- [x] 7 new tests: missing input fails validation, existing passes, relative path resolution, guard decoupling, inputs dir creation, missing input skips condition, existing input allows run
- [x] PR review agent ran — addressed critical finding (relative path resolution consistency)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)