### PR TITLE
feat: add --agent inline flag for embedded dispatch

### DIFF
--- a/orchestrator/inline_dispatch.py
+++ b/orchestrator/inline_dispatch.py
@@ -87,6 +87,7 @@ class InlineDispatcher(LLMDispatcher):
         iter_dir = output_path.parent
         response_path = iter_dir / f".nous_response_{role}_{phase.replace('-', '_')}"
         response_path.unlink(missing_ok=True)
+        self._clean_stale_artifacts(iter_dir, phase)
 
         if phase in ("design", "execute-analyze"):
             fmt = None
@@ -203,28 +204,38 @@ class InlineDispatcher(LLMDispatcher):
         phase: str,
         t0: float,
     ) -> str:
-        """Poll for agent response file."""
+        """Poll for the signal file, then verify required artifacts exist."""
         deadline = t0 + self.timeout
 
         while time.time() < deadline:
             if phase == "design":
-                bundle_path = iter_dir / "bundle.yaml"
-                problem_path = iter_dir / "problem.md"
-                if bundle_path.exists() and problem_path.exists():
-                    return f"Design artifacts written to {iter_dir}"
                 if response_path.exists():
+                    missing = self._check_design_artifacts(iter_dir)
+                    if missing:
+                        raise RuntimeError(
+                            f"Signal file exists but required design artifacts are missing: "
+                            f"{', '.join(missing)}. The agent must write all files before "
+                            f"touching {response_path}."
+                        )
                     return f"Design artifacts written to {iter_dir}"
 
             elif phase == "execute-analyze":
-                findings_path = iter_dir / "findings.json"
-                plan_path = iter_dir / "experiment_plan.yaml"
-                if findings_path.exists() and plan_path.exists():
-                    return f"Execution artifacts written to {iter_dir}"
                 if response_path.exists():
+                    missing = self._check_execute_artifacts(iter_dir)
+                    if missing:
+                        raise RuntimeError(
+                            f"Signal file exists but required execution artifacts are missing: "
+                            f"{', '.join(missing)}. The agent must write all files before "
+                            f"touching {response_path}."
+                        )
                     return f"Execution artifacts written to {iter_dir}"
 
             elif response_path.exists():
-                return response_path.read_text()
+                content = response_path.read_text()
+                if not content.strip():
+                    time.sleep(RESPONSE_POLL_INTERVAL_SEC)
+                    continue
+                return content
 
             time.sleep(RESPONSE_POLL_INTERVAL_SEC)
 
@@ -232,6 +243,32 @@ class InlineDispatcher(LLMDispatcher):
             f"Timed out after {self.timeout}s waiting for agent response at {response_path}. "
             f"The agent should write its response and then touch {response_path}."
         )
+
+    @staticmethod
+    def _clean_stale_artifacts(iter_dir: Path, phase: str) -> None:
+        """Remove artifacts from previous runs so polling starts clean."""
+        if phase == "design":
+            for name in ("problem.md", "bundle.yaml", "handoff.md"):
+                (iter_dir / name).unlink(missing_ok=True)
+        elif phase == "execute-analyze":
+            for name in ("experiment_plan.yaml", "findings.json", "principle_updates.json"):
+                (iter_dir / name).unlink(missing_ok=True)
+
+    @staticmethod
+    def _check_design_artifacts(iter_dir: Path) -> list[str]:
+        """Return list of missing required design artifact names."""
+        required = {"problem.md": iter_dir / "problem.md", "bundle.yaml": iter_dir / "bundle.yaml"}
+        return [name for name, path in required.items() if not path.exists()]
+
+    @staticmethod
+    def _check_execute_artifacts(iter_dir: Path) -> list[str]:
+        """Return list of missing required execution artifact names."""
+        required = {
+            "experiment_plan.yaml": iter_dir / "experiment_plan.yaml",
+            "findings.json": iter_dir / "findings.json",
+            "principle_updates.json": iter_dir / "principle_updates.json",
+        }
+        return [name for name, path in required.items() if not path.exists()]
 
     def _log_inline_metrics(self, role: str, phase: str, t0: float) -> None:
         """Log basic timing metrics for inline dispatch."""

--- a/orchestrator/inline_dispatch.py
+++ b/orchestrator/inline_dispatch.py
@@ -1,0 +1,249 @@
+"""Inline dispatch for the Nous orchestrator.
+
+Emits prompts to stdout so the calling CLI agent reasons about them
+directly — no subprocess, no API key. The agent writes artifacts to
+the iteration directory as instructed by the prompt.
+
+This dispatcher is designed for environments where Nous runs inside
+an existing CLI agent session (e.g., a Hive strategist agent using
+Copilot CLI or Claude Code). The agent sees the prompt as part of its
+tool output and responds in its own conversation turn.
+
+Usage:
+    python run_campaign.py examples/campaign.yaml --agent inline
+"""
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+from orchestrator.llm_dispatch import LLMDispatcher
+from orchestrator.metrics import log_metrics
+from orchestrator.util import atomic_write
+
+logger = logging.getLogger(__name__)
+
+RESPONSE_TIMEOUT_SEC = 300
+RESPONSE_POLL_INTERVAL_SEC = 2
+
+
+class InlineDispatcher(LLMDispatcher):
+    """Dispatch agent roles by emitting prompts to stdout.
+
+    The calling agent reads the prompt, reasons about it, and writes
+    its response to a designated file. This dispatcher polls for that
+    file and processes it.
+
+    For design and execute-analyze phases, the agent writes artifacts
+    directly to iter_dir (same as CLIDispatcher). For structured phases
+    (gate summaries), the agent writes a JSON response file.
+    """
+
+    def __init__(
+        self,
+        work_dir: Path,
+        campaign: dict,
+        model: str = "inline",
+        prompts_dir: Path | None = None,
+        timeout: int = 300,
+    ) -> None:
+        super().__init__(
+            work_dir=work_dir,
+            campaign=campaign,
+            model=model,
+            prompts_dir=prompts_dir,
+            completion_fn=lambda **kw: (_ for _ in ()).throw(
+                RuntimeError("InlineDispatcher does not use the completion API")
+            ),
+        )
+        self.timeout = timeout
+
+    def dispatch(
+        self,
+        role: str,
+        phase: str,
+        *,
+        output_path: Path,
+        iteration: int,
+        perspective: str | None = None,
+        h_main_result: str = "CONFIRMED",
+    ) -> None:
+        """Emit prompt to stdout and wait for agent response."""
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._current_role = role
+        self._current_phase = phase
+
+        template, fmt, schema_name = self._route(role, phase)
+        context = self._build_context(role, phase, iteration, perspective)
+        prompt = self.loader.load(template, context)
+
+        iter_dir = output_path.parent
+        response_path = iter_dir / f".nous_response_{role}_{phase.replace('-', '_')}"
+        response_path.unlink(missing_ok=True)
+
+        if phase in ("design", "execute-analyze"):
+            fmt = None
+            schema_name = None
+
+        self._emit_prompt(role, phase, prompt, fmt, schema_name, iter_dir, response_path)
+
+        t0 = time.time()
+        response = self._wait_for_response(response_path, output_path, iter_dir, phase, t0)
+
+        self._log_inline_metrics(role, phase, t0)
+
+        if fmt is None:
+            atomic_write(output_path, response)
+        else:
+            try:
+                data = self._extract_fenced_content(response, fmt)
+            except (json.JSONDecodeError, yaml.YAMLError, ValueError) as exc:
+                logger.warning(
+                    "Parse failed for %s/%s (%s). Agent response may need correction.",
+                    role, phase, exc,
+                )
+                raise RuntimeError(
+                    f"Could not parse agent response for {role}/{phase}: {exc}"
+                ) from exc
+
+            if schema_name is not None:
+                try:
+                    self._validate(data, schema_name)
+                except jsonschema.ValidationError as exc:
+                    logger.warning(
+                        "Schema validation failed for %s/%s: %s",
+                        role, phase, exc.message,
+                    )
+                    raise RuntimeError(
+                        f"Agent response for {role}/{phase} failed schema validation: {exc.message}"
+                    ) from exc
+
+            if fmt == "yaml":
+                atomic_write(
+                    output_path,
+                    yaml.safe_dump(data, default_flow_style=False, sort_keys=False),
+                )
+            else:
+                atomic_write(output_path, json.dumps(data, indent=2) + "\n")
+
+        logger.info("InlineDispatcher: role=%s phase=%s -> %s", role, phase, output_path)
+
+    def _emit_prompt(
+        self,
+        role: str,
+        phase: str,
+        prompt: str,
+        fmt: str | None,
+        schema_name: str | None,
+        iter_dir: Path,
+        response_path: Path,
+    ) -> None:
+        """Print the prompt and response instructions to stdout."""
+        separator = "=" * 70
+        print(f"\n{separator}", flush=True)
+        print(f"  NOUS INLINE DISPATCH — {role}/{phase}", flush=True)
+        print(f"{separator}\n", flush=True)
+        print(prompt, flush=True)
+        print(f"\n{separator}", flush=True)
+        print(f"  RESPONSE INSTRUCTIONS", flush=True)
+        print(f"{separator}\n", flush=True)
+
+        if phase == "design":
+            print(
+                f"Write your response as files in: {iter_dir}\n\n"
+                f"Required files:\n"
+                f"  {iter_dir}/problem.md    — Problem framing (markdown)\n"
+                f"  {iter_dir}/bundle.yaml   — Hypothesis bundle (YAML)\n"
+                f"  {iter_dir}/handoff.md    — Handoff notes for executor (markdown, optional)\n\n"
+                f"After writing all files, create the signal file:\n"
+                f"  touch {response_path}\n",
+                flush=True,
+            )
+        elif phase == "execute-analyze":
+            print(
+                f"Write your response as files in: {iter_dir}\n\n"
+                f"Required files:\n"
+                f"  {iter_dir}/experiment_plan.yaml  — Experiment plan\n"
+                f"  {iter_dir}/findings.json         — Findings with metrics\n"
+                f"  {iter_dir}/principle_updates.json — Principle updates (list, can be empty [])\n\n"
+                f"After writing all files, create the signal file:\n"
+                f"  touch {response_path}\n",
+                flush=True,
+            )
+        elif fmt is not None:
+            print(
+                f"Write your response to: {response_path}\n\n"
+                f"The response MUST be a ```{fmt}``` code fence containing valid {fmt.upper()}.\n",
+                flush=True,
+            )
+            if schema_name:
+                schema_path = Path(__file__).parent.parent / "schemas" / schema_name
+                if schema_path.exists():
+                    print(f"Schema: {schema_path}\n", flush=True)
+        else:
+            print(
+                f"Write your response (plain text/markdown) to: {response_path}\n",
+                flush=True,
+            )
+
+        print(f"{separator}\n", flush=True)
+
+    def _wait_for_response(
+        self,
+        response_path: Path,
+        output_path: Path,
+        iter_dir: Path,
+        phase: str,
+        t0: float,
+    ) -> str:
+        """Poll for agent response file."""
+        deadline = t0 + self.timeout
+
+        while time.time() < deadline:
+            if phase == "design":
+                bundle_path = iter_dir / "bundle.yaml"
+                problem_path = iter_dir / "problem.md"
+                if bundle_path.exists() and problem_path.exists():
+                    return f"Design artifacts written to {iter_dir}"
+                if response_path.exists():
+                    return f"Design artifacts written to {iter_dir}"
+
+            elif phase == "execute-analyze":
+                findings_path = iter_dir / "findings.json"
+                plan_path = iter_dir / "experiment_plan.yaml"
+                if findings_path.exists() and plan_path.exists():
+                    return f"Execution artifacts written to {iter_dir}"
+                if response_path.exists():
+                    return f"Execution artifacts written to {iter_dir}"
+
+            elif response_path.exists():
+                return response_path.read_text()
+
+            time.sleep(RESPONSE_POLL_INTERVAL_SEC)
+
+        raise RuntimeError(
+            f"Timed out after {self.timeout}s waiting for agent response at {response_path}. "
+            f"The agent should write its response and then touch {response_path}."
+        )
+
+    def _log_inline_metrics(self, role: str, phase: str, t0: float) -> None:
+        """Log basic timing metrics for inline dispatch."""
+        duration_ms = int((time.time() - t0) * 1000)
+        log_metrics(self._metrics_path, {
+            "dispatcher": "inline",
+            "role": role,
+            "phase": phase,
+            "model": "inline-agent",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0,
+            "duration_ms": duration_ms,
+            "num_turns": 1,
+        })

--- a/run_campaign.py
+++ b/run_campaign.py
@@ -4,8 +4,8 @@
 Usage:
     python run_campaign.py examples/campaign.yaml --max-iterations 5
 
-    # Use CLI agent instead of LLM API (no API key needed):
-    python run_campaign.py examples/campaign.yaml --agent cli
+    # Inline mode — embed inside an agent framework:
+    python run_campaign.py examples/campaign.yaml --agent inline
 
 Runs iterations in a loop: each iteration runs the full Nous loop
 (DESIGN → EXECUTE_ANALYZE → DONE), then appends a ledger row
@@ -14,10 +14,9 @@ campaign-level document) and previous findings feed the next iteration's
 design prompt so that each hypothesis bundle is informed by all prior learning.
 
 Dispatch backends:
-    --agent api (default): Requires OPENAI_API_KEY. Uses the OpenAI-compatible
-        LLM API for all non-code phases (gate summaries, reports).
-    --agent cli: All phases dispatched via `claude -p` subprocess. No API key
-        needed — runs within whatever CLI/model pair is available.
+    --agent api (default): Uses CLIDispatcher for code phases (when repo_path
+        is set) and LLMDispatcher for structured phases. OPENAI_API_KEY is
+        optional — gate summaries are skipped if not set.
     --agent inline: Emits prompts to stdout for the calling agent to reason
         about. No subprocess, no API key — the agent that invoked run_campaign.py
         sees the prompt and writes artifacts directly. Ideal for embedded use
@@ -32,7 +31,6 @@ from pathlib import Path
 import jsonschema
 import yaml
 
-from orchestrator.cli_dispatch import CLIDispatcher
 from orchestrator.engine import Engine
 from orchestrator.gates import HumanGate
 from orchestrator.inline_dispatch import InlineDispatcher
@@ -91,10 +89,6 @@ def _generate_report(
         if agent == "inline":
             dispatcher = InlineDispatcher(
                 work_dir=work_dir, campaign=campaign, timeout=timeout,
-            )
-        elif agent == "cli":
-            dispatcher = CLIDispatcher(
-                work_dir=work_dir, campaign=campaign, model=resolved, timeout=timeout,
             )
         else:
             dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model=resolved)
@@ -170,6 +164,7 @@ def run_campaign(
     auto_approve: bool = False,
     timeout: int = 1800,
     agent: str = "api",
+    max_cli_retries: int | None = None,
 ) -> None:
     """Run a multi-iteration Nous campaign.
 
@@ -184,8 +179,9 @@ def run_campaign(
         model: LLM model name.
         auto_approve: If True, all human gates (including continue gate)
             are automatically approved.
-        agent: Dispatch backend — "cli" to use the calling CLI agent,
-            "api" to use the OpenAI-compatible LLM API.
+        agent: Dispatch backend — "inline" emits prompts to stdout,
+            "api" uses the OpenAI-compatible LLM API.
+        max_cli_retries: Max retries for transient claude -p failures (None = unbounded).
     """
     continue_gate = (
         HumanGate(auto_response="approve") if auto_approve else HumanGate()
@@ -208,6 +204,7 @@ def run_campaign(
             outcome = run_iteration(
                 campaign, work_dir, iteration=i, model=model, final=is_last,
                 auto_approve=auto_approve, timeout=timeout, agent=agent,
+                max_cli_retries=max_cli_retries,
             )
 
             if outcome == IterationOutcome.REDESIGN:
@@ -249,11 +246,6 @@ def run_campaign(
             if agent == "inline":
                 dispatcher = InlineDispatcher(
                     work_dir=work_dir, campaign=campaign, timeout=timeout,
-                )
-            elif agent == "cli":
-                dispatcher = CLIDispatcher(
-                    work_dir=work_dir, campaign=campaign,
-                    model=resolved, timeout=timeout,
                 )
             else:
                 dispatcher = LLMDispatcher(
@@ -314,11 +306,12 @@ def main() -> None:
                         help="Auto-approve all human gates (skip interactive prompts)")
     parser.add_argument("--timeout", type=int, default=1800,
                         help="Timeout in seconds for claude -p calls (default: 1800)")
-    parser.add_argument("--agent", choices=["inline", "cli", "api"], default="api",
+    parser.add_argument("--max-cli-retries", type=int, default=10,
+                        help="Max retries for transient claude -p failures (-1 = unbounded, default: 10)")
+    parser.add_argument("--agent", choices=["inline", "api"], default="api",
                         help="Dispatch backend: 'inline' emits prompts to stdout for the "
-                             "calling agent to reason about (no subprocess, no API key), "
-                             "'cli' spawns claude -p subprocesses, "
-                             "'api' calls an OpenAI-compatible LLM API (default: api)")
+                             "calling agent (no subprocess, no API key), "
+                             "'api' uses the LLM API (default: api)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Enable debug logging")
     args = parser.parse_args()
@@ -364,6 +357,7 @@ def main() -> None:
         max_iterations=max_iter, model=args.model,
         auto_approve=args.auto_approve, timeout=args.timeout,
         agent=args.agent,
+        max_cli_retries=None if args.max_cli_retries == -1 else args.max_cli_retries,
     )
 
 

--- a/run_campaign.py
+++ b/run_campaign.py
@@ -4,15 +4,24 @@
 Usage:
     python run_campaign.py examples/campaign.yaml --max-iterations 5
 
+    # Use CLI agent instead of LLM API (no API key needed):
+    python run_campaign.py examples/campaign.yaml --agent cli
+
 Runs iterations in a loop: each iteration runs the full Nous loop
 (DESIGN → EXECUTE_ANALYZE → DONE), then appends a ledger row
 and prompts whether to continue. The designer's handoff.md (a living
 campaign-level document) and previous findings feed the next iteration's
 design prompt so that each hypothesis bundle is informed by all prior learning.
 
-Set your LLM API key before running:
-    export OPENAI_API_KEY=sk-...
-    (or set OPENAI_BASE_URL for a proxy endpoint)
+Dispatch backends:
+    --agent api (default): Requires OPENAI_API_KEY. Uses the OpenAI-compatible
+        LLM API for all non-code phases (gate summaries, reports).
+    --agent cli: All phases dispatched via `claude -p` subprocess. No API key
+        needed — runs within whatever CLI/model pair is available.
+    --agent inline: Emits prompts to stdout for the calling agent to reason
+        about. No subprocess, no API key — the agent that invoked run_campaign.py
+        sees the prompt and writes artifacts directly. Ideal for embedded use
+        inside agent frameworks (e.g., Hive strategist).
 """
 import argparse
 import json
@@ -23,8 +32,10 @@ from pathlib import Path
 import jsonschema
 import yaml
 
+from orchestrator.cli_dispatch import CLIDispatcher
 from orchestrator.engine import Engine
 from orchestrator.gates import HumanGate
+from orchestrator.inline_dispatch import InlineDispatcher
 from orchestrator.ledger import append_ledger_row
 from orchestrator.llm_dispatch import LLMDispatcher
 from orchestrator.metrics import summarize_metrics
@@ -70,11 +81,23 @@ def _write_metrics_summary(work_dir: Path) -> None:
         print(f"\n  Warning: could not write metrics summary: {exc}")
 
 
-def _generate_report(campaign: dict, work_dir: Path, model: str | None) -> None:
+def _generate_report(
+    campaign: dict, work_dir: Path, model: str | None,
+    agent: str = "api", timeout: int = 1800,
+) -> None:
     """Generate report.md summarizing the campaign."""
     try:
         resolved = _resolve_model(campaign, "report", model)
-        dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model=resolved)
+        if agent == "inline":
+            dispatcher = InlineDispatcher(
+                work_dir=work_dir, campaign=campaign, timeout=timeout,
+            )
+        elif agent == "cli":
+            dispatcher = CLIDispatcher(
+                work_dir=work_dir, campaign=campaign, model=resolved, timeout=timeout,
+            )
+        else:
+            dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model=resolved)
         dispatcher.dispatch(
             "extractor", "report",
             output_path=work_dir / "report.md",
@@ -146,7 +169,7 @@ def run_campaign(
     model: str | None = None,
     auto_approve: bool = False,
     timeout: int = 1800,
-    max_cli_retries: int | None = None,
+    agent: str = "api",
 ) -> None:
     """Run a multi-iteration Nous campaign.
 
@@ -161,7 +184,8 @@ def run_campaign(
         model: LLM model name.
         auto_approve: If True, all human gates (including continue gate)
             are automatically approved.
-        max_cli_retries: Max retries for transient claude -p failures (None = unbounded).
+        agent: Dispatch backend — "cli" to use the calling CLI agent,
+            "api" to use the OpenAI-compatible LLM API.
     """
     continue_gate = (
         HumanGate(auto_response="approve") if auto_approve else HumanGate()
@@ -183,8 +207,7 @@ def run_campaign(
 
             outcome = run_iteration(
                 campaign, work_dir, iteration=i, model=model, final=is_last,
-                auto_approve=auto_approve, timeout=timeout,
-                max_cli_retries=max_cli_retries,
+                auto_approve=auto_approve, timeout=timeout, agent=agent,
             )
 
             if outcome == IterationOutcome.REDESIGN:
@@ -200,7 +223,7 @@ def run_campaign(
         if outcome == IterationOutcome.COMPLETED:
             append_ledger_row(work_dir, i)
             print(f"\n  Campaign complete after {i} iteration(s).")
-            _generate_report(campaign, work_dir, model)
+            _generate_report(campaign, work_dir, model, agent=agent, timeout=timeout)
             _write_metrics_summary(work_dir)
             return
 
@@ -222,10 +245,21 @@ def run_campaign(
         # Generate continue gate summary
         gate_summary_path = iter_dir / "gate_summary_continue.json"
         try:
-            dispatcher = LLMDispatcher(
-                work_dir=work_dir, campaign=campaign,
-                model=_resolve_model(campaign, "report", model),
-            )
+            resolved = _resolve_model(campaign, "report", model)
+            if agent == "inline":
+                dispatcher = InlineDispatcher(
+                    work_dir=work_dir, campaign=campaign, timeout=timeout,
+                )
+            elif agent == "cli":
+                dispatcher = CLIDispatcher(
+                    work_dir=work_dir, campaign=campaign,
+                    model=resolved, timeout=timeout,
+                )
+            else:
+                dispatcher = LLMDispatcher(
+                    work_dir=work_dir, campaign=campaign,
+                    model=resolved,
+                )
             dispatcher.dispatch(
                 "summarizer", "summarize-gate",
                 output_path=gate_summary_path,
@@ -249,7 +283,7 @@ def run_campaign(
             engine = Engine(work_dir)
             engine.transition("DONE")
             print(f"\n  Campaign stopped after {i} iteration(s).")
-            _generate_report(campaign, work_dir, model)
+            _generate_report(campaign, work_dir, model, agent=agent, timeout=timeout)
             _write_metrics_summary(work_dir)
             return
 
@@ -260,7 +294,7 @@ def run_campaign(
         print(f"\n  Advancing to iteration {i + 1}...")
 
     print(f"\n  Campaign reached max_iterations ({max_iterations}).")
-    _generate_report(campaign, work_dir, model)
+    _generate_report(campaign, work_dir, model, agent=agent, timeout=timeout)
     _write_metrics_summary(work_dir)
 
 
@@ -280,8 +314,11 @@ def main() -> None:
                         help="Auto-approve all human gates (skip interactive prompts)")
     parser.add_argument("--timeout", type=int, default=1800,
                         help="Timeout in seconds for claude -p calls (default: 1800)")
-    parser.add_argument("--max-cli-retries", type=int, default=10,
-                        help="Max retries for transient claude -p failures (default: 10; 0 to disable; -1 for unlimited)")
+    parser.add_argument("--agent", choices=["inline", "cli", "api"], default="api",
+                        help="Dispatch backend: 'inline' emits prompts to stdout for the "
+                             "calling agent to reason about (no subprocess, no API key), "
+                             "'cli' spawns claude -p subprocesses, "
+                             "'api' calls an OpenAI-compatible LLM API (default: api)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Enable debug logging")
     args = parser.parse_args()
@@ -326,7 +363,7 @@ def main() -> None:
         campaign, work_dir,
         max_iterations=max_iter, model=args.model,
         auto_approve=args.auto_approve, timeout=args.timeout,
-        max_cli_retries=None if args.max_cli_retries == -1 else args.max_cli_retries,
+        agent=args.agent,
     )
 
 

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -4,15 +4,16 @@
 Usage:
     python run_iteration.py examples/campaign.yaml
 
-    # Use CLI agent instead of LLM API (no API key needed):
-    python run_iteration.py examples/campaign.yaml --agent cli
+    # Inline mode — embed inside an agent framework:
+    python run_iteration.py examples/campaign.yaml --agent inline
 
 Creates a working directory named after the target system, copies templates,
 and runs one full iteration with human gates for approval.
 
 Dispatch backends:
-    --agent api (default): Requires OPENAI_API_KEY.
-    --agent cli: All phases dispatched via `claude -p`. No API key needed.
+    --agent api (default): Uses CLIDispatcher for code phases (when repo_path
+        is set) and LLMDispatcher for structured phases. OPENAI_API_KEY is
+        optional — gate summaries are skipped if not set.
     --agent inline: Prompts emitted to stdout for the calling agent.
 """
 import argparse
@@ -237,6 +238,7 @@ def run_iteration(
     auto_approve: bool = False,
     timeout: int = 1800,
     agent: str = "api",
+    max_cli_retries: int | None = None,
 ) -> IterationOutcome:
     """Run a single iteration of the Nous loop.
 
@@ -245,9 +247,10 @@ def run_iteration(
     Args:
         final: If True (default), transitions to DONE after principle merge.
         auto_approve: If True, all human gates are automatically approved.
-        agent: Dispatch backend — "cli" uses CLIDispatcher for all phases,
+        agent: Dispatch backend — "inline" emits prompts to stdout,
             "api" uses LLMDispatcher (with CLIDispatcher for code phases
             when repo_path is set).
+        max_cli_retries: Max retries for transient claude -p failures (None = unbounded).
 
     Returns:
         An IterationOutcome value: COMPLETED, CONTINUE, ABORTED, or REDESIGN.
@@ -272,20 +275,11 @@ def run_iteration(
     from orchestrator.cli_dispatch import CLIDispatcher
     from orchestrator.inline_dispatch import InlineDispatcher
     if agent == "inline":
-        # Inline mode: emit prompts to stdout, agent reasons directly
         inline_dispatcher = InlineDispatcher(
             work_dir=work_dir, campaign=campaign, timeout=timeout,
         )
         cli_dispatcher = inline_dispatcher
         llm_dispatcher = inline_dispatcher
-    elif agent == "cli":
-        # CLI mode: use CLIDispatcher for ALL phases — no LLM API needed
-        cli_dispatcher = CLIDispatcher(
-            work_dir=work_dir, campaign=campaign,
-            model=_model_for("design"), timeout=timeout,
-            max_turns=_max_turns_for("design"),
-        )
-        llm_dispatcher = cli_dispatcher
     else:
         # API mode: CLIDispatcher for code-access roles only (when repo_path is set)
         cli_dispatcher = (
@@ -293,6 +287,7 @@ def run_iteration(
                 work_dir=work_dir, campaign=campaign,
                 model=_model_for("design"), timeout=timeout,
                 max_turns=_max_turns_for("design"),
+                max_retries=max_cli_retries,
             ) if repo_path else None
         )
         llm_dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model=_model_for("design"))
@@ -499,10 +494,11 @@ def main() -> None:
                         help="Auto-approve all human gates (skip interactive prompts)")
     parser.add_argument("--timeout", type=int, default=1800,
                         help="Timeout in seconds for claude -p calls (default: 1800)")
-    parser.add_argument("--agent", choices=["inline", "cli", "api"], default="api",
+    parser.add_argument("--max-cli-retries", type=int, default=10,
+                        help="Max retries for transient claude -p failures (-1 = unbounded, default: 10)")
+    parser.add_argument("--agent", choices=["inline", "api"], default="api",
                         help="Dispatch backend: 'inline' emits prompts to stdout for the "
-                             "calling agent, 'cli' spawns claude -p subprocesses, "
-                             "'api' calls an OpenAI-compatible LLM API (default: api)")
+                             "calling agent, 'api' uses the LLM API (default: api)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Enable debug logging")
     args = parser.parse_args()
@@ -540,6 +536,7 @@ def main() -> None:
         campaign, work_dir, model=args.model,
         auto_approve=args.auto_approve, timeout=args.timeout,
         agent=args.agent,
+        max_cli_retries=None if args.max_cli_retries == -1 else args.max_cli_retries,
     )
 
 

--- a/run_iteration.py
+++ b/run_iteration.py
@@ -4,12 +4,16 @@
 Usage:
     python run_iteration.py examples/campaign.yaml
 
+    # Use CLI agent instead of LLM API (no API key needed):
+    python run_iteration.py examples/campaign.yaml --agent cli
+
 Creates a working directory named after the target system, copies templates,
 and runs one full iteration with human gates for approval.
 
-Set your LLM API key before running:
-    export OPENAI_API_KEY=sk-...
-    (or set OPENAI_BASE_URL for a proxy endpoint)
+Dispatch backends:
+    --agent api (default): Requires OPENAI_API_KEY.
+    --agent cli: All phases dispatched via `claude -p`. No API key needed.
+    --agent inline: Prompts emitted to stdout for the calling agent.
 """
 import argparse
 import json
@@ -232,7 +236,7 @@ def run_iteration(
     final: bool = True,
     auto_approve: bool = False,
     timeout: int = 1800,
-    max_cli_retries: int | None = None,
+    agent: str = "api",
 ) -> IterationOutcome:
     """Run a single iteration of the Nous loop.
 
@@ -241,6 +245,9 @@ def run_iteration(
     Args:
         final: If True (default), transitions to DONE after principle merge.
         auto_approve: If True, all human gates are automatically approved.
+        agent: Dispatch backend — "cli" uses CLIDispatcher for all phases,
+            "api" uses LLMDispatcher (with CLIDispatcher for code phases
+            when repo_path is set).
 
     Returns:
         An IterationOutcome value: COMPLETED, CONTINUE, ABORTED, or REDESIGN.
@@ -262,17 +269,33 @@ def run_iteration(
     def _max_turns_for(phase_key: str) -> int:
         return default_max_turns.get(phase_key, 25)
 
-    # CLIDispatcher for code-access roles; LLMDispatcher for API-only phases
     from orchestrator.cli_dispatch import CLIDispatcher
-    cli_dispatcher = (
-        CLIDispatcher(
+    from orchestrator.inline_dispatch import InlineDispatcher
+    if agent == "inline":
+        # Inline mode: emit prompts to stdout, agent reasons directly
+        inline_dispatcher = InlineDispatcher(
+            work_dir=work_dir, campaign=campaign, timeout=timeout,
+        )
+        cli_dispatcher = inline_dispatcher
+        llm_dispatcher = inline_dispatcher
+    elif agent == "cli":
+        # CLI mode: use CLIDispatcher for ALL phases — no LLM API needed
+        cli_dispatcher = CLIDispatcher(
             work_dir=work_dir, campaign=campaign,
             model=_model_for("design"), timeout=timeout,
             max_turns=_max_turns_for("design"),
-            max_retries=max_cli_retries,
-        ) if repo_path else None
-    )
-    llm_dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model=_model_for("design"))
+        )
+        llm_dispatcher = cli_dispatcher
+    else:
+        # API mode: CLIDispatcher for code-access roles only (when repo_path is set)
+        cli_dispatcher = (
+            CLIDispatcher(
+                work_dir=work_dir, campaign=campaign,
+                model=_model_for("design"), timeout=timeout,
+                max_turns=_max_turns_for("design"),
+            ) if repo_path else None
+        )
+        llm_dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model=_model_for("design"))
     gate = HumanGate(auto_response="approve") if auto_approve else HumanGate()
 
     iter_dir = work_dir / "runs" / f"iter-{iteration}"
@@ -476,8 +499,10 @@ def main() -> None:
                         help="Auto-approve all human gates (skip interactive prompts)")
     parser.add_argument("--timeout", type=int, default=1800,
                         help="Timeout in seconds for claude -p calls (default: 1800)")
-    parser.add_argument("--max-cli-retries", type=int, default=10,
-                        help="Max retries for transient claude -p failures (default: 10; 0 to disable; -1 for unlimited)")
+    parser.add_argument("--agent", choices=["inline", "cli", "api"], default="api",
+                        help="Dispatch backend: 'inline' emits prompts to stdout for the "
+                             "calling agent, 'cli' spawns claude -p subprocesses, "
+                             "'api' calls an OpenAI-compatible LLM API (default: api)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Enable debug logging")
     args = parser.parse_args()
@@ -514,7 +539,7 @@ def main() -> None:
     run_iteration(
         campaign, work_dir, model=args.model,
         auto_approve=args.auto_approve, timeout=args.timeout,
-        max_cli_retries=None if args.max_cli_retries == -1 else args.max_cli_retries,
+        agent=args.agent,
     )
 
 

--- a/tests/test_inline_dispatch.py
+++ b/tests/test_inline_dispatch.py
@@ -1,4 +1,4 @@
-"""Tests for InlineDispatcher — stdout prompt emission and file-polling."""
+"""Tests for InlineDispatcher — stdout prompt emission, file-polling, and dispatch."""
 import json
 import threading
 import time
@@ -54,7 +54,7 @@ class TestInlineDispatcherInit:
 
 
 class TestWaitForResponse:
-    def test_design_phase_detects_artifacts(self, tmp_path):
+    def test_design_phase_signal_with_all_artifacts(self, tmp_path):
         dispatcher = InlineDispatcher(
             work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
         )
@@ -64,13 +64,14 @@ class TestWaitForResponse:
 
         (iter_dir / "problem.md").write_text("# Problem\nTest")
         (iter_dir / "bundle.yaml").write_text("metadata:\n  iteration: 1\n")
+        response_path.touch()
 
         result = dispatcher._wait_for_response(
             response_path, iter_dir / "design_log.md", iter_dir, "design", time.time(),
         )
         assert "Design artifacts" in result
 
-    def test_design_phase_detects_signal_file(self, tmp_path):
+    def test_design_phase_signal_without_artifacts_raises(self, tmp_path):
         dispatcher = InlineDispatcher(
             work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
         )
@@ -79,12 +80,12 @@ class TestWaitForResponse:
         response_path = iter_dir / ".nous_response_planner_design"
         response_path.touch()
 
-        result = dispatcher._wait_for_response(
-            response_path, iter_dir / "design_log.md", iter_dir, "design", time.time(),
-        )
-        assert "Design artifacts" in result
+        with pytest.raises(RuntimeError, match="required design artifacts are missing"):
+            dispatcher._wait_for_response(
+                response_path, iter_dir / "design_log.md", iter_dir, "design", time.time(),
+            )
 
-    def test_execute_analyze_detects_artifacts(self, tmp_path):
+    def test_execute_analyze_signal_with_all_artifacts(self, tmp_path):
         dispatcher = InlineDispatcher(
             work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
         )
@@ -94,11 +95,30 @@ class TestWaitForResponse:
 
         (iter_dir / "findings.json").write_text('{"iteration": 1}')
         (iter_dir / "experiment_plan.yaml").write_text("steps: []\n")
+        (iter_dir / "principle_updates.json").write_text("[]")
+        response_path.touch()
 
         result = dispatcher._wait_for_response(
             response_path, iter_dir / "output.md", iter_dir, "execute-analyze", time.time(),
         )
         assert "Execution artifacts" in result
+
+    def test_execute_analyze_missing_principle_updates_raises(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_executor_execute_analyze"
+
+        (iter_dir / "findings.json").write_text('{"iteration": 1}')
+        (iter_dir / "experiment_plan.yaml").write_text("steps: []\n")
+        response_path.touch()
+
+        with pytest.raises(RuntimeError, match="principle_updates.json"):
+            dispatcher._wait_for_response(
+                response_path, iter_dir / "output.md", iter_dir, "execute-analyze", time.time(),
+            )
 
     def test_structured_phase_reads_response_file(self, tmp_path):
         dispatcher = InlineDispatcher(
@@ -113,6 +133,28 @@ class TestWaitForResponse:
             response_path, iter_dir / "gate_summary.json", iter_dir, "summarize-gate", time.time(),
         )
         assert "decision" in result
+
+    def test_structured_phase_skips_empty_file(self, tmp_path):
+        """Empty response file should not be returned — wait for content."""
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=2,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_summarizer_report"
+
+        def _write_late():
+            response_path.write_text("")
+            time.sleep(0.3)
+            response_path.write_text("Real content")
+
+        threading.Thread(target=_write_late, daemon=True).start()
+
+        with patch("orchestrator.inline_dispatch.RESPONSE_POLL_INTERVAL_SEC", 0.1):
+            result = dispatcher._wait_for_response(
+                response_path, iter_dir / "report.md", iter_dir, "report", time.time(),
+            )
+        assert result == "Real content"
 
     def test_timeout_raises(self, tmp_path):
         dispatcher = InlineDispatcher(
@@ -149,6 +191,71 @@ class TestWaitForResponse:
         assert result == "Late response content"
 
 
+class TestCleanStaleArtifacts:
+    def test_design_artifacts_cleaned(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        for name in ("problem.md", "bundle.yaml", "handoff.md"):
+            (iter_dir / name).write_text("stale")
+
+        InlineDispatcher._clean_stale_artifacts(iter_dir, "design")
+
+        for name in ("problem.md", "bundle.yaml", "handoff.md"):
+            assert not (iter_dir / name).exists()
+
+    def test_execute_artifacts_cleaned(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        for name in ("experiment_plan.yaml", "findings.json", "principle_updates.json"):
+            (iter_dir / name).write_text("stale")
+
+        InlineDispatcher._clean_stale_artifacts(iter_dir, "execute-analyze")
+
+        for name in ("experiment_plan.yaml", "findings.json", "principle_updates.json"):
+            assert not (iter_dir / name).exists()
+
+    def test_other_phase_does_not_clean(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        (iter_dir / "problem.md").write_text("keep")
+
+        InlineDispatcher._clean_stale_artifacts(iter_dir, "summarize-gate")
+
+        assert (iter_dir / "problem.md").exists()
+
+
+class TestCheckArtifacts:
+    def test_check_design_all_present(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        (iter_dir / "problem.md").write_text("ok")
+        (iter_dir / "bundle.yaml").write_text("ok")
+        assert InlineDispatcher._check_design_artifacts(iter_dir) == []
+
+    def test_check_design_missing(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        missing = InlineDispatcher._check_design_artifacts(iter_dir)
+        assert "problem.md" in missing
+        assert "bundle.yaml" in missing
+
+    def test_check_execute_all_present(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        (iter_dir / "experiment_plan.yaml").write_text("ok")
+        (iter_dir / "findings.json").write_text("ok")
+        (iter_dir / "principle_updates.json").write_text("ok")
+        assert InlineDispatcher._check_execute_artifacts(iter_dir) == []
+
+    def test_check_execute_missing_principle_updates(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        (iter_dir / "experiment_plan.yaml").write_text("ok")
+        (iter_dir / "findings.json").write_text("ok")
+        missing = InlineDispatcher._check_execute_artifacts(iter_dir)
+        assert "principle_updates.json" in missing
+
+
 class TestEmitPrompt:
     def test_design_prompt_mentions_required_files(self, tmp_path, capsys):
         dispatcher = InlineDispatcher(
@@ -166,7 +273,7 @@ class TestEmitPrompt:
         assert "bundle.yaml" in captured
         assert "touch" in captured
 
-    def test_execute_analyze_prompt_mentions_required_files(self, tmp_path, capsys):
+    def test_execute_analyze_prompt_mentions_all_required_files(self, tmp_path, capsys):
         dispatcher = InlineDispatcher(
             work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN,
         )
@@ -180,6 +287,7 @@ class TestEmitPrompt:
         captured = capsys.readouterr().out
         assert "findings.json" in captured
         assert "experiment_plan.yaml" in captured
+        assert "principle_updates.json" in captured
 
     def test_structured_prompt_mentions_format(self, tmp_path, capsys):
         dispatcher = InlineDispatcher(
@@ -198,33 +306,103 @@ class TestEmitPrompt:
         assert str(response_path) in captured
 
 
+class TestDispatchEndToEnd:
+    """Integration tests for dispatch() — the full prompt-emit-poll-write cycle."""
+
+    def test_dispatch_design_writes_output(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        output_path = iter_dir / "design_log.md"
+        response_path = iter_dir / ".nous_response_planner_design"
+
+        def _simulate_agent():
+            time.sleep(0.2)
+            (iter_dir / "problem.md").write_text("# Problem\nTest problem")
+            (iter_dir / "bundle.yaml").write_text("metadata:\n  iteration: 1\n")
+            response_path.touch()
+
+        threading.Thread(target=_simulate_agent, daemon=True).start()
+
+        with patch.object(dispatcher, "_route", return_value=("design.md.j2", None, None)):
+            with patch.object(dispatcher.loader, "load", return_value="Test design prompt"):
+                with patch("orchestrator.inline_dispatch.RESPONSE_POLL_INTERVAL_SEC", 0.1):
+                    dispatcher.dispatch(
+                        "planner", "design",
+                        output_path=output_path, iteration=1,
+                    )
+
+        assert output_path.exists()
+        assert "Design artifacts" in output_path.read_text()
+
+    def test_dispatch_structured_phase_validates_and_writes(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        output_path = iter_dir / "gate_summary.json"
+        response_path = iter_dir / ".nous_response_summarizer_summarize_gate"
+
+        gate_response = '```json\n{"recommendation": "continue", "reasoning": "test"}\n```'
+
+        def _simulate_agent():
+            time.sleep(0.2)
+            response_path.write_text(gate_response)
+
+        threading.Thread(target=_simulate_agent, daemon=True).start()
+
+        with patch.object(dispatcher, "_route", return_value=("summarize-gate.md.j2", "json", None)):
+            with patch.object(dispatcher.loader, "load", return_value="Summarize this"):
+                with patch("orchestrator.inline_dispatch.RESPONSE_POLL_INTERVAL_SEC", 0.1):
+                    dispatcher.dispatch(
+                        "summarizer", "summarize-gate",
+                        output_path=output_path, iteration=1,
+                    )
+
+        assert output_path.exists()
+        data = json.loads(output_path.read_text())
+        assert data["recommendation"] == "continue"
+
+    def test_dispatch_cleans_stale_artifacts(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        output_path = iter_dir / "design_log.md"
+        response_path = iter_dir / ".nous_response_planner_design"
+
+        (iter_dir / "problem.md").write_text("stale from previous run")
+        (iter_dir / "bundle.yaml").write_text("stale from previous run")
+
+        def _simulate_agent():
+            time.sleep(0.3)
+            (iter_dir / "problem.md").write_text("# Fresh problem")
+            (iter_dir / "bundle.yaml").write_text("metadata:\n  iteration: 1\n")
+            response_path.touch()
+
+        threading.Thread(target=_simulate_agent, daemon=True).start()
+
+        with patch.object(dispatcher, "_route", return_value=("design.md.j2", None, None)):
+            with patch.object(dispatcher.loader, "load", return_value="Test prompt"):
+                with patch("orchestrator.inline_dispatch.RESPONSE_POLL_INTERVAL_SEC", 0.1):
+                    dispatcher.dispatch(
+                        "planner", "design",
+                        output_path=output_path, iteration=1,
+                    )
+
+        assert (iter_dir / "problem.md").read_text() == "# Fresh problem"
+
+
 class TestAgentRouting:
     """Test that --agent flag correctly routes to the right dispatcher type."""
 
     @patch("run_iteration.Engine")
     @patch("run_iteration.HumanGate")
-    def test_cli_mode_uses_cli_dispatcher_for_all(self, mock_gate, mock_engine, tmp_path):
-        from orchestrator.cli_dispatch import CLIDispatcher
-        from run_iteration import run_iteration
-
-        mock_engine_inst = MagicMock()
-        mock_engine_inst.phase = "DONE"
-        mock_engine.return_value = mock_engine_inst
-
-        campaign = SAMPLE_CAMPAIGN.copy()
-        work_dir = tmp_path
-        (work_dir / "state.json").write_text('{"phase": "DONE"}')
-
-        result = run_iteration(
-            campaign, work_dir, iteration=1, agent="cli", auto_approve=True,
-        )
-        # DONE phase means early return — we just verify it didn't crash
-        assert result is not None
-
-    @patch("run_iteration.Engine")
-    @patch("run_iteration.HumanGate")
     def test_inline_mode_uses_inline_dispatcher(self, mock_gate, mock_engine, tmp_path):
-        from orchestrator.inline_dispatch import InlineDispatcher
         from run_iteration import run_iteration
 
         mock_engine_inst = MagicMock()
@@ -258,3 +436,51 @@ class TestAgentRouting:
             campaign, work_dir, iteration=1, agent="api", auto_approve=True,
         )
         assert result is not None
+
+    @patch("orchestrator.llm_dispatch.openai")
+    @patch("run_iteration.Engine")
+    @patch("run_iteration.HumanGate")
+    def test_api_mode_accepts_max_cli_retries(self, mock_gate, mock_engine, mock_openai, tmp_path):
+        from run_iteration import run_iteration
+
+        mock_engine_inst = MagicMock()
+        mock_engine_inst.phase = "DONE"
+        mock_engine.return_value = mock_engine_inst
+
+        campaign = SAMPLE_CAMPAIGN.copy()
+        work_dir = tmp_path
+        (work_dir / "state.json").write_text('{"phase": "DONE"}')
+
+        result = run_iteration(
+            campaign, work_dir, iteration=1, agent="api",
+            auto_approve=True, max_cli_retries=5,
+        )
+        assert result is not None
+
+
+class TestRunCampaignRouting:
+    """Test that run_campaign.py correctly routes --agent and --max-cli-retries."""
+
+    @patch("run_campaign.run_iteration")
+    @patch("run_campaign._resume_completed_campaign", return_value=1)
+    @patch("run_campaign.append_ledger_row")
+    @patch("run_campaign._generate_report")
+    def test_campaign_passes_agent_and_retries(
+        self, mock_report, mock_ledger, mock_resume, mock_run_iter, tmp_path,
+    ):
+        from run_campaign import run_campaign
+        from run_iteration import IterationOutcome
+
+        mock_run_iter.return_value = IterationOutcome.COMPLETED
+
+        campaign = SAMPLE_CAMPAIGN.copy()
+
+        run_campaign(
+            campaign, tmp_path,
+            max_iterations=1, auto_approve=True,
+            agent="inline", max_cli_retries=3,
+        )
+
+        call_kwargs = mock_run_iter.call_args[1] if mock_run_iter.call_args[1] else {}
+        assert call_kwargs.get("agent") == "inline"
+        assert call_kwargs.get("max_cli_retries") == 3

--- a/tests/test_inline_dispatch.py
+++ b/tests/test_inline_dispatch.py
@@ -1,0 +1,260 @@
+"""Tests for InlineDispatcher — stdout prompt emission and file-polling."""
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from orchestrator.inline_dispatch import InlineDispatcher
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+
+
+def _make_campaign(repo_path: str = "/tmp/fake-repo") -> dict:
+    return {
+        "research_question": "Does batch size affect latency?",
+        "target_system": {
+            "name": "TestSystem",
+            "description": "A test system.",
+            "repo_path": repo_path,
+        },
+        "prompts": {
+            "methodology_layer": "prompts/methodology",
+            "domain_adapter_layer": None,
+        },
+    }
+
+
+SAMPLE_CAMPAIGN = _make_campaign()
+
+
+class TestInlineDispatcherInit:
+    def test_init_sets_timeout(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=60,
+        )
+        assert dispatcher.timeout == 60
+
+    def test_init_default_model_is_inline(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN,
+        )
+        assert dispatcher.model == "inline"
+
+    def test_completion_fn_raises(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN,
+        )
+        with pytest.raises(RuntimeError, match="does not use the completion API"):
+            dispatcher._completion(messages=[])
+
+
+class TestWaitForResponse:
+    def test_design_phase_detects_artifacts(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_planner_design"
+
+        (iter_dir / "problem.md").write_text("# Problem\nTest")
+        (iter_dir / "bundle.yaml").write_text("metadata:\n  iteration: 1\n")
+
+        result = dispatcher._wait_for_response(
+            response_path, iter_dir / "design_log.md", iter_dir, "design", time.time(),
+        )
+        assert "Design artifacts" in result
+
+    def test_design_phase_detects_signal_file(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_planner_design"
+        response_path.touch()
+
+        result = dispatcher._wait_for_response(
+            response_path, iter_dir / "design_log.md", iter_dir, "design", time.time(),
+        )
+        assert "Design artifacts" in result
+
+    def test_execute_analyze_detects_artifacts(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_executor_execute_analyze"
+
+        (iter_dir / "findings.json").write_text('{"iteration": 1}')
+        (iter_dir / "experiment_plan.yaml").write_text("steps: []\n")
+
+        result = dispatcher._wait_for_response(
+            response_path, iter_dir / "output.md", iter_dir, "execute-analyze", time.time(),
+        )
+        assert "Execution artifacts" in result
+
+    def test_structured_phase_reads_response_file(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=5,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_summarizer_summarize_gate"
+        response_path.write_text('```json\n{"decision": "continue"}\n```')
+
+        result = dispatcher._wait_for_response(
+            response_path, iter_dir / "gate_summary.json", iter_dir, "summarize-gate", time.time(),
+        )
+        assert "decision" in result
+
+    def test_timeout_raises(self, tmp_path):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=1,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_planner_design"
+
+        with pytest.raises(RuntimeError, match="Timed out"):
+            dispatcher._wait_for_response(
+                response_path, iter_dir / "design_log.md", iter_dir, "design", time.time() - 2,
+            )
+
+    def test_polling_picks_up_late_file(self, tmp_path):
+        """File appears after a short delay — polling should find it."""
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN, timeout=10,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_summarizer_report"
+
+        def _write_late():
+            time.sleep(0.5)
+            response_path.write_text("Late response content")
+
+        threading.Thread(target=_write_late, daemon=True).start()
+
+        with patch("orchestrator.inline_dispatch.RESPONSE_POLL_INTERVAL_SEC", 0.1):
+            result = dispatcher._wait_for_response(
+                response_path, iter_dir / "report.md", iter_dir, "report", time.time(),
+            )
+        assert result == "Late response content"
+
+
+class TestEmitPrompt:
+    def test_design_prompt_mentions_required_files(self, tmp_path, capsys):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_planner_design"
+
+        dispatcher._emit_prompt(
+            "planner", "design", "Test prompt", None, None, iter_dir, response_path,
+        )
+        captured = capsys.readouterr().out
+        assert "problem.md" in captured
+        assert "bundle.yaml" in captured
+        assert "touch" in captured
+
+    def test_execute_analyze_prompt_mentions_required_files(self, tmp_path, capsys):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_executor_execute_analyze"
+
+        dispatcher._emit_prompt(
+            "executor", "execute-analyze", "Test prompt", None, None, iter_dir, response_path,
+        )
+        captured = capsys.readouterr().out
+        assert "findings.json" in captured
+        assert "experiment_plan.yaml" in captured
+
+    def test_structured_prompt_mentions_format(self, tmp_path, capsys):
+        dispatcher = InlineDispatcher(
+            work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN,
+        )
+        iter_dir = tmp_path / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        response_path = iter_dir / ".nous_response_summarizer_gate"
+
+        dispatcher._emit_prompt(
+            "summarizer", "summarize-gate", "Test prompt", "json", "gate_summary.schema.json",
+            iter_dir, response_path,
+        )
+        captured = capsys.readouterr().out
+        assert "json" in captured.lower()
+        assert str(response_path) in captured
+
+
+class TestAgentRouting:
+    """Test that --agent flag correctly routes to the right dispatcher type."""
+
+    @patch("run_iteration.Engine")
+    @patch("run_iteration.HumanGate")
+    def test_cli_mode_uses_cli_dispatcher_for_all(self, mock_gate, mock_engine, tmp_path):
+        from orchestrator.cli_dispatch import CLIDispatcher
+        from run_iteration import run_iteration
+
+        mock_engine_inst = MagicMock()
+        mock_engine_inst.phase = "DONE"
+        mock_engine.return_value = mock_engine_inst
+
+        campaign = SAMPLE_CAMPAIGN.copy()
+        work_dir = tmp_path
+        (work_dir / "state.json").write_text('{"phase": "DONE"}')
+
+        result = run_iteration(
+            campaign, work_dir, iteration=1, agent="cli", auto_approve=True,
+        )
+        # DONE phase means early return — we just verify it didn't crash
+        assert result is not None
+
+    @patch("run_iteration.Engine")
+    @patch("run_iteration.HumanGate")
+    def test_inline_mode_uses_inline_dispatcher(self, mock_gate, mock_engine, tmp_path):
+        from orchestrator.inline_dispatch import InlineDispatcher
+        from run_iteration import run_iteration
+
+        mock_engine_inst = MagicMock()
+        mock_engine_inst.phase = "DONE"
+        mock_engine.return_value = mock_engine_inst
+
+        campaign = SAMPLE_CAMPAIGN.copy()
+        work_dir = tmp_path
+        (work_dir / "state.json").write_text('{"phase": "DONE"}')
+
+        result = run_iteration(
+            campaign, work_dir, iteration=1, agent="inline", auto_approve=True,
+        )
+        assert result is not None
+
+    @patch("orchestrator.llm_dispatch.openai")
+    @patch("run_iteration.Engine")
+    @patch("run_iteration.HumanGate")
+    def test_api_mode_uses_llm_dispatcher(self, mock_gate, mock_engine, mock_openai, tmp_path):
+        from run_iteration import run_iteration
+
+        mock_engine_inst = MagicMock()
+        mock_engine_inst.phase = "DONE"
+        mock_engine.return_value = mock_engine_inst
+
+        campaign = SAMPLE_CAMPAIGN.copy()
+        work_dir = tmp_path
+        (work_dir / "state.json").write_text('{"phase": "DONE"}')
+
+        result = run_iteration(
+            campaign, work_dir, iteration=1, agent="api", auto_approve=True,
+        )
+        assert result is not None


### PR DESCRIPTION
## Summary

- Adds `--agent inline` flag to both `run_campaign.py` and `run_iteration.py`
- When `--agent inline`: prompts emitted to stdout for the calling agent to reason about directly — no subprocess, no API key. Designed for embedded use inside agent frameworks (e.g., Hive strategist)
- When `--agent api` (default): unchanged behavior — CLIDispatcher for code phases (when repo_path is set), LLMDispatcher for structured phases

## Changes from v1 (addressing review feedback)

All 7 items from [review feedback](https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/pull/70#issuecomment-4454678878) addressed:

1. **Simplified to inline-only** — Dropped `--agent cli` (redundant after PR #74 made `OPENAI_API_KEY` optional). Now just `--agent inline|api`.
2. **Linked issue** — Created #79 to track the motivation. PR now has `Fixes #79`.
3. **Fixed stale artifact detection** — `_clean_stale_artifacts()` removes leftover files before dispatch. Polling relies solely on the signal file.
4. **Fixed signal-without-artifacts** — `_check_design_artifacts()` and `_check_execute_artifacts()` verify all required files exist when the signal file is touched. Clear error if any are missing.
5. **Fixed `principle_updates.json` not checked** — Now included in `_check_execute_artifacts()` validation (was previously missing from the 2-of-3 check).
6. **Fixed response file race condition** — Structured phase polling skips empty files, waits for non-empty content before returning.
7. **Restored `--max-cli-retries`** — Flag was removed in v1, now restored for the `--agent api` path which still creates CLIDispatcher.
8. **Added missing tests** — `dispatch()` end-to-end tests, `run_campaign` routing tests. Test count: 15 → 28.
9. **Rebased onto main** — Clean rebase including #71 (retry logic) and #74 (optional API key).

## Related Issue

Fixes #79

## Test Plan

- [x] All 28 inline dispatch tests pass
- [x] Full suite: 305 tests pass
- [x] `--agent inline` routing verified
- [x] `--agent api` with `--max-cli-retries` verified
- [x] Stale artifact cleanup verified
- [x] Signal-without-artifacts raises clear error
- [x] Empty response file race condition handled

🤖 Generated with [Claude Code](https://claude.ai/claude-code)