### PR TITLE
fix: resume mid-flight campaign at correct iteration after timeout

### DIFF
--- a/run_campaign.py
+++ b/run_campaign.py
@@ -86,24 +86,30 @@ def _generate_report(campaign: dict, work_dir: Path, model: str | None) -> None:
 
 
 def _resume_completed_campaign(work_dir: Path, max_iterations: int) -> int:
-    """Decide whether to resume a DONE campaign and, if so, advance it.
+    """Decide where to resume a campaign and, if DONE, advance it.
 
-    Resumes (transitions state DONE -> DESIGN and returns the next iteration
-    number) only when all of:
-      * state.phase == "DONE"
-      * ledger.json exists and parses
-      * the ledger has at least one real iteration row (iteration >= 1)
-      * completed iterations < max_iterations
+    Returns the iteration number to start the campaign loop from:
+      * INIT (fresh):     1
+      * Mid-flight:       engine.iteration (resume in-progress iteration)
+      * DONE (finished):  completed + 1 after transitioning DONE -> DESIGN,
+                          provided completed < max_iterations; else 1
 
-    In every other case — fresh campaign, mid-flight campaign, empty/corrupt
-    ledger, or already at max_iterations — returns 1 and leaves state
-    untouched. A corrupt ledger is logged at warning level so the user can
-    repair it; it never raises.
+    A corrupt ledger is logged at warning level; it never raises.
     """
     from orchestrator.engine import Engine
 
     engine = Engine(work_dir)
-    if engine.phase != "DONE":
+
+    # Mid-flight: resume the in-progress iteration
+    if engine.phase not in ("INIT", "DONE"):
+        start = engine.iteration
+        print(
+            f"  Resuming mid-flight campaign at iteration {start} "
+            f"(phase={engine.phase}, max_iterations={max_iterations})"
+        )
+        return start
+
+    if engine.phase == "INIT":
         return 1
 
     ledger_path = work_dir / "ledger.json"

--- a/run_campaign.py
+++ b/run_campaign.py
@@ -103,9 +103,22 @@ def _resume_completed_campaign(work_dir: Path, max_iterations: int) -> int:
     # Mid-flight: resume the in-progress iteration
     if engine.phase not in ("INIT", "DONE"):
         start = engine.iteration
-        print(
-            f"  Resuming mid-flight campaign at iteration {start} "
-            f"(phase={engine.phase}, max_iterations={max_iterations})"
+        if start < 1:
+            logger.warning(
+                "state.json has iteration=%d (< 1); starting fresh.", start,
+            )
+            return 1
+        if start > max_iterations:
+            logger.warning(
+                "Mid-flight iteration %d exceeds max_iterations=%d; "
+                "raise max_iterations to resume this campaign.",
+                start, max_iterations,
+            )
+            return start
+        logger.info(
+            "Resuming mid-flight campaign at iteration %d "
+            "(phase=%s, max_iterations=%d)",
+            start, engine.phase, max_iterations,
         )
         return start
 

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -201,12 +201,42 @@ class TestResumeCompletedCampaign:
     when the caller raises max_iterations."""
 
     def test_fresh_campaign_returns_iteration_1(self, tmp_path):
-        """With phase != DONE, function is a no-op returning 1."""
+        """Phase INIT (fresh) returns 1, state untouched."""
         from run_campaign import _resume_completed_campaign
         work_dir = _setup_work_dir(tmp_path)
         # Default state.json phase is INIT
         assert _resume_completed_campaign(work_dir, max_iterations=5) == 1
         assert Engine(work_dir).phase == "INIT"  # untouched
+
+    def test_mid_flight_design_resumes_at_correct_iteration(self, tmp_path):
+        """Mid-flight DESIGN phase returns engine.iteration without touching state."""
+        from run_campaign import _resume_completed_campaign
+        work_dir = _setup_work_dir(tmp_path)
+        state = json.loads((work_dir / "state.json").read_text())
+        state["phase"] = "DESIGN"
+        state["iteration"] = 16
+        (work_dir / "state.json").write_text(json.dumps(state))
+
+        result = _resume_completed_campaign(work_dir, max_iterations=20)
+        assert result == 16
+        engine = Engine(work_dir)
+        assert engine.phase == "DESIGN"   # untouched
+        assert engine.iteration == 16
+
+    def test_mid_flight_execute_analyze_resumes_at_correct_iteration(self, tmp_path):
+        """Mid-flight EXECUTE_ANALYZE phase returns engine.iteration without touching state."""
+        from run_campaign import _resume_completed_campaign
+        work_dir = _setup_work_dir(tmp_path)
+        state = json.loads((work_dir / "state.json").read_text())
+        state["phase"] = "EXECUTE_ANALYZE"
+        state["iteration"] = 5
+        (work_dir / "state.json").write_text(json.dumps(state))
+
+        result = _resume_completed_campaign(work_dir, max_iterations=10)
+        assert result == 5
+        engine = Engine(work_dir)
+        assert engine.phase == "EXECUTE_ANALYZE"  # untouched
+        assert engine.iteration == 5
 
     def test_done_with_more_iterations_configured_resumes(self, tmp_path):
         """Phase DONE + ledger shows iter 1 + max_iterations=2 -> transition to

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -238,6 +238,50 @@ class TestResumeCompletedCampaign:
         assert engine.phase == "EXECUTE_ANALYZE"  # untouched
         assert engine.iteration == 5
 
+    def test_mid_flight_iteration_1_boundary(self, tmp_path):
+        """Mid-flight at iteration=1 returns 1 (boundary where old and new code agree)."""
+        from run_campaign import _resume_completed_campaign
+        work_dir = _setup_work_dir(tmp_path)
+        state = json.loads((work_dir / "state.json").read_text())
+        state["phase"] = "DESIGN"
+        state["iteration"] = 1
+        (work_dir / "state.json").write_text(json.dumps(state))
+
+        result = _resume_completed_campaign(work_dir, max_iterations=5)
+        assert result == 1
+        engine = Engine(work_dir)
+        assert engine.phase == "DESIGN"  # untouched
+
+    def test_mid_flight_corrupt_iteration_falls_back_to_1(self, tmp_path, caplog):
+        """Mid-flight with iteration < 1 in state.json falls back to 1 with a warning."""
+        import logging
+        from run_campaign import _resume_completed_campaign
+        work_dir = _setup_work_dir(tmp_path)
+        state = json.loads((work_dir / "state.json").read_text())
+        state["phase"] = "DESIGN"
+        state["iteration"] = 0
+        (work_dir / "state.json").write_text(json.dumps(state))
+
+        with caplog.at_level(logging.WARNING):
+            result = _resume_completed_campaign(work_dir, max_iterations=5)
+        assert result == 1
+        assert any("iteration=0" in r.message for r in caplog.records)
+
+    def test_mid_flight_exceeds_max_iterations_warns(self, tmp_path, caplog):
+        """Mid-flight iteration > max_iterations logs a warning and returns start."""
+        import logging
+        from run_campaign import _resume_completed_campaign
+        work_dir = _setup_work_dir(tmp_path)
+        state = json.loads((work_dir / "state.json").read_text())
+        state["phase"] = "DESIGN"
+        state["iteration"] = 16
+        (work_dir / "state.json").write_text(json.dumps(state))
+
+        with caplog.at_level(logging.WARNING):
+            result = _resume_completed_campaign(work_dir, max_iterations=5)
+        assert result == 16
+        assert any("max_iterations" in r.message for r in caplog.records)
+
     def test_done_with_more_iterations_configured_resumes(self, tmp_path):
         """Phase DONE + ledger shows iter 1 + max_iterations=2 -> transition to
         DESIGN and return 2."""


### PR DESCRIPTION
Fixes #90

## Summary

- `_resume_completed_campaign` returned `1` for any non-DONE phase, so a campaign interrupted mid-iteration (timeout, kill signal, etc.) always restarted the loop at `i=1`
- Artifacts landed in `iter-1/` instead of the interrupted `iter-N/`, and the engine's phase was applied to the wrong iteration
- Fix: detect mid-flight phases (not `INIT`, not `DONE`) and return `engine.iteration` directly, leaving `state.json` untouched so `_enter_phase` resumes from the correct phase

## Test plan

- [ ] `TestResumeCompletedCampaign::test_mid_flight_design_resumes_at_correct_iteration` — DESIGN phase at iter 16 returns 16, state untouched
- [ ] `TestResumeCompletedCampaign::test_mid_flight_execute_analyze_resumes_at_correct_iteration` — EXECUTE_ANALYZE phase at iter 5 returns 5, state untouched
- [ ] All existing `TestResumeCompletedCampaign` tests still pass (INIT, DONE, corrupt ledger cases unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)