### PR TITLE
fix: retry on subprocess timeout (e.g. LiteLLM auth failure)

### DIFF
--- a/orchestrator/cli_dispatch.py
+++ b/orchestrator/cli_dispatch.py
@@ -49,6 +49,10 @@ class _TransientCLIError(RuntimeError):
     """Raised internally by _call_claude_once when the failure is transient."""
 
 
+class _TransientTimeoutError(_TransientCLIError):
+    """Raised when claude -p times out; tracked separately for a tighter retry cap."""
+
+
 def _is_transient(response_json: dict | None, stderr: str = "") -> bool:
     """Return True if the claude -p failure looks like a transient transport error."""
     if response_json is not None:
@@ -94,6 +98,7 @@ class CLIDispatcher(LLMDispatcher):
         timeout: int = 1800,
         max_turns: int = 25,
         max_retries: int | None = 10,
+        max_timeout_retries: int = 2,
     ) -> None:
         super().__init__(
             work_dir=work_dir,
@@ -107,6 +112,7 @@ class CLIDispatcher(LLMDispatcher):
         self.timeout = timeout
         self.max_turns = max_turns
         self.max_retries = max_retries
+        self.max_timeout_retries = max_timeout_retries
         repo_path = campaign.get("target_system", {}).get("repo_path")
         self._cwd = Path(repo_path) if repo_path else None
 
@@ -234,9 +240,28 @@ class CLIDispatcher(LLMDispatcher):
         print(f"    Waiting for claude -p ({self.model}, max_turns={turns})...", flush=True)
 
         failure_count = 0
+        timeout_count = 0
         while True:
             try:
                 return self._call_claude_once(cmd, prompt, cwd)
+            except _TransientTimeoutError as exc:
+                timeout_count += 1
+                if timeout_count > self.max_timeout_retries:
+                    raise RuntimeError(
+                        f"claude -p timed out after {self.timeout}s "
+                        f"({timeout_count} time(s)); giving up."
+                    ) from exc
+                delay = _backoff_for(timeout_count)
+                logger.error(
+                    "claude -p timed out (attempt %d/%d) — retrying in %.0fs",
+                    timeout_count, self.max_timeout_retries, delay,
+                )
+                print(
+                    f"    claude -p timed out (attempt {timeout_count}/{self.max_timeout_retries}); "
+                    f"retrying in {delay:.0f}s...",
+                    flush=True,
+                )
+                time.sleep(delay)
             except _TransientCLIError as exc:
                 failure_count += 1
                 if self.max_retries is not None and failure_count > self.max_retries:
@@ -271,16 +296,9 @@ class CLIDispatcher(LLMDispatcher):
                 "claude CLI not found. Install Claude Code: "
                 "https://docs.anthropic.com/en/docs/claude-code"
             )
-        except subprocess.TimeoutExpired as exc:
-            # Treat as transient — a timeout is often caused by an upstream
-            # authentication or network issue that may resolve on retry.
-            stderr_snippet = ""
-            if exc.stderr:
-                chunk = exc.stderr if isinstance(exc.stderr, str) else exc.stderr.decode("utf-8", errors="replace")
-                stderr_snippet = chunk[-500:]
-            raise _TransientCLIError(
+        except subprocess.TimeoutExpired:
+            raise _TransientTimeoutError(
                 f"claude -p timed out after {self.timeout}s."
-                + (f" stderr: {stderr_snippet}" if stderr_snippet else "")
             )
 
         if result.returncode != 0:

--- a/orchestrator/cli_dispatch.py
+++ b/orchestrator/cli_dispatch.py
@@ -271,9 +271,16 @@ class CLIDispatcher(LLMDispatcher):
                 "claude CLI not found. Install Claude Code: "
                 "https://docs.anthropic.com/en/docs/claude-code"
             )
-        except subprocess.TimeoutExpired:
-            raise RuntimeError(
+        except subprocess.TimeoutExpired as exc:
+            # Treat as transient — a timeout is often caused by an upstream
+            # authentication or network issue that may resolve on retry.
+            stderr_snippet = ""
+            if exc.stderr:
+                chunk = exc.stderr if isinstance(exc.stderr, str) else exc.stderr.decode("utf-8", errors="replace")
+                stderr_snippet = chunk[-500:]
+            raise _TransientCLIError(
                 f"claude -p timed out after {self.timeout}s."
+                + (f" stderr: {stderr_snippet}" if stderr_snippet else "")
             )
 
         if result.returncode != 0:

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -563,7 +563,7 @@ class TestCLIDispatcherRetry:
     def test_timeout_retries_then_succeeds(
         self, work_dir: Path, campaign: dict, fast_sleep,
     ) -> None:
-        """subprocess.TimeoutExpired is treated as transient and retried."""
+        """subprocess.TimeoutExpired is retried up to max_timeout_retries times."""
         import subprocess
         from orchestrator.cli_dispatch import CLIDispatcher
 
@@ -574,16 +574,16 @@ class TestCLIDispatcherRetry:
                 _success_result("# Design\nStub."),
             ],
         ) as mock_run:
-            d = CLIDispatcher(work_dir=work_dir, campaign=campaign)
+            d = CLIDispatcher(work_dir=work_dir, campaign=campaign, max_timeout_retries=2)
             d.dispatch("planner", "design", output_path=work_dir / "out.md", iteration=1)
 
         assert mock_run.call_count == 2
-        fast_sleep.assert_called_once()
+        fast_sleep.assert_called_once_with(5)  # _backoff_for(1) == 5s
 
-    def test_timeout_exhausts_max_retries(
+    def test_timeout_exhausts_max_timeout_retries(
         self, work_dir: Path, campaign: dict, fast_sleep,
     ) -> None:
-        """Repeated timeouts exhaust max_retries and raise RuntimeError."""
+        """Timeouts respect max_timeout_retries (independent of max_retries)."""
         import subprocess
         from orchestrator.cli_dispatch import CLIDispatcher
 
@@ -591,11 +591,38 @@ class TestCLIDispatcherRetry:
             "orchestrator.cli_dispatch.subprocess.run",
             side_effect=subprocess.TimeoutExpired(cmd=["claude"], timeout=1800),
         ) as mock_run:
-            d = CLIDispatcher(work_dir=work_dir, campaign=campaign, max_retries=2)
-            with pytest.raises(RuntimeError, match="still failing after"):
+            d = CLIDispatcher(work_dir=work_dir, campaign=campaign, max_timeout_retries=2)
+            with pytest.raises(RuntimeError, match="timed out"):
                 d.dispatch("planner", "design", output_path=work_dir / "out.md", iteration=1)
 
         assert mock_run.call_count == 3  # 1 initial + 2 retries
+        assert fast_sleep.call_count == 2
+        assert fast_sleep.call_args_list[0][0][0] == 5   # _backoff_for(1)
+        assert fast_sleep.call_args_list[1][0][0] == 30  # _backoff_for(2)
+
+    def test_timeout_does_not_consume_max_retries_budget(
+        self, work_dir: Path, campaign: dict, fast_sleep,
+    ) -> None:
+        """Timeout retries are tracked separately — a timeout does not decrement
+        the transient-error (max_retries) budget."""
+        import subprocess
+        from orchestrator.cli_dispatch import CLIDispatcher
+
+        with patch(
+            "orchestrator.cli_dispatch.subprocess.run",
+            side_effect=[
+                subprocess.TimeoutExpired(cmd=["claude"], timeout=1800),
+                _transient_socket_result(),
+                _success_result("# Design\nStub."),
+            ],
+        ) as mock_run:
+            d = CLIDispatcher(
+                work_dir=work_dir, campaign=campaign,
+                max_timeout_retries=1, max_retries=1,
+            )
+            d.dispatch("planner", "design", output_path=work_dir / "out.md", iteration=1)
+
+        assert mock_run.call_count == 3
 
     def test_file_not_found_does_not_retry(
         self, work_dir: Path, campaign: dict, fast_sleep,

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -560,10 +560,30 @@ class TestCLIDispatcherRetry:
         assert mock_run.call_count == 3
         assert fast_sleep.call_count == 2
 
-    def test_timeout_does_not_retry(
+    def test_timeout_retries_then_succeeds(
         self, work_dir: Path, campaign: dict, fast_sleep,
     ) -> None:
-        """subprocess.TimeoutExpired is NOT retried — it means the session exceeded self.timeout."""
+        """subprocess.TimeoutExpired is treated as transient and retried."""
+        import subprocess
+        from orchestrator.cli_dispatch import CLIDispatcher
+
+        with patch(
+            "orchestrator.cli_dispatch.subprocess.run",
+            side_effect=[
+                subprocess.TimeoutExpired(cmd=["claude"], timeout=1800),
+                _success_result("# Design\nStub."),
+            ],
+        ) as mock_run:
+            d = CLIDispatcher(work_dir=work_dir, campaign=campaign)
+            d.dispatch("planner", "design", output_path=work_dir / "out.md", iteration=1)
+
+        assert mock_run.call_count == 2
+        fast_sleep.assert_called_once()
+
+    def test_timeout_exhausts_max_retries(
+        self, work_dir: Path, campaign: dict, fast_sleep,
+    ) -> None:
+        """Repeated timeouts exhaust max_retries and raise RuntimeError."""
         import subprocess
         from orchestrator.cli_dispatch import CLIDispatcher
 
@@ -571,12 +591,11 @@ class TestCLIDispatcherRetry:
             "orchestrator.cli_dispatch.subprocess.run",
             side_effect=subprocess.TimeoutExpired(cmd=["claude"], timeout=1800),
         ) as mock_run:
-            d = CLIDispatcher(work_dir=work_dir, campaign=campaign)
-            with pytest.raises(RuntimeError, match="timed out"):
+            d = CLIDispatcher(work_dir=work_dir, campaign=campaign, max_retries=2)
+            with pytest.raises(RuntimeError, match="still failing after"):
                 d.dispatch("planner", "design", output_path=work_dir / "out.md", iteration=1)
 
-        assert mock_run.call_count == 1
-        fast_sleep.assert_not_called()
+        assert mock_run.call_count == 3  # 1 initial + 2 retries
 
     def test_file_not_found_does_not_retry(
         self, work_dir: Path, campaign: dict, fast_sleep,


### PR DESCRIPTION
Fixes #92

## Summary

- `subprocess.TimeoutExpired` was caught and re-raised as a plain `RuntimeError`, bypassing the transient-retry loop in `_call_claude` entirely
- A hung subprocess (e.g. LiteLLM silently retrying a failed auth until the 1800s wall clock expires) is indistinguishable from any other transient upstream failure — it should be retried, not crashed
- Fix: catch `TimeoutExpired` and raise `_TransientCLIError` instead, so the existing backoff/retry loop handles it and `--max-cli-retries` is respected

## Test plan

- [ ] `test_timeout_retries_then_succeeds` — one timeout followed by success retries correctly (2 subprocess calls, 1 sleep)
- [ ] `test_timeout_exhausts_max_retries` — repeated timeouts with `max_retries=2` exhaust retries and raise `RuntimeError: still failing after` (3 total calls)
- [ ] All other `TestTransientRetry` tests still pass (no regression to existing transient/permanent error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)