### PR TITLE
fix: implement arm-level fast-fail when h-main is refuted

### DIFF
--- a/orchestrator/dispatch.py
+++ b/orchestrator/dispatch.py
@@ -97,6 +97,13 @@ class StubDispatcher:
                     "diagnostic": "Stub: check if effect exists",
                 },
                 {
+                    "type": "h-ablation",
+                    "component": "stub-component",
+                    "prediction": "Stub: removing stub-component degrades performance",
+                    "mechanism": "Stub: component is essential to the mechanism",
+                    "diagnostic": "Stub: check component-level contribution",
+                },
+                {
                     "type": "h-control-negative",
                     "prediction": "Stub: no effect at low load",
                     "mechanism": "Stub: mechanism irrelevant without contention",
@@ -144,6 +151,7 @@ class StubDispatcher:
         iter_dir = path.parent
         iter_dir.mkdir(parents=True, exist_ok=True)
 
+        fast_failed = h_main_result == "REFUTED"
         plan = {
             "metadata": {
                 "iteration": iteration,
@@ -163,6 +171,15 @@ class StubDispatcher:
                         {
                             "name": "treatment",
                             "cmd": "echo '{\"latency_ms\": 40}'",
+                        },
+                    ],
+                },
+                {
+                    "arm_id": "h-ablation",
+                    "conditions": [
+                        {
+                            "name": "ablation",
+                            "cmd": "echo '{\"latency_ms\": 55}'",
                         },
                     ],
                 },
@@ -194,6 +211,18 @@ class StubDispatcher:
                     "diagnostic_note": None
                     if h_main_result == "CONFIRMED"
                     else "Mechanism does not hold",
+                },
+                {
+                    "arm_type": "h-ablation",
+                    "predicted": "removing stub-component degrades performance",
+                    "observed": "stub-component removal increased latency by 10%"
+                    if not fast_failed
+                    else "skipped — h-main refuted",
+                    "status": "CONFIRMED" if not fast_failed else "SKIPPED",
+                    "error_type": None,
+                    "diagnostic_note": None
+                    if not fast_failed
+                    else "fast-fail: h-main refuted",
                 },
                 {
                     "arm_type": "h-control-negative",

--- a/orchestrator/ledger.py
+++ b/orchestrator/ledger.py
@@ -123,11 +123,14 @@ def _collect_ablation_results(arms: list[dict]) -> dict[str, str]:
 
 
 def _compute_accuracy(arms: list[dict]) -> dict | None:
-    """Compute prediction accuracy across all arms."""
+    """Compute prediction accuracy across arms that were actually run."""
     if not arms:
         return None
-    total = len(arms)
-    correct = sum(1 for a in arms if a.get("status") == "CONFIRMED")
+    runnable = [a for a in arms if a.get("status") != "SKIPPED"]
+    if not runnable:
+        return None
+    total = len(runnable)
+    correct = sum(1 for a in runnable if a.get("status") == "CONFIRMED")
     return {
         "arms_correct": correct,
         "arms_total": total,

--- a/prompts/methodology/execute_analyze.md
+++ b/prompts/methodology/execute_analyze.md
@@ -122,6 +122,10 @@ After each baseline+treatment pair with the same seed, compare key metrics. If t
 
 **All results must land in `{{iter_dir}}/results/`.** The worktree is temporary — anything written there will be lost.
 
+**Fast-fail rule:** After running h-main and before running any h-ablation, h-super-additivity, or h-robustness arms, evaluate the h-main result:
+- If h-main is **REFUTED**: do NOT run h-ablation, h-super-additivity, or h-robustness arms. Record each skipped arm in findings with `status: "SKIPPED"`, `observed: "skipped — h-main refuted"`, `error_type: null`, and `diagnostic_note: "fast-fail: h-main refuted"`. Continue with h-control-negative as planned, then proceed to Phase 3.
+- If h-main is **CONFIRMED** or **PARTIALLY_CONFIRMED**: run all remaining arms as planned.
+
 ## Phase 3: Analyze and Write Findings
 
 Compare the predictions in the hypothesis bundle against the metrics you observed.

--- a/schemas/findings.schema.json
+++ b/schemas/findings.schema.json
@@ -40,7 +40,7 @@
         "observed": { "type": "string", "minLength": 1 },
         "status": {
           "type": "string",
-          "enum": ["CONFIRMED", "REFUTED", "PARTIALLY_CONFIRMED"]
+          "enum": ["CONFIRMED", "REFUTED", "PARTIALLY_CONFIRMED", "SKIPPED"]
         },
         "error_type": {
           "type": ["string", "null"],

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -76,6 +76,31 @@ class TestStubDispatcher:
         assert findings["arms"][0]["status"] == "REFUTED"
         jsonschema.validate(findings, _load_schema("findings.schema.json"))
 
+    def test_dispatch_executor_refuted_fast_fails_ablation(self, work_dir):
+        dispatcher = _make_dispatcher(work_dir)
+        iter_dir = work_dir / "runs" / "iter-1"
+        dispatcher.dispatch(
+            "executor", "execute-analyze",
+            output_path=iter_dir / "executor_log.md", iteration=1, h_main_result="REFUTED",
+        )
+        findings = json.loads((iter_dir / "findings.json").read_text())
+        jsonschema.validate(findings, _load_schema("findings.schema.json"))
+        statuses = {a["arm_type"]: a["status"] for a in findings["arms"]}
+        assert statuses["h-main"] == "REFUTED"
+        assert statuses["h-ablation"] == "SKIPPED"
+        assert statuses["h-control-negative"] == "CONFIRMED"
+
+    def test_dispatch_executor_confirmed_runs_ablation(self, work_dir):
+        dispatcher = _make_dispatcher(work_dir)
+        iter_dir = work_dir / "runs" / "iter-1"
+        dispatcher.dispatch(
+            "executor", "execute-analyze",
+            output_path=iter_dir / "executor_log.md", iteration=1, h_main_result="CONFIRMED",
+        )
+        findings = json.loads((iter_dir / "findings.json").read_text())
+        statuses = {a["arm_type"]: a["status"] for a in findings["arms"]}
+        assert statuses["h-ablation"] == "CONFIRMED"
+
     def test_dispatch_unknown_role_rejected(self, work_dir):
         dispatcher = _make_dispatcher(work_dir)
         with pytest.raises(ValueError, match="Unknown role"):

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -238,6 +238,47 @@ class TestAppendLedgerRow:
         ledger = json.loads((tmp_path / "ledger.json").read_text())
         assert len(ledger["iterations"]) == 1
 
+    def test_accuracy_excludes_skipped_arms(self, tmp_path):
+        iter_dir = tmp_path / "runs" / "iter-1"
+        _write_bundle(iter_dir)
+        findings = {
+            "iteration": 1,
+            "bundle_ref": "runs/iter-1/bundle.yaml",
+            "arms": [
+                {
+                    "arm_type": "h-main",
+                    "predicted": "p", "observed": "o",
+                    "status": "REFUTED",
+                    "error_type": "direction", "diagnostic_note": None,
+                },
+                {
+                    "arm_type": "h-ablation",
+                    "predicted": "p", "observed": "skipped — h-main refuted",
+                    "status": "SKIPPED",
+                    "error_type": None, "diagnostic_note": "fast-fail: h-main refuted",
+                },
+                {
+                    "arm_type": "h-control-negative",
+                    "predicted": "p", "observed": "o",
+                    "status": "CONFIRMED",
+                    "error_type": None, "diagnostic_note": None,
+                },
+            ],
+            "experiment_valid": True,
+            "discrepancy_analysis": "H-main refuted.",
+        }
+        (iter_dir / "findings.json").write_text(json.dumps(findings, indent=2))
+        _write_principles(tmp_path, [])
+
+        append_ledger_row(tmp_path, 1)
+
+        ledger = json.loads((tmp_path / "ledger.json").read_text())
+        row = ledger["iterations"][0]
+        # Only 2 runnable arms (h-main REFUTED, h-control CONFIRMED); h-ablation SKIPPED excluded
+        assert row["prediction_accuracy"]["arms_total"] == 2
+        assert row["prediction_accuracy"]["arms_correct"] == 1
+        assert row["prediction_accuracy"]["accuracy_pct"] == 50.0
+
     def test_no_bundle_still_works(self, tmp_path):
         iter_dir = tmp_path / "runs" / "iter-1"
         iter_dir.mkdir(parents=True)


### PR DESCRIPTION
Closes #103

## Summary

- **`findings.schema.json`**: add `"SKIPPED"` to the `status` enum — previously there was no way to represent a skipped arm in a valid artifact
- **`execute_analyze.md`**: add fast-fail rule to Phase 2 — after h-main runs, if REFUTED, record h-ablation / h-super-additivity / h-robustness as `SKIPPED` and skip their execution; h-control-negative still runs
- **`orchestrator/dispatch.py`** (StubDispatcher): add h-ablation arm to the stub bundle/plan; mark it `SKIPPED` in findings when `h_main_result == "REFUTED"`
- **`orchestrator/ledger.py`**: exclude `SKIPPED` arms from `_compute_accuracy` so fast-failed arms don't unfairly lower prediction accuracy

## Test plan

- [ ] `test_dispatch_executor_refuted_fast_fails_ablation` — h-ablation is `SKIPPED`, h-control-negative is `CONFIRMED` when h-main is REFUTED
- [ ] `test_dispatch_executor_confirmed_runs_ablation` — h-ablation is `CONFIRMED` when h-main is CONFIRMED
- [ ] `test_accuracy_excludes_skipped_arms` — ledger accuracy counts only runnable arms
- [ ] Full suite (302 tests) passes with no regressions: `python -m pytest --ignore=tests/test_integration_real_execution.py --ignore=tests/test_integration_llm.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)