### PR TITLE
fix: send previous-response delta on CLI parse/schema retries

### DIFF
--- a/orchestrator/cli_dispatch.py
+++ b/orchestrator/cli_dispatch.py
@@ -159,7 +159,7 @@ class CLIDispatcher(LLMDispatcher):
                     "Parse failed for %s/%s (%s), retrying with feedback.",
                     role, phase, exc,
                 )
-                data = self._retry_cli_parse(prompt, exc, fmt)
+                data = self._retry_cli_parse(response, exc, fmt)
 
             if schema_name is not None:
                 try:
@@ -169,7 +169,7 @@ class CLIDispatcher(LLMDispatcher):
                         "Schema validation failed for %s/%s, retrying: %s",
                         role, phase, exc.message,
                     )
-                    data = self._retry_cli_schema(prompt, exc, fmt, schema_name)
+                    data = self._retry_cli_schema(response, exc, fmt, schema_name)
 
             if fmt == "yaml":
                 atomic_write(
@@ -181,14 +181,14 @@ class CLIDispatcher(LLMDispatcher):
 
         logger.info("CLIDispatcher: role=%s phase=%s -> %s", role, phase, output_path)
 
-    def _retry_cli_parse(self, original_prompt: str, error: Exception, fmt: str) -> dict:
+    def _retry_cli_parse(self, previous_response: str, error: Exception, fmt: str) -> dict:
         feedback = (
             f"Your previous response could not be parsed.\n\n"
             f"Error: {error}\n\n"
             f"Please output ONLY a ```{fmt}``` code fence with valid "
             f"{fmt.upper()} inside. No explanation outside the fence."
         )
-        response = self._call_claude(f"{original_prompt}\n\n---\n\n{feedback}")
+        response = self._call_claude(f"{previous_response}\n\n---\n\n{feedback}")
         try:
             return self._extract_fenced_content(response, fmt)
         except (json.JSONDecodeError, yaml.YAMLError, ValueError) as exc:
@@ -197,7 +197,7 @@ class CLIDispatcher(LLMDispatcher):
             ) from exc
 
     def _retry_cli_schema(
-        self, original_prompt: str, error: jsonschema.ValidationError,
+        self, previous_response: str, error: jsonschema.ValidationError,
         fmt: str, schema_name: str,
     ) -> dict:
         feedback = (
@@ -205,7 +205,7 @@ class CLIDispatcher(LLMDispatcher):
             f"Please fix the issue and return only the corrected "
             f"{fmt} in a code fence."
         )
-        response = self._call_claude(f"{original_prompt}\n\n---\n\n{feedback}")
+        response = self._call_claude(f"{previous_response}\n\n---\n\n{feedback}")
         try:
             data = self._extract_fenced_content(response, fmt)
         except (json.JSONDecodeError, yaml.YAMLError, ValueError) as exc:

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -692,3 +692,85 @@ class TestIsTransientClassifier:
         """api_error_status 5xx is transient even if is_error is absent/False."""
         from orchestrator.cli_dispatch import _is_transient
         assert _is_transient({"is_error": False, "api_error_status": 503, "result": ""})
+
+
+class TestCLIParseRetryDelta:
+    """Retry methods must send the previous-response delta, not re-send the full prompt."""
+
+    def test_retry_cli_parse_prompt_starts_with_previous_response(
+        self, work_dir: Path, campaign: dict,
+    ) -> None:
+        from unittest.mock import patch
+        from orchestrator.cli_dispatch import CLIDispatcher
+
+        previous_bad = "SENTINEL_BAD_RESPONSE_no_fence_here"
+        valid_fence = (
+            '```json\n{"gate_type": "design", "summary": "ok", '
+            '"key_points": ["a"]}\n```'
+        )
+
+        d = CLIDispatcher(work_dir=work_dir, campaign=campaign)
+        with patch("orchestrator.cli_dispatch.subprocess.run") as mock_run:
+            mock_run.return_value = _success_result(valid_fence)
+            d._retry_cli_parse(previous_bad, ValueError("no fence"), "json")
+
+        stdin_text = mock_run.call_args.kwargs["input"]
+        assert stdin_text.startswith(previous_bad)
+
+    def test_retry_cli_schema_prompt_starts_with_previous_response(
+        self, work_dir: Path, campaign: dict,
+    ) -> None:
+        from unittest.mock import patch
+        from orchestrator.cli_dispatch import CLIDispatcher
+
+        previous_bad = '```json\n{"wrong_key": true}\n```'
+        valid_fence = (
+            '```json\n{"gate_type": "design", "summary": "ok", '
+            '"key_points": ["a"]}\n```'
+        )
+
+        schema = load_schema("gate_summary.schema.json")
+        try:
+            jsonschema.validate({"wrong_key": True}, schema)
+        except jsonschema.ValidationError as exc:
+            validation_error = exc
+
+        d = CLIDispatcher(work_dir=work_dir, campaign=campaign)
+        with patch("orchestrator.cli_dispatch.subprocess.run") as mock_run:
+            mock_run.return_value = _success_result(valid_fence)
+            d._retry_cli_schema(
+                previous_bad, validation_error, "json", "gate_summary.schema.json"
+            )
+
+        stdin_text = mock_run.call_args.kwargs["input"]
+        assert stdin_text.startswith(previous_bad)
+
+    def test_dispatch_parse_retry_does_not_resend_full_context(
+        self, work_dir: Path, campaign: dict,
+    ) -> None:
+        """On a parse error, the retry subprocess call gets the bad response, not the full prompt."""
+        from unittest.mock import patch
+        from orchestrator.cli_dispatch import CLIDispatcher
+
+        BAD_RESPONSE = "SENTINEL_BAD_NO_FENCE_xyz"
+        valid_fence = (
+            '```json\n{"gate_type": "design", "summary": "ok", '
+            '"key_points": ["tested"]}\n```'
+        )
+
+        with patch("orchestrator.cli_dispatch.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                _success_result(BAD_RESPONSE),
+                _success_result(valid_fence),
+            ]
+            d = CLIDispatcher(work_dir=work_dir, campaign=campaign)
+            out = work_dir / "runs" / "iter-1" / "gate.json"
+            d.dispatch("summarizer", "summarize-gate", output_path=out, iteration=1)
+
+        assert mock_run.call_count == 2
+        first_input = mock_run.call_args_list[0].kwargs["input"]
+        retry_input = mock_run.call_args_list[1].kwargs["input"]
+
+        assert "TestSystem" in first_input        # full context went to first call
+        assert BAD_RESPONSE in retry_input         # retry contains the bad response
+        assert "TestSystem" not in retry_input     # retry does NOT re-send full context


### PR DESCRIPTION
## Summary

- `dispatch()` was passing `prompt` (full rendered template) to `_retry_cli_parse` and `_retry_cli_schema` — now passes `response` (the model's previous bad output)
- Both retry methods renamed `original_prompt` → `previous_response`; retry prompt is now `{previous_response}\n\n---\n\n{feedback}`

Fixes #105.

## Why this matters

Every parse or schema-validation retry was re-sending the full system context (bundle, handoff, instructions) + feedback, doubling token cost. The model only needs to see its previous (bad) output and the correction message to fix formatting/structure errors — it already produced the content, it just needs to reformat it.

This matches the pattern already used by the inline `LLMDispatcher._retry_parse` / `_retry_with_feedback`, which correctly pass the assistant's previous response as a separate message.

## Test plan

- [x] `test_retry_cli_parse_prompt_starts_with_previous_response` — retry prompt starts with bad response, not full prompt
- [x] `test_retry_cli_schema_prompt_starts_with_previous_response` — same for schema retry
- [x] `test_dispatch_parse_retry_does_not_resend_full_context` — integration test through `dispatch()`: retry input contains the bad response and does NOT contain campaign-context markers (`TestSystem`)
- [x] All 39 existing `test_cli_dispatch.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)