### PR TITLE
fix: prevent test_is_error_still_logs_metrics from hanging

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -201,7 +201,7 @@ class TestCLIDispatcherMetrics:
         mock_result.stderr = ""
 
         with patch("orchestrator.cli_dispatch.subprocess.run", return_value=mock_result):
-            d = CLIDispatcher(work_dir=work_dir, campaign=campaign)
+            d = CLIDispatcher(work_dir=work_dir, campaign=campaign, max_retries=0)
             with pytest.raises(RuntimeError, match="returned an error"):
                 d.dispatch("planner", "design", output_path=work_dir / "out.yaml", iteration=1)
 


### PR DESCRIPTION
## Summary

- Fixes #112: `test_is_error_still_logs_metrics` hangs indefinitely since PR #111 changed `is_error=True` to raise `_TransientCLIError`, entering the retry loop with real `time.sleep` backoff (~3455s total).
- Adds `max_retries=0` to the `CLIDispatcher` in this test — retry behavior is already covered by `TestCLIDispatcherRetry::test_metrics_logged_per_attempt`.

## Test plan

- [x] `pytest tests/test_metrics.py::TestCLIDispatcherMetrics::test_is_error_still_logs_metrics` passes in <1s
- [x] Full test suite (319 tests) passes in ~18s

🤖 Generated with [Claude Code](https://claude.com/claude-code)