### PR TITLE
fix(cli): nous replay executes plan mechanically, no LLM needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ nous status campaign.yaml        # show campaign phase, iteration, principles
 nous cost campaign.yaml          # token/cost summary from llm_metrics.jsonl
 nous report campaign.yaml        # generate report.md (uses LLM)
 nous resume campaign.yaml        # resume a paused/interrupted campaign
+nous replay campaign.yaml --iter 1  # re-run iteration 1 commands in fresh worktree (no LLM)
 nous validate design --dir .nous/run/runs/iter-1/   # validate artifacts (agent-facing)
 ```
 

--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -231,15 +231,9 @@ def _cmd_report(args):
 
 
 def _cmd_replay(args):
-    import logging
+    import subprocess
     import yaml
     from orchestrator.worktree import create_experiment_worktree, remove_experiment_worktree
-    from orchestrator.cli_dispatch import CLIDispatcher
-
-    logging.basicConfig(
-        level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(asctime)s %(name)s %(levelname)s %(message)s",
-    )
 
     if not args.target.endswith((".yaml", ".yml")):
         print("Error: replay requires campaign.yaml.\nUse: nous replay <campaign.yaml> --iter N", file=sys.stderr)
@@ -265,23 +259,35 @@ def _cmd_replay(args):
         sys.exit(1)
     repo_path = Path(raw_repo)
 
+    plan = yaml.safe_load(plan_path.read_text())
+
     print(f"Replaying iteration {iteration} from {iter_dir}")
     experiment_id = None
     experiment_dir, experiment_id = create_experiment_worktree(repo_path, iteration)
     print(f"  Worktree: {experiment_dir}")
 
     try:
-        model = args.model or campaign.get("models", {}).get("execute_analyze") or "claude-sonnet-4-6"
-        dispatcher = CLIDispatcher(
-            work_dir=work_dir, campaign=campaign,
-            model=model, timeout=args.timeout,
-        )
-        with dispatcher.override_cwd(experiment_dir):
-            dispatcher.dispatch(
-                "executor", "execute-analyze",
-                output_path=iter_dir / "executor_log.md",
-                iteration=iteration,
-            )
+        for step in plan.get("setup", []):
+            print(f"  [setup] {step.get('description', step['cmd'][:60])}")
+            result = subprocess.run(step["cmd"], shell=True, cwd=experiment_dir)
+            if result.returncode != 0:
+                print(f"Error: setup command failed (exit {result.returncode})", file=sys.stderr)
+                sys.exit(1)
+
+        total = sum(len(arm.get("conditions", [])) for arm in plan.get("arms", []))
+        done = 0
+        for arm in plan.get("arms", []):
+            arm_id = arm.get("arm_id", "unknown")
+            for cond in arm.get("conditions", []):
+                done += 1
+                name = cond.get("name", "unnamed")
+                print(f"  [{done}/{total}] {arm_id}/{name}")
+                result = subprocess.run(cond["cmd"], shell=True, cwd=experiment_dir)
+                if result.returncode != 0:
+                    print(f"Error: {arm_id}/{name} failed (exit {result.returncode})", file=sys.stderr)
+                    sys.exit(1)
+
+        print(f"  Replay complete: {done}/{total} conditions passed.")
     finally:
         if experiment_id:
             remove_experiment_worktree(repo_path, experiment_id)
@@ -337,8 +343,6 @@ def main():
     p_replay = subparsers.add_parser("replay")
     p_replay.add_argument("target")
     p_replay.add_argument("--iter", required=True, type=int)
-    p_replay.add_argument("--model")
-    p_replay.add_argument("--timeout", type=int, default=1800)
     p_replay.set_defaults(func=_cmd_replay)
 
     args = parser.parse_args()

--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -260,6 +260,9 @@ def _cmd_replay(args):
     repo_path = Path(raw_repo)
 
     plan = yaml.safe_load(plan_path.read_text())
+    if not isinstance(plan, dict):
+        print(f"Error: experiment_plan.yaml is empty or malformed in {iter_dir}", file=sys.stderr)
+        sys.exit(1)
 
     print(f"Replaying iteration {iteration} from {iter_dir}")
     experiment_id = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,14 +261,11 @@ class TestCmdReplay:
             f"run_id: exp1\nmax_iterations: 3\n"
             f"target_system:\n  name: test\n  description: t\n  repo_path: {repo}\n"
         )
-        args = argparse.Namespace(
-            target=str(campaign_file), iter=5, model=None,
-            timeout=1800, agent="api", verbose=False,
-        )
+        args = argparse.Namespace(target=str(campaign_file), iter=5, verbose=False)
         with pytest.raises(SystemExit):
             _cmd_replay(args)
 
-    def test_replay_creates_worktree_and_dispatches(self, tmp_path):
+    def test_replay_runs_commands_mechanically(self, tmp_path):
         import json
         import yaml as _yaml
         repo = tmp_path / "myrepo"
@@ -276,33 +273,39 @@ class TestCmdReplay:
         work_dir = repo / ".nous" / "exp1"
         iter_dir = work_dir / "runs" / "iter-1"
         iter_dir.mkdir(parents=True)
+        results_dir = iter_dir / "results" / "h-main"
+        results_dir.mkdir(parents=True)
         (work_dir / "state.json").write_text(json.dumps({
             "phase": "DONE", "iteration": 1, "run_id": "exp1"
         }))
-        (iter_dir / "experiment_plan.yaml").write_text(_yaml.dump({"arms": []}))
+        plan = {
+            "metadata": {"iteration": 1},
+            "setup": [{"cmd": "echo setup", "description": "build"}],
+            "arms": [{
+                "arm_id": "h-main",
+                "conditions": [{
+                    "name": "baseline",
+                    "cmd": f"echo ok > {results_dir}/baseline.json",
+                    "output": str(results_dir / "baseline.json"),
+                    "inputs": [],
+                }],
+            }],
+        }
+        (iter_dir / "experiment_plan.yaml").write_text(_yaml.dump(plan))
         campaign_file = tmp_path / "campaign.yaml"
         campaign_file.write_text(
             f"run_id: exp1\nmax_iterations: 3\n"
             f"target_system:\n  name: test\n  description: t\n  repo_path: {repo}\n"
         )
-        args = argparse.Namespace(
-            target=str(campaign_file), iter=1, model=None,
-            timeout=1800, agent="api", verbose=False,
-        )
-        with patch("orchestrator.worktree.create_experiment_worktree", return_value=(tmp_path / "wt", "exp-id")) as mock_create, \
-             patch("orchestrator.worktree.remove_experiment_worktree") as mock_remove, \
-             patch("orchestrator.cli_dispatch.CLIDispatcher") as mock_cls:
-            mock_dispatcher = MagicMock()
-            mock_cls.return_value = mock_dispatcher
-            mock_dispatcher.override_cwd.return_value.__enter__ = MagicMock()
-            mock_dispatcher.override_cwd.return_value.__exit__ = MagicMock(return_value=False)
+        args = argparse.Namespace(target=str(campaign_file), iter=1, verbose=False)
+        with patch("orchestrator.worktree.create_experiment_worktree", return_value=(tmp_path / "wt", "exp-id")), \
+             patch("orchestrator.worktree.remove_experiment_worktree") as mock_remove:
             (tmp_path / "wt").mkdir()
             _cmd_replay(args)
-            mock_create.assert_called_once()
-            mock_dispatcher.dispatch.assert_called_once()
             mock_remove.assert_called_once()
+        assert (results_dir / "baseline.json").exists()
 
-    def test_replay_cleans_up_worktree_on_dispatch_failure(self, tmp_path):
+    def test_replay_reports_failed_command(self, tmp_path, capsys):
         import json
         import yaml as _yaml
         repo = tmp_path / "myrepo"
@@ -313,25 +316,25 @@ class TestCmdReplay:
         (work_dir / "state.json").write_text(json.dumps({
             "phase": "DONE", "iteration": 1, "run_id": "exp1"
         }))
-        (iter_dir / "experiment_plan.yaml").write_text(_yaml.dump({"arms": []}))
+        plan = {
+            "metadata": {"iteration": 1},
+            "setup": [],
+            "arms": [{
+                "arm_id": "h-main",
+                "conditions": [{"name": "bad", "cmd": "exit 1", "output": "", "inputs": []}],
+            }],
+        }
+        (iter_dir / "experiment_plan.yaml").write_text(_yaml.dump(plan))
         campaign_file = tmp_path / "campaign.yaml"
         campaign_file.write_text(
             f"run_id: exp1\nmax_iterations: 3\n"
             f"target_system:\n  name: test\n  description: t\n  repo_path: {repo}\n"
         )
-        args = argparse.Namespace(
-            target=str(campaign_file), iter=1, model=None,
-            timeout=1800, agent="api", verbose=False,
-        )
+        args = argparse.Namespace(target=str(campaign_file), iter=1, verbose=False)
         with patch("orchestrator.worktree.create_experiment_worktree", return_value=(tmp_path / "wt", "exp-id")), \
-             patch("orchestrator.worktree.remove_experiment_worktree") as mock_remove, \
-             patch("orchestrator.cli_dispatch.CLIDispatcher") as mock_cls:
-            mock_dispatcher = MagicMock()
-            mock_cls.return_value = mock_dispatcher
-            mock_dispatcher.override_cwd.return_value.__enter__ = MagicMock()
-            mock_dispatcher.override_cwd.return_value.__exit__ = MagicMock(return_value=False)
-            mock_dispatcher.dispatch.side_effect = RuntimeError("agent crashed")
+             patch("orchestrator.worktree.remove_experiment_worktree"):
             (tmp_path / "wt").mkdir()
-            with pytest.raises(RuntimeError):
+            with pytest.raises(SystemExit):
                 _cmd_replay(args)
-            mock_remove.assert_called_once()
+        err = capsys.readouterr().err
+        assert "h-main/bad" in err


### PR DESCRIPTION
## Summary
- Replaces CLIDispatcher (LLM agent) with direct `subprocess.run()` execution of `experiment_plan.yaml` commands
- Each condition's `cmd` is run sequentially in a fresh git worktree
- Progress reported as `[3/12] h-main/baseline-load-spikes`
- Fails fast on non-zero exit with clear error message
- Removes `--model` and `--timeout` flags (no longer needed)

## Related Issue
Closes #117

## Test Plan
- [x] `test_replay_errors_if_iter_dir_missing` — exits cleanly
- [x] `test_replay_runs_commands_mechanically` — creates worktree, runs cmds, produces output files, cleans up
- [x] `test_replay_reports_failed_command` — exits 1 with `arm_id/name` in error message
- [x] 338 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)