### PR TITLE
feat: SDK dispatcher behind --agent sdk (#121)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,7 +110,8 @@ Both agents write artifacts directly to the campaign directory (`iter_dir`) and 
 **Implementations:**
 
 - `StubDispatcher` (`dispatch.py`) produces valid, schema-conformant artifacts without calling any LLM. Used for testing the orchestrator loop.
-- `CLIDispatcher` (`cli_dispatch.py`) invokes `claude -p` as a subprocess, giving agents code access and shell tools. Agents write files directly to `iter_dir`. Supports `override_cwd()` context manager for pointing the executor at a git worktree.
+- `CLIDispatcher` (`cli_dispatch.py`) invokes `claude -p` as a subprocess, giving agents code access and shell tools. Agents write files directly to `iter_dir`. Supports `override_cwd()` context manager for pointing the executor at a git worktree. Selected via `--agent api`.
+- `SDKDispatcher` (`sdk_dispatch.py`) calls the Claude Agent SDK (`claude-agent-sdk`) instead of spawning a subprocess. Same artifact and metrics contract as `CLIDispatcher`; gains native streaming, programmatic prompt caching, and message-level retry. Selected via `--agent sdk`. Requires the optional `sdk` install extra (`pip install -e ".[sdk]"`). Inherits parse / validate / retry-with-feedback machinery from `CLIDispatcher` — only the transport changes.
 
 **Dispatch interface:**
 ```python
@@ -122,7 +123,7 @@ dispatcher.dispatch(
 )
 ```
 
-Both dispatchers share the same interface — `CLIDispatcher` extends `LLMDispatcher`.
+All three dispatchers share the same interface. `CLIDispatcher` extends `LLMDispatcher`; `SDKDispatcher` extends `CLIDispatcher` and overrides only `_call_claude` and `preflight_check`.
 
 ## CLI Dispatch
 

--- a/orchestrator/campaign.py
+++ b/orchestrator/campaign.py
@@ -206,15 +206,24 @@ def run_campaign(
         HumanGate(auto_response="approve") if auto_approve else HumanGate()
     )
 
-    # Pre-flight: validate CLI + credentials before starting the campaign
+    # Pre-flight: validate CLI + credentials before starting the campaign.
+    # SDK mode pre-flights via claude-agent-sdk import; API mode via claude CLI.
     repo_path = campaign.get("target_system", {}).get("repo_path")
     if agent != "inline" and repo_path:
-        from orchestrator.cli_dispatch import CLIDispatcher
-        preflight_dispatcher = CLIDispatcher(
-            work_dir=work_dir, campaign=campaign,
-            model=_resolve_model(campaign, "design", model),
-            max_retries=max_cli_retries,
-        )
+        if agent == "sdk":
+            from orchestrator.sdk_dispatch import SDKDispatcher
+            preflight_dispatcher = SDKDispatcher(
+                work_dir=work_dir, campaign=campaign,
+                model=_resolve_model(campaign, "design", model),
+                max_retries=max_cli_retries,
+            )
+        else:
+            from orchestrator.cli_dispatch import CLIDispatcher
+            preflight_dispatcher = CLIDispatcher(
+                work_dir=work_dir, campaign=campaign,
+                model=_resolve_model(campaign, "design", model),
+                max_retries=max_cli_retries,
+            )
         preflight_dispatcher.preflight_check()
 
     start_iter = _resume_completed_campaign(work_dir, max_iterations)
@@ -353,7 +362,7 @@ def main() -> None:
                         help="Timeout in seconds for claude -p calls (default: 1800)")
     parser.add_argument("--max-cli-retries", type=int, default=10,
                         help="Max retries for claude -p failures (-1 = unbounded, default: 10)")
-    parser.add_argument("--agent", choices=["inline", "api"], default="api",
+    parser.add_argument("--agent", choices=["inline", "api", "sdk"], default="api",
                         help="Dispatch backend: 'inline' emits prompts to stdout for the "
                              "calling agent (no subprocess, no API key), "
                              "'api' uses the LLM API (default: api)")

--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -310,7 +310,7 @@ def main():
     p_run.add_argument("--auto-approve", action="store_true")
     p_run.add_argument("--timeout", type=int, default=1800)
     p_run.add_argument("--max-cli-retries", type=int, default=10)
-    p_run.add_argument("--agent", choices=["inline", "api"], default="api")
+    p_run.add_argument("--agent", choices=["inline", "api", "sdk"], default="api")
     p_run.set_defaults(func=_cmd_run)
 
     p_resume = subparsers.add_parser("resume")
@@ -320,7 +320,7 @@ def main():
     p_resume.add_argument("--auto-approve", action="store_true")
     p_resume.add_argument("--timeout", type=int, default=1800)
     p_resume.add_argument("--max-cli-retries", type=int, default=10)
-    p_resume.add_argument("--agent", choices=["inline", "api"], default="api")
+    p_resume.add_argument("--agent", choices=["inline", "api", "sdk"], default="api")
     p_resume.set_defaults(func=_cmd_resume)
 
     p_validate = subparsers.add_parser("validate")
@@ -340,7 +340,7 @@ def main():
     p_report.add_argument("target")
     p_report.add_argument("--model")
     p_report.add_argument("--timeout", type=int, default=1800)
-    p_report.add_argument("--agent", choices=["inline", "api"], default="api")
+    p_report.add_argument("--agent", choices=["inline", "api", "sdk"], default="api")
     p_report.set_defaults(func=_cmd_report)
 
     p_replay = subparsers.add_parser("replay")

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -281,9 +281,15 @@ def run_iteration(
         cli_dispatcher = inline_dispatcher
         llm_dispatcher = inline_dispatcher
     else:
-        # API mode: CLIDispatcher for code-access roles only (when repo_path is set)
+        # API or SDK mode: code-access dispatcher only when repo_path is set.
+        # SDK uses claude-agent-sdk; api uses the claude -p subprocess (CLIDispatcher).
+        if agent == "sdk":
+            from orchestrator.sdk_dispatch import SDKDispatcher
+            code_dispatcher_cls = SDKDispatcher
+        else:
+            code_dispatcher_cls = CLIDispatcher
         cli_dispatcher = (
-            CLIDispatcher(
+            code_dispatcher_cls(
                 work_dir=work_dir, campaign=campaign,
                 model=_model_for("design"), timeout=timeout,
                 max_turns=_max_turns_for("design"),
@@ -493,7 +499,7 @@ def main() -> None:
                         help="Timeout in seconds for claude -p calls (default: 1800)")
     parser.add_argument("--max-cli-retries", type=int, default=10,
                         help="Max retries for claude -p failures (-1 = unbounded, default: 10)")
-    parser.add_argument("--agent", choices=["inline", "api"], default="api",
+    parser.add_argument("--agent", choices=["inline", "api", "sdk"], default="api",
                         help="Dispatch backend: 'inline' emits prompts to stdout for the "
                              "calling agent, 'api' uses the LLM API (default: api)")
     parser.add_argument("-v", "--verbose", action="store_true",

--- a/orchestrator/sdk_dispatch.py
+++ b/orchestrator/sdk_dispatch.py
@@ -1,0 +1,355 @@
+"""SDK-based agent dispatch for the Nous orchestrator.
+
+Calls the Claude Agent SDK in place of `claude -p` subprocess. Same
+artifact and metrics contract as :class:`orchestrator.cli_dispatch.CLIDispatcher`;
+this class swaps the transport without changing the orchestrator's contract
+with the rest of Nous.
+
+Why SDK over `claude -p`:
+  * Native streaming → fast progress visibility (#127).
+  * Programmatic prompt caching → token savings (#122).
+  * Native subagent spawning → parallel arms without manual fork/join (#123).
+  * Message-level retry instead of subprocess restart.
+
+Design decisions worth knowing:
+
+  * The actual SDK call is delegated to a ``sdk_runner`` callable. The
+    default lazily resolves to a real ``claude_agent_sdk`` runner; tests
+    inject a deterministic fake. The runner returns an ``SDKResult``
+    (text + usage + cost + error flag); the dispatcher's job is to turn
+    that into on-disk artifacts and a metrics row, with retry on transient
+    failure. This keeps tests behavioral — they assert what's on disk,
+    not which method we called.
+  * Inherits from CLIDispatcher to reuse the parse/validate/retry-with-feedback
+    machinery used for fenced-output phases (gate summaries, etc.).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Protocol, runtime_checkable
+
+from orchestrator.cli_dispatch import CLIDispatcher, _backoff_for
+from orchestrator.metrics import log_metrics, log_retry_event
+
+logger = logging.getLogger(__name__)
+
+
+class SDKTransientError(RuntimeError):
+    """Runner raises this for retryable transport-level failures."""
+
+
+@dataclass
+class SDKResult:
+    """One SDK call's outcome.
+
+    The dispatcher reads only these fields. Producers (real or fake) must
+    populate ``text`` (assistant final text); usage/cost fields default
+    to zero so trivial fakes need not set them.
+    """
+
+    text: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cost_usd: float = 0.0
+    duration_ms: int = 0
+    num_turns: int = 1
+    is_error: bool = False
+    error_message: str = ""
+    extra: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class SDKRunner(Protocol):
+    """A callable that performs one SDK turn and returns an ``SDKResult``.
+
+    Raise :class:`SDKTransientError` for retryable failures (network blips,
+    rate limits, mid-stream disconnect). Return ``SDKResult(is_error=True,
+    error_message=...)`` for API-reported errors that should also be retried.
+    Other exceptions bubble up as fatal.
+    """
+
+    def __call__(
+        self,
+        *,
+        prompt: str,
+        model: str,
+        cwd: Path | None,
+        max_turns: int,
+        system_prompt: str | None = None,
+        settings_path: Path | None = None,
+    ) -> SDKResult:
+        ...
+
+
+def _default_sdk_runner_factory() -> SDKRunner:
+    """Return a runner that calls the real ``claude_agent_sdk``.
+
+    Resolved lazily so that tests (and environments without the SDK
+    installed) don't fail at import time.
+    """
+
+    def _runner(
+        *,
+        prompt: str,
+        model: str,
+        cwd: Path | None,
+        max_turns: int,
+        system_prompt: str | None = None,
+        settings_path: Path | None = None,
+    ) -> SDKResult:
+        try:
+            import anyio
+            from claude_agent_sdk import (  # type: ignore[import-not-found]
+                ClaudeAgentOptions,
+                query,
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "claude-agent-sdk is not installed. "
+                "Install with `pip install claude-agent-sdk` or use --agent api."
+            ) from exc
+
+        async def _run() -> SDKResult:
+            options = ClaudeAgentOptions(
+                model=model,
+                cwd=str(cwd) if cwd else None,
+                max_turns=max_turns,
+                system_prompt=system_prompt,
+                settings=str(settings_path) if settings_path else None,
+            )
+            text_chunks: list[str] = []
+            usage: dict = {}
+            cost_usd = 0.0
+            duration_ms = 0
+            num_turns = 0
+            t0 = time.time()
+            async for message in query(prompt=prompt, options=options):
+                cls = type(message).__name__
+                if cls == "AssistantMessage":
+                    for block in getattr(message, "content", []):
+                        if hasattr(block, "text"):
+                            text_chunks.append(block.text)
+                elif cls == "ResultMessage":
+                    usage = getattr(message, "usage", {}) or {}
+                    cost_usd = float(getattr(message, "total_cost_usd", 0.0) or 0.0)
+                    duration_ms = int(getattr(message, "duration_ms", 0) or 0)
+                    num_turns = int(getattr(message, "num_turns", 0) or 0)
+                    if getattr(message, "is_error", False):
+                        return SDKResult(
+                            text="".join(text_chunks),
+                            error_message=str(getattr(message, "result", "unknown")),
+                            is_error=True,
+                            input_tokens=int(usage.get("input_tokens", 0) or 0),
+                            output_tokens=int(usage.get("output_tokens", 0) or 0),
+                            cache_read_input_tokens=int(
+                                usage.get("cache_read_input_tokens", 0) or 0
+                            ),
+                            cache_creation_input_tokens=int(
+                                usage.get("cache_creation_input_tokens", 0) or 0
+                            ),
+                            cost_usd=cost_usd,
+                            duration_ms=duration_ms,
+                            num_turns=num_turns,
+                        )
+            return SDKResult(
+                text="".join(text_chunks),
+                input_tokens=int(usage.get("input_tokens", 0) or 0),
+                output_tokens=int(usage.get("output_tokens", 0) or 0),
+                cache_read_input_tokens=int(
+                    usage.get("cache_read_input_tokens", 0) or 0
+                ),
+                cache_creation_input_tokens=int(
+                    usage.get("cache_creation_input_tokens", 0) or 0
+                ),
+                cost_usd=cost_usd,
+                duration_ms=duration_ms or int((time.time() - t0) * 1000),
+                num_turns=num_turns or 1,
+            )
+
+        try:
+            return anyio.run(_run)
+        except Exception as exc:
+            cls_name = type(exc).__name__
+            transient_signals = (
+                "ConnectionError",
+                "ReadTimeout",
+                "WriteTimeout",
+                "RemoteProtocolError",
+                "ServerDisconnectedError",
+                "TimeoutError",
+            )
+            if any(sig in cls_name for sig in transient_signals):
+                raise SDKTransientError(f"{cls_name}: {exc}") from exc
+            raise
+
+    return _runner
+
+
+class SDKDispatcher(CLIDispatcher):
+    """Dispatch agent roles via the Claude Agent SDK.
+
+    Inherits dispatch() / parse / retry-with-feedback / route logic from
+    :class:`CLIDispatcher`. Overrides ``_call_claude`` to use the SDK
+    runner instead of a subprocess, and ``preflight_check`` to verify
+    the SDK package is importable.
+    """
+
+    def __init__(
+        self,
+        work_dir: Path,
+        campaign: dict,
+        model: str = "claude-sonnet-4-6",
+        prompts_dir: Path | None = None,
+        timeout: int = 1800,
+        max_turns: int = 25,
+        max_retries: int | None = 10,
+        sdk_runner: Callable | None = None,
+        system_prompt: str | None = None,
+        settings_path: Path | None = None,
+    ) -> None:
+        super().__init__(
+            work_dir=work_dir,
+            campaign=campaign,
+            model=model,
+            prompts_dir=prompts_dir,
+            timeout=timeout,
+            max_turns=max_turns,
+            max_retries=max_retries,
+        )
+        self._sdk_runner = sdk_runner or _default_sdk_runner_factory()
+        self._system_prompt = system_prompt
+        self._settings_path = settings_path
+
+    # ------------------------------------------------------------------
+    # Pre-flight
+    # ------------------------------------------------------------------
+
+    def preflight_check(self) -> None:
+        """Verify the SDK is reachable before starting a campaign."""
+        try:
+            import claude_agent_sdk  # type: ignore[import-not-found] # noqa: F401
+        except ImportError as exc:
+            raise RuntimeError(
+                "Pre-flight check failed: claude-agent-sdk is not installed. "
+                "Install with `pip install claude-agent-sdk`, or pass --agent api "
+                "to use the OpenAI-compatible path instead."
+            ) from exc
+        logger.info("SDK pre-flight check passed (model=%s)", self.model)
+
+    # ------------------------------------------------------------------
+    # Core call with retry
+    # ------------------------------------------------------------------
+
+    def _call_claude(self, prompt: str, max_turns: int | None = None) -> str:
+        """Run one SDK turn with retry on transient failure.
+
+        Mirrors CLIDispatcher._call_claude semantics: retry on transient
+        errors (with exponential backoff), log each failure to retry_log.jsonl,
+        log each completed call to llm_metrics.jsonl, give up after
+        max_retries.
+        """
+        cwd = self._cwd
+        if cwd and not cwd.exists():
+            raise RuntimeError(
+                f"SDKDispatcher cwd does not exist: {cwd}. "
+                f"Check that 'repo_path' in campaign.yaml is correct."
+            )
+        turns = max_turns or self.max_turns
+        logger.info(
+            "SDK turn (model=%s, cwd=%s, max_turns=%d)", self.model, cwd, turns,
+        )
+
+        failure_count = 0
+        original_prompt = prompt
+        while True:
+            try:
+                result = self._sdk_runner(
+                    prompt=prompt,
+                    model=self.model,
+                    cwd=cwd,
+                    max_turns=turns,
+                    system_prompt=self._system_prompt,
+                    settings_path=self._settings_path,
+                )
+            except SDKTransientError as exc:
+                failure_count += 1
+                self._log_retry("transient", failure_count, exc)
+                if self._exhausted(failure_count):
+                    raise RuntimeError(
+                        f"SDK still failing after {failure_count} attempt(s): {exc}"
+                    ) from exc
+                time.sleep(_backoff_for(failure_count))
+                prompt = self._maybe_resume_hint(prompt, original_prompt, "transient")
+                continue
+
+            self._log_metrics_row(result)
+
+            if result.is_error:
+                failure_count += 1
+                self._log_retry(
+                    "api_error", failure_count, RuntimeError(result.error_message),
+                )
+                if self._exhausted(failure_count):
+                    raise RuntimeError(
+                        f"SDK returned error after {failure_count} attempt(s): "
+                        f"{result.error_message}"
+                    )
+                time.sleep(_backoff_for(failure_count))
+                prompt = self._maybe_resume_hint(prompt, original_prompt, "api_error")
+                continue
+
+            return result.text
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _exhausted(self, failure_count: int) -> bool:
+        return self.max_retries is not None and failure_count > self.max_retries
+
+    def _log_retry(self, kind: str, attempt: int, exc: BaseException) -> None:
+        log_retry_event(self._metrics_path, {
+            "role": self._current_role,
+            "phase": self._current_phase,
+            "failure_type": kind,
+            "attempt": attempt,
+            "error": str(exc)[:500],
+        })
+
+    def _log_metrics_row(self, result: SDKResult) -> None:
+        log_metrics(self._metrics_path, {
+            "dispatcher": "sdk",
+            "role": self._current_role,
+            "phase": self._current_phase,
+            "model": self.model,
+            "input_tokens": result.input_tokens,
+            "output_tokens": result.output_tokens,
+            "cache_creation_input_tokens": result.cache_creation_input_tokens,
+            "cache_read_input_tokens": result.cache_read_input_tokens,
+            "cost_usd": result.cost_usd,
+            "duration_ms": result.duration_ms,
+            "num_turns": result.num_turns,
+        })
+
+    @staticmethod
+    def _maybe_resume_hint(prompt: str, original_prompt: str, kind: str) -> str:
+        """If the prompt has not yet been annotated with a resume hint, add one.
+
+        Mirrors CLIDispatcher: tells the agent that the prior attempt was
+        interrupted so it picks up from existing artifacts rather than
+        starting fresh.
+        """
+        marker = "\nNote: Your previous attempt was interrupted"
+        if marker in prompt:
+            return prompt
+        return (
+            f"{original_prompt}\n\n---\n"
+            f"Note: Your previous attempt was interrupted ({kind}). "
+            f"Check the working directory for artifacts from your prior "
+            f"attempt and continue from where you left off."
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=4.0",
 ]
+sdk = [
+    "claude-agent-sdk>=0.0.20",
+    "anyio>=4.0",
+]
 
 [project.scripts]
 nous = "orchestrator.cli:main"

--- a/tests/test_sdk_dispatch.py
+++ b/tests/test_sdk_dispatch.py
@@ -1,0 +1,268 @@
+"""Behavioral tests for the SDK-based dispatcher.
+
+These tests do NOT mock the Claude Agent SDK directly. They inject a
+``sdk_runner`` callable that returns a ``SDKResult`` — same contract the
+real dispatcher uses internally — and assert what the dispatcher does
+with that result: artifacts on disk, metrics rows, retry behavior.
+
+That is the contract the rest of Nous depends on. Tests below should
+keep passing across SDK API churn as long as the dispatcher's responsibility
+to write artifacts and emit metrics holds.
+
+No assertions about argv shape, internal helper calls, or which methods
+the dispatcher invoked on the runner. That's structural — out of scope.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.sdk_dispatch import SDKDispatcher, SDKResult, SDKTransientError
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+
+
+def _load_schema(name: str) -> dict:
+    path = SCHEMAS_DIR / name
+    if path.suffix in (".yaml", ".yml"):
+        return yaml.safe_load(path.read_text())
+    return json.loads(path.read_text())
+
+
+def _make_campaign(repo_path: Path | None = None) -> dict:
+    target = {
+        "name": "test-system",
+        "description": "A small test system used by behavioral tests.",
+        "observable_metrics": ["latency", "throughput"],
+        "controllable_knobs": ["batch_size", "concurrency"],
+    }
+    if repo_path is not None:
+        target["repo_path"] = str(repo_path)
+    return {
+        "research_question": "What drives latency?",
+        "target_system": target,
+    }
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+class _ScriptedRunner:
+    """A runner that returns a queue of pre-staged results.
+
+    Each call pops the next entry. Entries can be SDKResult objects (returned)
+    or BaseException instances (raised). When the queue is exhausted, raises
+    AssertionError — a test-only failure mode that signals the dispatcher
+    called the runner more times than expected.
+    """
+
+    def __init__(self, scripted: list):
+        self._scripted = list(scripted)
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs) -> SDKResult:
+        self.calls.append(kwargs)
+        if not self._scripted:
+            raise AssertionError(
+                f"Runner exhausted; dispatcher called it {len(self.calls)} times "
+                f"but only {len(self.calls) - 1} responses were scripted."
+            )
+        nxt = self._scripted.pop(0)
+        if isinstance(nxt, BaseException):
+            raise nxt
+        return nxt
+
+
+# ─── Text-output phase (design): dispatcher writes assistant text to log ───
+
+class TestSDKDispatchTextPhase:
+    """For design/execute-analyze, the SDK runs an agent that writes
+    artifacts via tool calls; the dispatcher persists the assistant's
+    final text message as a log."""
+
+    def test_writes_assistant_text_to_output_path(self, tmp_path):
+        runner = _ScriptedRunner([
+            SDKResult(text="design log content here", input_tokens=100, output_tokens=50),
+        ])
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_make_campaign(tmp_path),
+            sdk_runner=runner,
+        )
+
+        out = tmp_path / "runs" / "iter-1" / "design_log.md"
+        dispatcher.dispatch("planner", "design", output_path=out, iteration=1)
+
+        assert out.exists()
+        assert "design log content here" in out.read_text()
+
+    def test_emits_one_metrics_row_per_call(self, tmp_path):
+        runner = _ScriptedRunner([
+            SDKResult(
+                text="ok",
+                input_tokens=400,
+                output_tokens=120,
+                cache_read_input_tokens=300,
+                cache_creation_input_tokens=0,
+                cost_usd=0.021,
+                duration_ms=4500,
+                num_turns=3,
+            ),
+        ])
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_make_campaign(tmp_path),
+            sdk_runner=runner,
+        )
+
+        dispatcher.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+
+        rows = _read_jsonl(tmp_path / "llm_metrics.jsonl")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["dispatcher"] == "sdk"
+        assert row["role"] == "planner"
+        assert row["phase"] == "design"
+        assert row["input_tokens"] == 400
+        assert row["output_tokens"] == 120
+        assert row["cache_read_input_tokens"] == 300
+        assert row["cost_usd"] == pytest.approx(0.021)
+        assert row["num_turns"] == 3
+
+
+# ─── Structured-output phase: dispatcher parses + validates + writes JSON ──
+
+class TestSDKDispatchStructuredPhase:
+    """Gate-summary phase: SDK returns a fenced JSON; dispatcher parses,
+    validates against gate_summary.schema.json, writes JSON output."""
+
+    _SUMMARY = {
+        "gate_type": "design",
+        "summary": "Hypothesis bundle is well-formed and consistent with active principles.",
+        "key_points": [
+            "Hypothesis bundle covers the four arms.",
+            "Methodology aligns with prior principles.",
+        ],
+    }
+
+    def test_writes_valid_json_when_runner_returns_fenced_payload(self, tmp_path):
+        fenced = "```json\n" + json.dumps(self._SUMMARY) + "\n```"
+        runner = _ScriptedRunner([SDKResult(text=fenced)])
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_make_campaign(),
+            sdk_runner=runner,
+        )
+
+        out = tmp_path / "runs" / "iter-1" / "gate_summary.json"
+        dispatcher.dispatch(
+            "summarizer", "summarize-gate",
+            output_path=out, iteration=1, perspective="design",
+        )
+
+        assert out.exists()
+        parsed = json.loads(out.read_text())
+        jsonschema.validate(parsed, _load_schema("gate_summary.schema.json"))
+        assert parsed["gate_type"] == "design"
+
+
+# ─── Transient retry behavior ───────────────────────────────────────────────
+
+class TestSDKDispatchTransientRetry:
+
+    def test_retries_after_transient_error_then_succeeds(self, tmp_path, monkeypatch):
+        # Disable backoff sleep to keep the test fast.
+        monkeypatch.setattr(
+            "orchestrator.sdk_dispatch.time.sleep", lambda _s: None,
+        )
+        runner = _ScriptedRunner([
+            SDKTransientError("network blip"),
+            SDKResult(text="recovered text", input_tokens=10, output_tokens=5),
+        ])
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_make_campaign(tmp_path),
+            sdk_runner=runner,
+            max_retries=3,
+        )
+
+        out = tmp_path / "runs" / "iter-1" / "design_log.md"
+        dispatcher.dispatch("planner", "design", output_path=out, iteration=1)
+
+        assert "recovered text" in out.read_text()
+
+        retry_log = _read_jsonl(tmp_path / "retry_log.jsonl")
+        assert len(retry_log) == 1
+        assert retry_log[0]["role"] == "planner"
+        assert retry_log[0]["phase"] == "design"
+        assert "network blip" in retry_log[0]["error"]
+
+    def test_raises_after_retries_exhausted(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "orchestrator.sdk_dispatch.time.sleep", lambda _s: None,
+        )
+        runner = _ScriptedRunner([
+            SDKTransientError("persistent failure"),
+            SDKTransientError("persistent failure"),
+            SDKTransientError("persistent failure"),
+        ])
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_make_campaign(tmp_path),
+            sdk_runner=runner,
+            max_retries=2,
+        )
+
+        with pytest.raises(RuntimeError, match="still failing"):
+            dispatcher.dispatch(
+                "planner", "design",
+                output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+                iteration=1,
+            )
+
+        retry_log = _read_jsonl(tmp_path / "retry_log.jsonl")
+        # Three failures = three retry-log rows.
+        assert len(retry_log) == 3
+
+
+# ─── Error result path ──────────────────────────────────────────────────────
+
+class TestSDKDispatchErrorResult:
+    """When the SDK returns is_error=True (e.g. API rejected the request),
+    the dispatcher treats it as transient unless explicitly fatal."""
+
+    def test_is_error_treated_as_transient_and_retried(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "orchestrator.sdk_dispatch.time.sleep", lambda _s: None,
+        )
+        runner = _ScriptedRunner([
+            SDKResult(text="", is_error=True, error_message="rate limit exceeded"),
+            SDKResult(text="finally got through", input_tokens=10, output_tokens=5),
+        ])
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_make_campaign(tmp_path),
+            sdk_runner=runner,
+            max_retries=3,
+        )
+
+        out = tmp_path / "runs" / "iter-1" / "design_log.md"
+        dispatcher.dispatch("planner", "design", output_path=out, iteration=1)
+
+        assert "finally got through" in out.read_text()
+
+        retry_log = _read_jsonl(tmp_path / "retry_log.jsonl")
+        assert len(retry_log) == 1
+        assert "rate limit exceeded" in retry_log[0]["error"]


### PR DESCRIPTION
## Summary

- Add `SDKDispatcher` (orchestrator/sdk_dispatch.py) — Claude Agent SDK transport, opt-in via new `--agent sdk` flag.
- Reuses CLIDispatcher's parse / validate / retry-with-feedback machinery (overrides only `_call_claude` + `preflight_check`); same artifact and metrics contract.
- Pluggable `sdk_runner` Protocol returning an `SDKResult` dataclass — the test seam, and the foundation for #122 (cache_control), #127 (stream-json), and #123 (subagent spawning).

## Why

`claude -p` is blind for up to 7200s, no native streaming, no programmatic prompt caching, no subagent spawning, and retries by subprocess restart (loses message context). The SDK fixes all four. This is the foundation issue in [#120](https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/issues/120) — most other children become configurations rather than lifts once it lands.

## What's not in this PR

- **Removing `claude -p`** — keep CLIDispatcher unchanged until SDK soaks. A later cleanup PR removes it.
- **Prompt caching** — #122.
- **Stream-json TUI** — #127.
- **Subagent spawning** — #123 (depends on #133 too).

## Behavioral testing discipline

Six new tests in `tests/test_sdk_dispatch.py`:

- text phase: assistant text → output_path
- text phase: usage → llm_metrics.jsonl row with `dispatcher: "sdk"`
- structured phase: fenced JSON → parsed + schema-validated → output JSON
- transient: SDK error then success → retry log + final artifact
- transient: persistent failure → exhausts retries with structured error
- result-error: `is_error=True` → retried, then succeeds

All assertions describe what's on disk or what's in the metrics file. **None** assert which methods were called on the runner, what argv was constructed, or how internal helpers behaved. The `sdk_runner` Protocol + `SDKResult` dataclass is the contract; SDK-library API churn won't break these tests.

## Test plan

- [x] `pytest tests/test_sdk_dispatch.py` — 6/6 pass
- [x] `pytest` (full suite) — 350/350 pass (was 344; 6 new)
- [ ] Soak: run a real campaign with `--agent sdk` against an `inference-sim` fixture; compare ledger + findings byte-equality vs `--agent api`. (Manual; this PR does not block on it.)

## Files

| File | Change |
|---|---|
| `orchestrator/sdk_dispatch.py` | new |
| `tests/test_sdk_dispatch.py` | new |
| `orchestrator/cli.py` | extend `--agent` choices |
| `orchestrator/campaign.py` | route preflight to SDK in sdk mode; extend choices |
| `orchestrator/iteration.py` | route code-access dispatcher to SDK; extend choices |
| `pyproject.toml` | add `[sdk]` optional extra (`claude-agent-sdk`, `anyio`) |
| `docs/architecture.md` | document the new path |

Closes #121.
Refs #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)