### PR TITLE
feat: deterministic Stop hook for executor completion (#129)

### DIFF
--- a/bin/nous-execute-stop
+++ b/bin/nous-execute-stop
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Stop hook for the Nous executor session (issue #129).
+
+Runs after every Claude Code agent turn. Returns:
+    exit 0 → allow the agent to stop (its work is done).
+    exit 2 → block stopping; the structured reason on stderr is fed back
+             into the agent's conversation so it can react.
+
+A "stop is allowed" decision needs two pieces of evidence on disk:
+    1. ``$NOUS_ITER_DIR/principle_updates.json`` exists.
+    2. ``nous validate execution --dir $NOUS_ITER_DIR`` returns ``status: pass``.
+
+Both are deterministic — no LLM judgment, no agent self-assessment. The
+hook pairs with the ``/goal``-driven loop (#124) but is preferred wherever
+the success criterion is a schema check, because it's cheaper and more
+reliable than a Haiku evaluator.
+
+Configured per-campaign in ``.claude/settings.json`` (see #135). The
+orchestrator sets ``NOUS_ITER_DIR`` before launching the executor session.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# When invoked as a Claude Code hook, the script's directory may not be
+# on PYTHONPATH. Add the repo root so `orchestrator.validate` imports.
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from orchestrator.validate import validate_execution  # noqa: E402
+
+
+_OK = 0
+_BLOCK = 2
+
+
+def main() -> int:
+    iter_dir_str = os.environ.get("NOUS_ITER_DIR")
+    if not iter_dir_str:
+        print(
+            "NOUS_ITER_DIR is not set. The orchestrator should export this "
+            "variable before launching the executor session.",
+            file=sys.stderr,
+        )
+        return _BLOCK
+
+    iter_dir = Path(iter_dir_str)
+    if not iter_dir.is_dir():
+        print(
+            f"iter_dir does not exist: {iter_dir}. NOUS_ITER_DIR is "
+            f"misconfigured or the executor was launched before init.",
+            file=sys.stderr,
+        )
+        return _BLOCK
+
+    principles = iter_dir / "principle_updates.json"
+    if not principles.exists():
+        print(
+            f"principle_updates.json is missing from {iter_dir}. "
+            f"Write the file (a JSON list, possibly empty: []) before stopping.",
+            file=sys.stderr,
+        )
+        return _BLOCK
+
+    result = validate_execution(iter_dir)
+    if result.get("status") != "pass":
+        errors = result.get("errors", [])
+        print(
+            f"validation failed for {iter_dir} ({len(errors)} error(s)). "
+            f"Fix these before stopping:",
+            file=sys.stderr,
+        )
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return _BLOCK
+
+    return _OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,6 +124,17 @@ dispatcher.dispatch(
 
 Both dispatchers share the same interface — `CLIDispatcher` extends `LLMDispatcher`.
 
+### Stop Hook (`bin/nous-execute-stop`)
+
+Claude Code Stop hooks fire after every agent turn and decide whether the agent is allowed to terminate. `bin/nous-execute-stop` is Nous's deterministic completion check: the executor is allowed to stop only when both conditions hold on disk, no LLM judgment involved:
+
+1. `principle_updates.json` exists in the iteration directory.
+2. `nous validate execution --dir $NOUS_ITER_DIR` returns `status: pass`.
+
+If either fails, the hook exits with code 2 and writes a structured reason to stderr; Claude Code feeds that reason back into the agent's conversation so it can fix the artifact and try again. Wire-up lives in the per-campaign `.claude/settings.json` (see #135) — the orchestrator exports `NOUS_ITER_DIR` before launching the executor session.
+
+This is preferred over a probabilistic Haiku evaluator anywhere the success criterion is a schema check: cheaper, faster, and immune to evaluator drift.
+
 ## CLI Dispatch
 
 `CLIDispatcher` invokes `claude -p` for both agent roles.

--- a/tests/test_execute_stop_hook.py
+++ b/tests/test_execute_stop_hook.py
@@ -1,0 +1,147 @@
+"""Behavioral tests for the deterministic Stop hook (#129).
+
+The hook tells Claude Code whether the executor agent's work is complete,
+based on objective evidence on disk: did `nous validate execution` pass,
+and is `principle_updates.json` present? No LLM judgment, no agent
+self-assessment.
+
+Hook exit-code convention (Claude Code Stop hooks):
+    0 → allow stop (work complete; agent terminates cleanly).
+    2 → block stop (work incomplete; structured reason on stderr; agent
+        receives the stderr in its conversation and keeps going).
+
+The tests below describe the contract: given iter_dir state X, the hook
+exits with code Y and writes a useful reason to stderr. They do NOT
+inspect which functions the hook called or how it organized its work.
+"""
+from __future__ import annotations
+
+import importlib.util
+import importlib.machinery
+import json
+import warnings
+from pathlib import Path
+
+
+HOOK_PATH = Path(__file__).resolve().parent.parent / "bin" / "nous-execute-stop"
+
+
+def _load_hook_main():
+    """Load the hook script as a Python module and return its main().
+
+    The hook has no ``.py`` suffix (it's an executable on PATH), so we
+    construct the spec with an explicit SourceFileLoader.
+    """
+    loader = importlib.machinery.SourceFileLoader("nous_execute_stop", str(HOOK_PATH))
+    spec = importlib.util.spec_from_loader("nous_execute_stop", loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module.main
+
+
+def _populate_passing_iter_dir(work_dir: Path, iteration: int = 1) -> Path:
+    """Use StubDispatcher to write a valid execution iter_dir.
+
+    StubDispatcher produces schema-conformant artifacts. Tests here can then
+    mutate the dir to simulate failure modes.
+    """
+    from orchestrator.dispatch import StubDispatcher
+
+    iter_dir = work_dir / "runs" / f"iter-{iteration}"
+    iter_dir.mkdir(parents=True, exist_ok=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dispatcher = StubDispatcher(work_dir)
+
+    # Stub also needs design artifacts present for full validation.
+    dispatcher.dispatch(
+        "planner", "design",
+        output_path=iter_dir / "design_log.md", iteration=iteration,
+    )
+    dispatcher.dispatch(
+        "executor", "execute-analyze",
+        output_path=iter_dir / "executor_log.md", iteration=iteration,
+    )
+    return iter_dir
+
+
+# ─── Pass case ──────────────────────────────────────────────────────────────
+
+class TestStopHookPassCase:
+
+    def test_exits_zero_when_validation_passes_and_principles_present(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        iter_dir = _populate_passing_iter_dir(tmp_path)
+        monkeypatch.setenv("NOUS_ITER_DIR", str(iter_dir))
+
+        main = _load_hook_main()
+        rc = main()
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+
+# ─── Block cases (exit 2) ──────────────────────────────────────────────────
+
+class TestStopHookBlockCases:
+
+    def test_blocks_when_principle_updates_missing(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        iter_dir = _populate_passing_iter_dir(tmp_path)
+        (iter_dir / "principle_updates.json").unlink()
+        monkeypatch.setenv("NOUS_ITER_DIR", str(iter_dir))
+
+        main = _load_hook_main()
+        rc = main()
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "principle_updates.json" in captured.err
+
+    def test_blocks_with_validation_diff_when_findings_corrupted(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        iter_dir = _populate_passing_iter_dir(tmp_path)
+
+        # Drop a required field from findings.json so schema validation fails.
+        findings_path = iter_dir / "findings.json"
+        findings = json.loads(findings_path.read_text())
+        findings.pop("arms", None)  # arms is required
+        findings_path.write_text(json.dumps(findings))
+
+        monkeypatch.setenv("NOUS_ITER_DIR", str(iter_dir))
+
+        main = _load_hook_main()
+        rc = main()
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        # Reason should reference the actual schema problem so the agent
+        # can fix it without re-running the entire iteration.
+        assert "findings.json" in captured.err
+        assert "arms" in captured.err.lower() or "schema" in captured.err.lower()
+
+    def test_blocks_when_iter_dir_missing(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("NOUS_ITER_DIR", str(tmp_path / "nonexistent"))
+
+        main = _load_hook_main()
+        rc = main()
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "nonexistent" in captured.err or "does not exist" in captured.err
+
+    def test_blocks_when_env_var_unset(self, monkeypatch, capsys):
+        monkeypatch.delenv("NOUS_ITER_DIR", raising=False)
+
+        main = _load_hook_main()
+        rc = main()
+
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "NOUS_ITER_DIR" in captured.err


### PR DESCRIPTION
## Summary

- New `bin/nous-execute-stop` Python entrypoint suitable for use as a Claude Code Stop hook.
- Allows the executor session to terminate only when both `principle_updates.json` exists and `nous validate execution` passes — schema-driven, no LLM judgment.
- On block, writes a structured reason to stderr; Claude Code feeds that back into the agent's conversation so it fixes the artifact instead of restarting.

## Why deterministic over Haiku

The `/goal` evaluator (#124) is right for fuzzy success criteria, but execution completion is a schema check — a shell-out that runs `validate_execution` is cheaper, faster, and immune to evaluator drift. The two coexist.

## Wire-up

The orchestrator exports `NOUS_ITER_DIR` before launching the executor session; the per-campaign `.claude/settings.json` (lands in #135) registers this script under `hooks.Stop`. This PR ships just the script — installation today is manual via that settings file.

## Behavioral tests

Five cases in `tests/test_execute_stop_hook.py`:

| Scenario | Expected |
|---|---|
| Valid iter dir + principle_updates.json present | exit 0, no stderr |
| principle_updates.json missing | exit 2, stderr names the file |
| findings.json missing required field | exit 2, stderr has schema diff |
| NOUS_ITER_DIR points at non-existent dir | exit 2, reason given |
| NOUS_ITER_DIR unset | exit 2, config-error reason |

Tests use `StubDispatcher` to populate a known-passing iter_dir, then mutate it to simulate failure modes. Assertions describe what the hook emits (exit code + stderr substrings) — never which functions it called or how it organized internal work.

## Test plan

- [x] `pytest tests/test_execute_stop_hook.py` — 5/5 pass
- [x] `pytest` (full suite) — 343/343 pass (was 338; 5 new)
- [ ] Wire into a real `.claude/settings.json` after #135 lands and confirm an executor session terminates only when validation passes.

Closes #129.
Refs #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)