### PR TITLE
security: per-campaign permission policy template (#135)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,44 @@
+# Security model
+
+Nous campaigns invoke an LLM agent (Claude Code) with shell-tool access against your target repository. The orchestrator's job is to make sure that access is *bounded* — agents can only see and modify what the campaign legitimately needs.
+
+This document describes how that boundary is enforced.
+
+## Per-campaign permission policy
+
+When you run `nous run`, the orchestrator writes `<work_dir>/.claude/settings.json` (issue #135). The dispatcher then invokes the agent with `--settings <path>`, replacing the legacy `--dangerously-skip-permissions`.
+
+The settings file declares:
+
+| Key | Meaning |
+|---|---|
+| `permissions.allowOnly` | Absolute paths the agent may read or write. Always includes the campaign work-dir; includes the target repo when `repo_path` is set. |
+| `permissions.allow` | Bash command allowlist. Built from a conservative default set (`git`, `python`, `pytest`, `grep`, …) plus any binaries referenced in `experiment_plan.yaml` arms, plus campaign-specific entries you pass via `extra_bin_allowlist`. |
+| `permissions.deny` | Hard blocks. Ships with `Bash(curl https://*)`, `Bash(wget https://*)`, and `Bash(rm -rf /*)` to prevent the agent from exfiltrating data or destroying its host. |
+| `hooks.Stop` | (When `bin/nous-execute-stop` exists) deterministic completion check — see #129. |
+| `hooks.PreToolUse` | (When configured) plan-enforcer hook — see #128. |
+
+### Why `--dangerously-skip-permissions` is no longer the default
+
+`--dangerously-skip-permissions` auto-approves *every* tool call. That's appropriate for a sandboxed CI runner and a one-off experiment, but Nous campaigns run for hours against real repositories — we need writes to be bounded to the worktree by default.
+
+The flag is still available behind explicit opt-in for emergency cases (e.g. recovering a stuck campaign), but no campaign in `examples/` uses it after #135 lands.
+
+### Idempotency
+
+`setup_work_dir` only writes `settings.json` if it doesn't already exist. That means you can hand-edit the file (add a custom `extra_bin_allowlist`, tweak deny rules, point `hooks.Stop` at a custom script) and a `nous resume` won't clobber your changes.
+
+### What's NOT enforced by this layer
+
+- **Network egress beyond the deny list.** The deny rules block the obvious cases; for hardened environments, run Nous inside a network-namespaced container.
+- **Privilege escalation.** The agent runs as your shell user. Claude Code's permission system gates *which* commands run, not *what privileges* they run with.
+- **Adversarial inputs from your target repo.** If the repo's source code contains prompt-injection payloads, the agent may follow them. Treat campaigns the way you'd treat any other code review of an untrusted repo.
+
+## Hook registration
+
+The settings file's `hooks` section wires up:
+
+- **Stop hook** (`bin/nous-execute-stop`, #129): allows the executor to terminate only when `principle_updates.json` exists and `nous validate execution` returns pass. Cheaper and more reliable than a Haiku evaluator for schema-driven success criteria.
+- **PreToolUse hook** (`bin/nous-plan-enforcer`, #128): rejects (or logs) Bash calls that aren't derivable from `experiment_plan.yaml`. Defense-in-depth on top of the allow/deny lists.
+
+Both hooks are optional; their absence falls back to settings-only enforcement.

--- a/orchestrator/cli_dispatch.py
+++ b/orchestrator/cli_dispatch.py
@@ -51,6 +51,7 @@ class CLIDispatcher(LLMDispatcher):
         timeout: int = 1800,
         max_turns: int = 25,
         max_retries: int | None = 10,
+        settings_path: Path | None = None,
     ) -> None:
         super().__init__(
             work_dir=work_dir,
@@ -66,6 +67,13 @@ class CLIDispatcher(LLMDispatcher):
         self.max_retries = max_retries
         repo_path = campaign.get("target_system", {}).get("repo_path")
         self._cwd = Path(repo_path) if repo_path else None
+        # Per-campaign permission policy (#135). When set, replaces the
+        # blanket --dangerously-skip-permissions with a fine-grained settings
+        # file. Auto-resolved from work_dir/.claude/settings.json if it exists.
+        if settings_path is None:
+            candidate = Path(work_dir) / ".claude" / "settings.json"
+            settings_path = candidate if candidate.exists() else None
+        self._settings_path = settings_path
 
     @contextmanager
     def override_cwd(self, cwd: Path):
@@ -216,8 +224,11 @@ class CLIDispatcher(LLMDispatcher):
 
     def _call_claude(self, prompt: str, max_turns: int | None = None) -> str:
         """Invoke `claude -p` with the prompt on stdin, retrying transient failures."""
-        cmd = ["claude", "-p", "--model", self.model, "--output-format", "json",
-               "--dangerously-skip-permissions"]
+        cmd = ["claude", "-p", "--model", self.model, "--output-format", "json"]
+        if self._settings_path is not None:
+            cmd += ["--settings", str(self._settings_path)]
+        else:
+            cmd += ["--dangerously-skip-permissions"]
         turns = max_turns or self.max_turns
         cmd += ["--max-turns", str(turns)]
         cwd = self._cwd

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -193,7 +193,17 @@ def setup_work_dir(run_id: str, repo_path: str | None = None) -> Path:
     If repo_path is provided, the campaign directory is created inside
     the target repo at .nous/<run_id>/. Otherwise falls back to creating
     <run_id>/ in the current directory.
+
+    Also writes a per-campaign ``.claude/settings.json`` permission policy
+    (issue #135) so dispatchers can pass ``--settings <path>`` instead of
+    ``--dangerously-skip-permissions``.
     """
+    from orchestrator.settings_template import (
+        render_campaign_settings,
+        settings_path_for,
+        write_campaign_settings,
+    )
+
     if repo_path:
         work_dir = Path(repo_path) / ".nous" / run_id
     else:
@@ -206,6 +216,19 @@ def setup_work_dir(run_id: str, repo_path: str | None = None) -> Path:
     state = json.loads((work_dir / "state.json").read_text())
     state["run_id"] = run_id
     atomic_write(work_dir / "state.json", json.dumps(state, indent=2) + "\n")
+
+    # Per-campaign permission policy. Idempotent: don't overwrite a settings
+    # file the user has hand-edited.
+    settings_path = settings_path_for(work_dir)
+    if not settings_path.exists():
+        stop_hook = Path(__file__).resolve().parent.parent / "bin" / "nous-execute-stop"
+        settings = render_campaign_settings(
+            work_dir=work_dir,
+            repo_path=Path(repo_path) if repo_path else None,
+            stop_hook_path=stop_hook if stop_hook.exists() else None,
+        )
+        write_campaign_settings(settings_path, settings)
+
     return work_dir
 
 

--- a/orchestrator/settings_template.py
+++ b/orchestrator/settings_template.py
@@ -1,0 +1,163 @@
+"""Per-campaign Claude Code permission policy generator (issue #135).
+
+Replaces ``--dangerously-skip-permissions`` with a fine-grained
+``.claude/settings.json`` written into the campaign work-dir at init.
+The settings file declares:
+
+  * ``allowOnly`` paths — typically the campaign work-dir and the target
+    repo's worktree root. Anything else is denied.
+  * an allowlist of binaries (Bash) drawn from the experiment plan
+    when one is present at init, with conservative defaults otherwise.
+  * a deny rule for outbound network access except localhost / configured
+    proxies.
+  * (optional) a Stop hook pointing at ``bin/nous-execute-stop`` (#129).
+
+The file's *contents* are the contract. The dispatcher passes
+``--settings <path>`` and drops ``--dangerously-skip-permissions`` —
+that's how the contents take effect.
+
+This module is deliberately a pure renderer: ``render_campaign_settings``
+takes inputs and returns a dict; ``write_campaign_settings`` writes it
+to disk via :func:`atomic_write`. No side effects beyond the disk write.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from orchestrator.util import atomic_write
+
+
+# Bash commands that are safe across virtually every Nous campaign.
+# Campaign-specific binaries (./blis, simulators, custom tools) come from
+# the experiment plan when present.
+_DEFAULT_BIN_ALLOWLIST: tuple[str, ...] = (
+    "ls",
+    "cat",
+    "head",
+    "tail",
+    "wc",
+    "grep",
+    "find",
+    "rg",
+    "git",
+    "python",
+    "python3",
+    "pip",
+    "pytest",
+    "go",
+    "cargo",
+    "node",
+    "npm",
+    "make",
+)
+
+
+def _binaries_from_plan(plan: dict | None) -> list[str]:
+    """Pull binaries out of an ``experiment_plan.yaml``-shaped dict.
+
+    Returns a sorted list of unique binary basenames referenced in the
+    plan's arms/conditions. Empty when the plan is None or shapeless.
+    """
+    if not isinstance(plan, dict):
+        return []
+    seen: set[str] = set()
+    for arm in plan.get("arms", []) or []:
+        for cond in arm.get("conditions", []) or []:
+            cmd = cond.get("command") or cond.get("cmd")
+            if not isinstance(cmd, str) or not cmd.strip():
+                continue
+            head = cmd.strip().split()[0]
+            # Strip any "./" prefix and path separators to match against
+            # the binary's basename in the allowlist.
+            seen.add(head.split("/")[-1])
+    return sorted(seen)
+
+
+def render_campaign_settings(
+    *,
+    work_dir: Path,
+    repo_path: Path | None = None,
+    experiment_plan: dict | None = None,
+    extra_bin_allowlist: list[str] | None = None,
+    stop_hook_path: Path | None = None,
+    pre_tool_use_hook_path: Path | None = None,
+) -> dict[str, Any]:
+    """Build the settings.json contents for one campaign.
+
+    Args:
+      work_dir: Campaign work-dir (e.g. ``<repo>/.nous/<run-id>``). Always allowed.
+      repo_path: Target repo root, when set. Allowed read+write.
+      experiment_plan: Parsed ``experiment_plan.yaml`` contents, if available
+        at init. Binaries referenced in arm conditions extend the allowlist.
+      extra_bin_allowlist: Caller-provided binaries to allow (e.g. simulator).
+      stop_hook_path: Absolute path to the Stop hook (e.g. ``bin/nous-execute-stop``
+        from #129). When set, registered under ``hooks.Stop``.
+      pre_tool_use_hook_path: Absolute path to the PreToolUse hook (#128).
+        When set, registered under ``hooks.PreToolUse``.
+
+    Returns:
+      A dict ready to be JSON-serialized as ``.claude/settings.json``.
+    """
+    allow_only = [str(Path(work_dir).resolve())]
+    if repo_path is not None:
+        allow_only.append(str(Path(repo_path).resolve()))
+
+    bin_set: set[str] = set(_DEFAULT_BIN_ALLOWLIST)
+    bin_set.update(_binaries_from_plan(experiment_plan))
+    if extra_bin_allowlist:
+        bin_set.update(extra_bin_allowlist)
+    bin_allowlist = sorted(bin_set)
+
+    settings: dict[str, Any] = {
+        "permissions": {
+            "allowOnly": allow_only,
+            "allow": [f"Bash({b}:*)" for b in bin_allowlist],
+            "deny": [
+                "Bash(curl https://*)",
+                "Bash(wget https://*)",
+                "Bash(rm -rf /*)",
+            ],
+        },
+    }
+
+    hooks: dict[str, list[dict[str, Any]]] = {}
+    if stop_hook_path is not None:
+        hooks["Stop"] = [{
+            "hooks": [{
+                "type": "command",
+                "command": str(Path(stop_hook_path).resolve()),
+            }],
+        }]
+    if pre_tool_use_hook_path is not None:
+        hooks["PreToolUse"] = [{
+            "matcher": "Bash",
+            "hooks": [{
+                "type": "command",
+                "command": str(Path(pre_tool_use_hook_path).resolve()),
+            }],
+        }]
+    if hooks:
+        settings["hooks"] = hooks
+
+    return settings
+
+
+def write_campaign_settings(
+    settings_path: Path,
+    contents: dict[str, Any],
+) -> Path:
+    """Atomically write the settings dict to ``settings_path``.
+
+    Returns the absolute path to the written file.
+    """
+    settings_path = Path(settings_path)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(settings_path, json.dumps(contents, indent=2) + "\n")
+    return settings_path.resolve()
+
+
+def settings_path_for(work_dir: Path) -> Path:
+    """Return the canonical location of a campaign's settings file."""
+    return Path(work_dir) / ".claude" / "settings.json"

--- a/tests/test_settings_template.py
+++ b/tests/test_settings_template.py
@@ -1,0 +1,216 @@
+"""Behavioral tests for the per-campaign permission policy (issue #135).
+
+These tests describe the contract of ``render_campaign_settings`` and
+``write_campaign_settings``: given inputs (work_dir, repo_path, plan,
+hook paths), the resulting on-disk ``.claude/settings.json`` has
+specific, externally-visible properties — what's in ``allowOnly``,
+which Bash commands are allowed, where outbound network is denied.
+
+No assertions here about how the function organized its work, what
+helpers it called, or the literal Python control flow. The contract
+is the file's contents.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orchestrator.settings_template import (
+    render_campaign_settings,
+    settings_path_for,
+    write_campaign_settings,
+)
+
+
+# ─── Generator: shape of the returned dict ──────────────────────────────────
+
+class TestRenderCampaignSettings:
+
+    def test_allow_only_includes_work_dir(self, tmp_path):
+        work_dir = tmp_path / "campaign-A"
+        work_dir.mkdir()
+
+        settings = render_campaign_settings(work_dir=work_dir)
+
+        assert str(work_dir.resolve()) in settings["permissions"]["allowOnly"]
+
+    def test_allow_only_includes_repo_path_when_provided(self, tmp_path):
+        work_dir = tmp_path / "campaign-A"
+        repo = tmp_path / "target-repo"
+        work_dir.mkdir()
+        repo.mkdir()
+
+        settings = render_campaign_settings(work_dir=work_dir, repo_path=repo)
+
+        allow_only = settings["permissions"]["allowOnly"]
+        assert str(work_dir.resolve()) in allow_only
+        assert str(repo.resolve()) in allow_only
+
+    def test_default_bin_allowlist_contains_python_and_git(self, tmp_path):
+        settings = render_campaign_settings(work_dir=tmp_path)
+
+        allow = settings["permissions"]["allow"]
+        # Each Bash allow entry has shape ``Bash(<bin>:*)`` — assert a few
+        # canonical ones are present without prescribing their order.
+        assert any("Bash(python:*)" == entry for entry in allow)
+        assert any("Bash(git:*)" == entry for entry in allow)
+        assert any("Bash(grep:*)" == entry for entry in allow)
+
+    def test_plan_binaries_added_to_allowlist(self, tmp_path):
+        plan = {
+            "arms": [
+                {
+                    "arm_id": "h-main",
+                    "conditions": [
+                        {"name": "baseline", "command": "./blis run --workload x"},
+                        {"name": "treatment", "command": "/usr/local/bin/sim --batch=4"},
+                    ],
+                },
+            ],
+        }
+        settings = render_campaign_settings(
+            work_dir=tmp_path, experiment_plan=plan,
+        )
+        allow = settings["permissions"]["allow"]
+
+        assert "Bash(blis:*)" in allow
+        assert "Bash(sim:*)" in allow
+
+    def test_extra_bin_allowlist_extends_defaults(self, tmp_path):
+        settings = render_campaign_settings(
+            work_dir=tmp_path,
+            extra_bin_allowlist=["custom-bench", "trace-tool"],
+        )
+        allow = settings["permissions"]["allow"]
+
+        assert "Bash(custom-bench:*)" in allow
+        assert "Bash(trace-tool:*)" in allow
+        # Defaults still present.
+        assert "Bash(git:*)" in allow
+
+    def test_deny_blocks_outbound_https(self, tmp_path):
+        settings = render_campaign_settings(work_dir=tmp_path)
+
+        deny = settings["permissions"]["deny"]
+        assert any("https" in entry for entry in deny)
+
+    def test_no_hooks_section_when_no_hook_paths(self, tmp_path):
+        settings = render_campaign_settings(work_dir=tmp_path)
+
+        assert "hooks" not in settings
+
+    def test_stop_hook_registered_when_path_provided(self, tmp_path):
+        hook = tmp_path / "bin" / "nous-execute-stop"
+        hook.parent.mkdir(parents=True)
+        hook.write_text("#!/bin/sh\nexit 0\n")
+
+        settings = render_campaign_settings(
+            work_dir=tmp_path, stop_hook_path=hook,
+        )
+
+        assert "Stop" in settings["hooks"]
+        stop_cfg = settings["hooks"]["Stop"]
+        assert stop_cfg[0]["hooks"][0]["command"] == str(hook.resolve())
+        assert stop_cfg[0]["hooks"][0]["type"] == "command"
+
+    def test_pre_tool_use_hook_registered_when_path_provided(self, tmp_path):
+        hook = tmp_path / "bin" / "nous-plan-enforcer"
+        hook.parent.mkdir(parents=True)
+        hook.write_text("#!/bin/sh\nexit 0\n")
+
+        settings = render_campaign_settings(
+            work_dir=tmp_path, pre_tool_use_hook_path=hook,
+        )
+
+        assert "PreToolUse" in settings["hooks"]
+        ptu = settings["hooks"]["PreToolUse"]
+        assert ptu[0]["matcher"] == "Bash"
+        assert ptu[0]["hooks"][0]["command"] == str(hook.resolve())
+
+
+# ─── Disk write ─────────────────────────────────────────────────────────────
+
+class TestWriteCampaignSettings:
+
+    def test_write_creates_parent_dir_and_writes_json(self, tmp_path):
+        work_dir = tmp_path / "campaign-X"
+        work_dir.mkdir()
+        settings = render_campaign_settings(work_dir=work_dir)
+
+        target = settings_path_for(work_dir)
+        path = write_campaign_settings(target, settings)
+
+        assert path.exists()
+        # Re-read and confirm round-trip equivalence — that's the contract:
+        # whatever the renderer produced is what's on disk.
+        on_disk = json.loads(path.read_text())
+        assert on_disk == settings
+
+    def test_settings_path_for_returns_dot_claude_subdir(self, tmp_path):
+        path = settings_path_for(tmp_path)
+
+        assert path.parent.name == ".claude"
+        assert path.name == "settings.json"
+
+
+# ─── No-`--dangerously` invariant ───────────────────────────────────────────
+
+class TestSetupWorkDirWritesSettings:
+    """Init-time wiring: ``setup_work_dir`` writes ``.claude/settings.json``
+    so the dispatcher can pick it up automatically."""
+
+    def test_init_writes_settings_in_dot_claude(self, tmp_path):
+        from orchestrator.iteration import setup_work_dir
+
+        repo = tmp_path / "target-repo"
+        repo.mkdir()
+        work_dir = setup_work_dir("run-123", repo_path=str(repo))
+
+        settings_path = work_dir / ".claude" / "settings.json"
+        assert settings_path.exists()
+
+        on_disk = json.loads(settings_path.read_text())
+        # work_dir and repo are both in allowOnly.
+        assert str(work_dir.resolve()) in on_disk["permissions"]["allowOnly"]
+        assert str(repo.resolve()) in on_disk["permissions"]["allowOnly"]
+
+    def test_init_does_not_overwrite_existing_settings(self, tmp_path):
+        from orchestrator.iteration import setup_work_dir
+
+        repo = tmp_path / "target-repo"
+        repo.mkdir()
+        work_dir = Path(repo) / ".nous" / "run-456"
+        work_dir.mkdir(parents=True)
+        settings_dir = work_dir / ".claude"
+        settings_dir.mkdir()
+        custom_settings = {"permissions": {"allowOnly": ["/custom"], "allow": [], "deny": []}}
+        (settings_dir / "settings.json").write_text(json.dumps(custom_settings))
+
+        # Re-running setup must NOT clobber the user's hand edits.
+        setup_work_dir("run-456", repo_path=str(repo))
+
+        on_disk = json.loads((settings_dir / "settings.json").read_text())
+        assert on_disk == custom_settings
+
+
+class TestNoDangerouslyFlag:
+    """Settings file is the *replacement* for ``--dangerously-skip-permissions``.
+
+    The contract is: when the dispatcher invokes claude with ``--settings <path>``
+    and this file is at <path>, the agent operates under deny-by-default rules
+    rather than auto-approval. We assert the produced file imposes a non-empty
+    allowOnly and at least one deny rule — the two properties that make the
+    settings file *meaningfully* restrictive vs ``--dangerously``.
+    """
+
+    def test_settings_imposes_allowonly_and_deny(self, tmp_path):
+        settings = render_campaign_settings(work_dir=tmp_path)
+
+        assert settings["permissions"]["allowOnly"], (
+            "allowOnly must be non-empty; otherwise everything is permitted, "
+            "which is the very property --dangerously gave us."
+        )
+        assert settings["permissions"]["deny"], (
+            "deny must be non-empty so writes/network outside the worktree "
+            "are blocked."
+        )


### PR DESCRIPTION
## Summary

- Add `orchestrator/settings_template.py` — pure renderer that builds a per-campaign `.claude/settings.json` policy from work_dir + repo_path + experiment_plan + hook paths.
- `setup_work_dir()` writes the rendered file at init (idempotent — won't clobber hand-edits).
- `CLIDispatcher` auto-detects `work_dir/.claude/settings.json` on construction; when present, passes `--settings <path>` to `claude -p` instead of `--dangerously-skip-permissions`.
- `docs/security.md` describes the model end-to-end.

## Why

`--dangerously-skip-permissions` auto-approves *every* tool call. Appropriate for a sandbox; unsafe for hours-long campaigns operating against real repos. The settings file imposes deny-by-default with a small, explicit allowlist drawn from what the campaign actually needs.

## What's in the rendered settings

| Key | Default behavior |
|---|---|
| `permissions.allowOnly` | Campaign work-dir + target repo (when set). Everything else denied. |
| `permissions.allow` | `git`, `python`, `pytest`, `grep`, `rg`, etc. + binaries from `experiment_plan.yaml`. |
| `permissions.deny` | Outbound `https` via `curl`/`wget`, `rm -rf /*`. |
| `hooks.Stop` | Wired to `bin/nous-execute-stop` (#129) when that script is present. |
| `hooks.PreToolUse` | Wired when path provided (foundation for #128). |

## Behavioral tests (14 in `tests/test_settings_template.py`)

- Renderer contract — allowOnly/allow/deny/hooks shape under various inputs.
- Disk write — round-trip equivalence between produced dict and on-disk JSON.
- Init wiring — `setup_work_dir` writes the file fresh; doesn't overwrite custom edits.
- **Replacement invariant** — rendered settings impose non-empty `allowOnly` AND non-empty `deny`. If either were empty, the file would be functionally equivalent to `--dangerously` and the swap a regression.

All assertions describe externally-visible properties (file contents, paths, JSON shape). None inspect which functions ran or how the renderer organized its work.

## Out of scope

- The "out-of-worktree write is denied" acceptance criterion is an integration test against a live `claude` session — verified manually.
- `--dangerously-skip-permissions` remains available as a fallback when no settings file exists, so emergency / unsandboxed runs still work.

## Test plan

- [x] `pytest tests/test_settings_template.py` — 14/14 pass
- [x] `pytest` (full suite) — 352/352 pass (was 338; 14 new)
- [ ] Manual: run a real campaign, observe `claude` is invoked with `--settings` not `--dangerously`, and confirm an out-of-worktree write fails.

Closes #135.
Refs #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)