### PR TITLE
feat: PreToolUse plan-enforcer hook (#128)

### DIFF
--- a/bin/nous-plan-enforcer
+++ b/bin/nous-plan-enforcer
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: enforce experiment_plan.yaml during EXECUTE_ANALYZE (#128).
+
+Claude Code calls this hook before every Bash tool invocation in the
+executor session. It compares the proposed command against the plan
+sitting in ``$NOUS_ITER_DIR/experiment_plan.yaml`` and decides whether
+to allow it.
+
+Two modes (controlled by ``NOUS_PLAN_ENFORCEMENT``):
+
+  * ``strict``: exit 2 with a structured reason on stderr if the
+    proposed command's head binary doesn't match any planned condition's
+    head binary. The agent receives the reason in its conversation and
+    is expected to either (a) revise the command or (b) annotate it
+    ``# nous: ad-hoc`` to explicitly opt out for one call.
+  * ``warn`` (default): always exit 0; record violations to
+    ``$NOUS_ITER_DIR/plan_violations.jsonl`` for audit. Lets you watch
+    for drift in soak runs without breaking iteration.
+
+Escape hatch: a command containing the literal string ``# nous: ad-hoc``
+is allowed in both modes and logged as ``kind: ad-hoc`` so reviewers can
+audit how often it's used.
+
+Exit codes: 0 = allow, 2 = block (strict only).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+_AD_HOC_MARKER = "# nous: ad-hoc"
+_OK = 0
+_BLOCK = 2
+
+
+def _read_event() -> dict:
+    """Read the PreToolUse JSON payload from stdin. Returns {} on bad input."""
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return {}
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _proposed_command(event: dict) -> str | None:
+    """Return the Bash command this event is proposing, or None for non-Bash."""
+    if event.get("tool_name") != "Bash":
+        return None
+    cmd = event.get("tool_input", {}).get("command")
+    if not isinstance(cmd, str):
+        return None
+    return cmd
+
+
+def _head_binary(cmd: str) -> str | None:
+    """Pull the basename of the first token of a shell command."""
+    cmd = cmd.lstrip()
+    # Strip leading comments or ad-hoc marker so we extract the real binary.
+    for line in cmd.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        first = stripped.split()[0]
+        # Drop env-var prefix like ``FOO=bar binary``.
+        while "=" in first and not first.startswith("/") and not first.startswith("./"):
+            # heuristic: env-var-only assignment, skip to next token
+            tokens = stripped.split()
+            if len(tokens) < 2:
+                return None
+            tokens.pop(0)
+            stripped = " ".join(tokens)
+            first = stripped.split()[0]
+        return first.split("/")[-1]
+    return None
+
+
+def _plan_binaries(plan_path: Path) -> set[str]:
+    """Extract the set of head-binary basenames referenced in the plan."""
+    if not plan_path.exists():
+        return set()
+    try:
+        plan = yaml.safe_load(plan_path.read_text()) or {}
+    except yaml.YAMLError:
+        return set()
+    bins: set[str] = set()
+    for arm in plan.get("arms", []) or []:
+        for cond in arm.get("conditions", []) or []:
+            cmd = cond.get("command") or cond.get("cmd")
+            if isinstance(cmd, str):
+                bin_name = _head_binary(cmd)
+                if bin_name:
+                    bins.add(bin_name)
+    return bins
+
+
+def _planning_arm_for(plan_path: Path, head: str) -> str | None:
+    """Best-effort: return arm_id where ``head`` appears (or None)."""
+    if not plan_path.exists():
+        return None
+    try:
+        plan = yaml.safe_load(plan_path.read_text()) or {}
+    except yaml.YAMLError:
+        return None
+    for arm in plan.get("arms", []) or []:
+        for cond in arm.get("conditions", []) or []:
+            cmd = cond.get("command") or cond.get("cmd")
+            if isinstance(cmd, str) and _head_binary(cmd) == head:
+                return arm.get("arm_id")
+    return None
+
+
+def _log_violation(
+    iter_dir: Path,
+    *,
+    kind: str,
+    command: str,
+    arm: str | None,
+) -> None:
+    log_path = iter_dir / "plan_violations.jsonl"
+    record = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "kind": kind,
+        "command": command,
+        "arm": arm or "",
+    }
+    try:
+        with open(log_path, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        # Best-effort; never block the agent because logging failed.
+        pass
+
+
+def main() -> int:
+    iter_dir_str = os.environ.get("NOUS_ITER_DIR")
+    mode = os.environ.get("NOUS_PLAN_ENFORCEMENT", "warn").lower()
+
+    event = _read_event()
+    cmd = _proposed_command(event)
+    if cmd is None:
+        # Not a Bash event — nothing to enforce.
+        return _OK
+
+    if not iter_dir_str:
+        # Hook misconfigured — fail open (cannot block what we can't compare).
+        return _OK
+
+    iter_dir = Path(iter_dir_str)
+    plan_path = iter_dir / "experiment_plan.yaml"
+
+    # Escape hatch.
+    if _AD_HOC_MARKER in cmd:
+        _log_violation(iter_dir, kind="ad-hoc", command=cmd, arm=None)
+        return _OK
+
+    head = _head_binary(cmd)
+    if head is None:
+        # Couldn't parse — fail open (warn) or block (strict).
+        if mode == "strict":
+            print(
+                f"plan enforcer could not parse the proposed command:\n  {cmd!r}",
+                file=sys.stderr,
+            )
+            return _BLOCK
+        return _OK
+
+    planned = _plan_binaries(plan_path)
+    if head in planned:
+        return _OK
+
+    arm = _planning_arm_for(plan_path, head)
+    if mode == "strict":
+        print(
+            f"command head '{head}' is not in experiment_plan.yaml.\n"
+            f"Either revise the command to use a planned binary, or, "
+            f"if this is intentional, add '{_AD_HOC_MARKER}' as a comment "
+            f"line in the command.",
+            file=sys.stderr,
+        )
+        return _BLOCK
+
+    _log_violation(iter_dir, kind="unplanned", command=cmd, arm=arm)
+    return _OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,44 @@
+# Security model
+
+Nous campaigns invoke an LLM agent (Claude Code) with shell-tool access against your target repository. The orchestrator's job is to make sure that access is *bounded* — agents can only see and modify what the campaign legitimately needs.
+
+This document describes how that boundary is enforced.
+
+## Per-campaign permission policy
+
+When you run `nous run`, the orchestrator writes `<work_dir>/.claude/settings.json` (issue #135). The dispatcher then invokes the agent with `--settings <path>`, replacing the legacy `--dangerously-skip-permissions`.
+
+The settings file declares:
+
+| Key | Meaning |
+|---|---|
+| `permissions.allowOnly` | Absolute paths the agent may read or write. Always includes the campaign work-dir; includes the target repo when `repo_path` is set. |
+| `permissions.allow` | Bash command allowlist. Built from a conservative default set (`git`, `python`, `pytest`, `grep`, …) plus any binaries referenced in `experiment_plan.yaml` arms, plus campaign-specific entries you pass via `extra_bin_allowlist`. |
+| `permissions.deny` | Hard blocks. Ships with `Bash(curl https://*)`, `Bash(wget https://*)`, and `Bash(rm -rf /*)` to prevent the agent from exfiltrating data or destroying its host. |
+| `hooks.Stop` | (When `bin/nous-execute-stop` exists) deterministic completion check — see #129. |
+| `hooks.PreToolUse` | (When configured) plan-enforcer hook — see #128. |
+
+### Why `--dangerously-skip-permissions` is no longer the default
+
+`--dangerously-skip-permissions` auto-approves *every* tool call. That's appropriate for a sandboxed CI runner and a one-off experiment, but Nous campaigns run for hours against real repositories — we need writes to be bounded to the worktree by default.
+
+The flag is still available behind explicit opt-in for emergency cases (e.g. recovering a stuck campaign), but no campaign in `examples/` uses it after #135 lands.
+
+### Idempotency
+
+`setup_work_dir` only writes `settings.json` if it doesn't already exist. That means you can hand-edit the file (add a custom `extra_bin_allowlist`, tweak deny rules, point `hooks.Stop` at a custom script) and a `nous resume` won't clobber your changes.
+
+### What's NOT enforced by this layer
+
+- **Network egress beyond the deny list.** The deny rules block the obvious cases; for hardened environments, run Nous inside a network-namespaced container.
+- **Privilege escalation.** The agent runs as your shell user. Claude Code's permission system gates *which* commands run, not *what privileges* they run with.
+- **Adversarial inputs from your target repo.** If the repo's source code contains prompt-injection payloads, the agent may follow them. Treat campaigns the way you'd treat any other code review of an untrusted repo.
+
+## Hook registration
+
+The settings file's `hooks` section wires up:
+
+- **Stop hook** (`bin/nous-execute-stop`, #129): allows the executor to terminate only when `principle_updates.json` exists and `nous validate execution` returns pass. Cheaper and more reliable than a Haiku evaluator for schema-driven success criteria.
+- **PreToolUse hook** (`bin/nous-plan-enforcer`, #128): rejects (or logs) Bash calls that aren't derivable from `experiment_plan.yaml`. Defense-in-depth on top of the allow/deny lists.
+
+Both hooks are optional; their absence falls back to settings-only enforcement.

--- a/orchestrator/cli_dispatch.py
+++ b/orchestrator/cli_dispatch.py
@@ -51,6 +51,7 @@ class CLIDispatcher(LLMDispatcher):
         timeout: int = 1800,
         max_turns: int = 25,
         max_retries: int | None = 10,
+        settings_path: Path | None = None,
     ) -> None:
         super().__init__(
             work_dir=work_dir,
@@ -66,6 +67,13 @@ class CLIDispatcher(LLMDispatcher):
         self.max_retries = max_retries
         repo_path = campaign.get("target_system", {}).get("repo_path")
         self._cwd = Path(repo_path) if repo_path else None
+        # Per-campaign permission policy (#135). When set, replaces the
+        # blanket --dangerously-skip-permissions with a fine-grained settings
+        # file. Auto-resolved from work_dir/.claude/settings.json if it exists.
+        if settings_path is None:
+            candidate = Path(work_dir) / ".claude" / "settings.json"
+            settings_path = candidate if candidate.exists() else None
+        self._settings_path = settings_path
 
     @contextmanager
     def override_cwd(self, cwd: Path):
@@ -216,8 +224,11 @@ class CLIDispatcher(LLMDispatcher):
 
     def _call_claude(self, prompt: str, max_turns: int | None = None) -> str:
         """Invoke `claude -p` with the prompt on stdin, retrying transient failures."""
-        cmd = ["claude", "-p", "--model", self.model, "--output-format", "json",
-               "--dangerously-skip-permissions"]
+        cmd = ["claude", "-p", "--model", self.model, "--output-format", "json"]
+        if self._settings_path is not None:
+            cmd += ["--settings", str(self._settings_path)]
+        else:
+            cmd += ["--dangerously-skip-permissions"]
         turns = max_turns or self.max_turns
         cmd += ["--max-turns", str(turns)]
         cwd = self._cwd

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -193,7 +193,17 @@ def setup_work_dir(run_id: str, repo_path: str | None = None) -> Path:
     If repo_path is provided, the campaign directory is created inside
     the target repo at .nous/<run_id>/. Otherwise falls back to creating
     <run_id>/ in the current directory.
+
+    Also writes a per-campaign ``.claude/settings.json`` permission policy
+    (issue #135) so dispatchers can pass ``--settings <path>`` instead of
+    ``--dangerously-skip-permissions``.
     """
+    from orchestrator.settings_template import (
+        render_campaign_settings,
+        settings_path_for,
+        write_campaign_settings,
+    )
+
     if repo_path:
         work_dir = Path(repo_path) / ".nous" / run_id
     else:
@@ -206,6 +216,19 @@ def setup_work_dir(run_id: str, repo_path: str | None = None) -> Path:
     state = json.loads((work_dir / "state.json").read_text())
     state["run_id"] = run_id
     atomic_write(work_dir / "state.json", json.dumps(state, indent=2) + "\n")
+
+    # Per-campaign permission policy. Idempotent: don't overwrite a settings
+    # file the user has hand-edited.
+    settings_path = settings_path_for(work_dir)
+    if not settings_path.exists():
+        stop_hook = Path(__file__).resolve().parent.parent / "bin" / "nous-execute-stop"
+        settings = render_campaign_settings(
+            work_dir=work_dir,
+            repo_path=Path(repo_path) if repo_path else None,
+            stop_hook_path=stop_hook if stop_hook.exists() else None,
+        )
+        write_campaign_settings(settings_path, settings)
+
     return work_dir
 
 

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -221,11 +221,14 @@ def setup_work_dir(run_id: str, repo_path: str | None = None) -> Path:
     # file the user has hand-edited.
     settings_path = settings_path_for(work_dir)
     if not settings_path.exists():
-        stop_hook = Path(__file__).resolve().parent.parent / "bin" / "nous-execute-stop"
+        bin_dir = Path(__file__).resolve().parent.parent / "bin"
+        stop_hook = bin_dir / "nous-execute-stop"
+        plan_enforcer = bin_dir / "nous-plan-enforcer"
         settings = render_campaign_settings(
             work_dir=work_dir,
             repo_path=Path(repo_path) if repo_path else None,
             stop_hook_path=stop_hook if stop_hook.exists() else None,
+            pre_tool_use_hook_path=plan_enforcer if plan_enforcer.exists() else None,
         )
         write_campaign_settings(settings_path, settings)
 

--- a/orchestrator/settings_template.py
+++ b/orchestrator/settings_template.py
@@ -1,0 +1,163 @@
+"""Per-campaign Claude Code permission policy generator (issue #135).
+
+Replaces ``--dangerously-skip-permissions`` with a fine-grained
+``.claude/settings.json`` written into the campaign work-dir at init.
+The settings file declares:
+
+  * ``allowOnly`` paths — typically the campaign work-dir and the target
+    repo's worktree root. Anything else is denied.
+  * an allowlist of binaries (Bash) drawn from the experiment plan
+    when one is present at init, with conservative defaults otherwise.
+  * a deny rule for outbound network access except localhost / configured
+    proxies.
+  * (optional) a Stop hook pointing at ``bin/nous-execute-stop`` (#129).
+
+The file's *contents* are the contract. The dispatcher passes
+``--settings <path>`` and drops ``--dangerously-skip-permissions`` —
+that's how the contents take effect.
+
+This module is deliberately a pure renderer: ``render_campaign_settings``
+takes inputs and returns a dict; ``write_campaign_settings`` writes it
+to disk via :func:`atomic_write`. No side effects beyond the disk write.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from orchestrator.util import atomic_write
+
+
+# Bash commands that are safe across virtually every Nous campaign.
+# Campaign-specific binaries (./blis, simulators, custom tools) come from
+# the experiment plan when present.
+_DEFAULT_BIN_ALLOWLIST: tuple[str, ...] = (
+    "ls",
+    "cat",
+    "head",
+    "tail",
+    "wc",
+    "grep",
+    "find",
+    "rg",
+    "git",
+    "python",
+    "python3",
+    "pip",
+    "pytest",
+    "go",
+    "cargo",
+    "node",
+    "npm",
+    "make",
+)
+
+
+def _binaries_from_plan(plan: dict | None) -> list[str]:
+    """Pull binaries out of an ``experiment_plan.yaml``-shaped dict.
+
+    Returns a sorted list of unique binary basenames referenced in the
+    plan's arms/conditions. Empty when the plan is None or shapeless.
+    """
+    if not isinstance(plan, dict):
+        return []
+    seen: set[str] = set()
+    for arm in plan.get("arms", []) or []:
+        for cond in arm.get("conditions", []) or []:
+            cmd = cond.get("command") or cond.get("cmd")
+            if not isinstance(cmd, str) or not cmd.strip():
+                continue
+            head = cmd.strip().split()[0]
+            # Strip any "./" prefix and path separators to match against
+            # the binary's basename in the allowlist.
+            seen.add(head.split("/")[-1])
+    return sorted(seen)
+
+
+def render_campaign_settings(
+    *,
+    work_dir: Path,
+    repo_path: Path | None = None,
+    experiment_plan: dict | None = None,
+    extra_bin_allowlist: list[str] | None = None,
+    stop_hook_path: Path | None = None,
+    pre_tool_use_hook_path: Path | None = None,
+) -> dict[str, Any]:
+    """Build the settings.json contents for one campaign.
+
+    Args:
+      work_dir: Campaign work-dir (e.g. ``<repo>/.nous/<run-id>``). Always allowed.
+      repo_path: Target repo root, when set. Allowed read+write.
+      experiment_plan: Parsed ``experiment_plan.yaml`` contents, if available
+        at init. Binaries referenced in arm conditions extend the allowlist.
+      extra_bin_allowlist: Caller-provided binaries to allow (e.g. simulator).
+      stop_hook_path: Absolute path to the Stop hook (e.g. ``bin/nous-execute-stop``
+        from #129). When set, registered under ``hooks.Stop``.
+      pre_tool_use_hook_path: Absolute path to the PreToolUse hook (#128).
+        When set, registered under ``hooks.PreToolUse``.
+
+    Returns:
+      A dict ready to be JSON-serialized as ``.claude/settings.json``.
+    """
+    allow_only = [str(Path(work_dir).resolve())]
+    if repo_path is not None:
+        allow_only.append(str(Path(repo_path).resolve()))
+
+    bin_set: set[str] = set(_DEFAULT_BIN_ALLOWLIST)
+    bin_set.update(_binaries_from_plan(experiment_plan))
+    if extra_bin_allowlist:
+        bin_set.update(extra_bin_allowlist)
+    bin_allowlist = sorted(bin_set)
+
+    settings: dict[str, Any] = {
+        "permissions": {
+            "allowOnly": allow_only,
+            "allow": [f"Bash({b}:*)" for b in bin_allowlist],
+            "deny": [
+                "Bash(curl https://*)",
+                "Bash(wget https://*)",
+                "Bash(rm -rf /*)",
+            ],
+        },
+    }
+
+    hooks: dict[str, list[dict[str, Any]]] = {}
+    if stop_hook_path is not None:
+        hooks["Stop"] = [{
+            "hooks": [{
+                "type": "command",
+                "command": str(Path(stop_hook_path).resolve()),
+            }],
+        }]
+    if pre_tool_use_hook_path is not None:
+        hooks["PreToolUse"] = [{
+            "matcher": "Bash",
+            "hooks": [{
+                "type": "command",
+                "command": str(Path(pre_tool_use_hook_path).resolve()),
+            }],
+        }]
+    if hooks:
+        settings["hooks"] = hooks
+
+    return settings
+
+
+def write_campaign_settings(
+    settings_path: Path,
+    contents: dict[str, Any],
+) -> Path:
+    """Atomically write the settings dict to ``settings_path``.
+
+    Returns the absolute path to the written file.
+    """
+    settings_path = Path(settings_path)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(settings_path, json.dumps(contents, indent=2) + "\n")
+    return settings_path.resolve()
+
+
+def settings_path_for(work_dir: Path) -> Path:
+    """Return the canonical location of a campaign's settings file."""
+    return Path(work_dir) / ".claude" / "settings.json"

--- a/tests/test_plan_enforcer_hook.py
+++ b/tests/test_plan_enforcer_hook.py
@@ -1,0 +1,240 @@
+"""Behavioral tests for the PreToolUse plan-enforcer hook (issue #128).
+
+The hook intercepts Bash tool calls during EXECUTE_ANALYZE and decides
+whether the proposed command is consistent with the iteration's
+``experiment_plan.yaml``. The decision protocol:
+
+  * ``--strict`` (env: ``NOUS_PLAN_ENFORCEMENT=strict``): block (exit 2)
+    if the command's head binary doesn't appear in any planned condition.
+  * ``--warn`` (default): always allow (exit 0) but log violations to
+    ``<iter_dir>/plan_violations.jsonl``.
+  * Escape hatch: a command containing ``# nous: ad-hoc`` is allowed in
+    strict mode AND logged distinctly so reviewers can audit the use.
+
+The hook is invoked by Claude Code with JSON on stdin describing the
+proposed tool call. We test the contract: given (mode, plan, proposed
+command) → exit code + violations log entry.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import io
+import json
+from pathlib import Path
+
+import yaml
+
+
+HOOK_PATH = Path(__file__).resolve().parent.parent / "bin" / "nous-plan-enforcer"
+
+
+def _load_hook_main():
+    loader = importlib.machinery.SourceFileLoader("nous_plan_enforcer", str(HOOK_PATH))
+    spec = importlib.util.spec_from_loader("nous_plan_enforcer", loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module.main
+
+
+def _write_plan(iter_dir: Path, arms: list[dict]) -> None:
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    plan = {"arms": arms}
+    (iter_dir / "experiment_plan.yaml").write_text(yaml.safe_dump(plan))
+
+
+def _hook_event(command: str, cwd: str) -> str:
+    """Emit a Claude Code PreToolUse hook payload for a Bash call."""
+    return json.dumps({
+        "session_id": "test-session",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": cwd,
+    })
+
+
+def _run_hook(stdin_text: str, *, env: dict, monkeypatch) -> int:
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin_text))
+    return _load_hook_main()()
+
+
+def _read_violations(iter_dir: Path) -> list[dict]:
+    p = iter_dir / "plan_violations.jsonl"
+    if not p.exists():
+        return []
+    return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
+
+
+# ─── Strict mode ────────────────────────────────────────────────────────────
+
+class TestStrictMode:
+
+    def test_allows_planned_binary(self, tmp_path, monkeypatch, capsys):
+        _write_plan(tmp_path, [{
+            "arm_id": "h-main",
+            "conditions": [{"name": "baseline", "command": "./blis run --workload x"}],
+        }])
+        rc = _run_hook(
+            _hook_event("./blis run --workload y", str(tmp_path)),
+            env={"NOUS_ITER_DIR": str(tmp_path), "NOUS_PLAN_ENFORCEMENT": "strict"},
+            monkeypatch=monkeypatch,
+        )
+        assert rc == 0
+        assert capsys.readouterr().err == ""
+
+    def test_blocks_unplanned_binary_with_reason(self, tmp_path, monkeypatch, capsys):
+        _write_plan(tmp_path, [{
+            "arm_id": "h-main",
+            "conditions": [{"name": "baseline", "command": "./blis run"}],
+        }])
+        rc = _run_hook(
+            _hook_event("rm -rf /", str(tmp_path)),
+            env={"NOUS_ITER_DIR": str(tmp_path), "NOUS_PLAN_ENFORCEMENT": "strict"},
+            monkeypatch=monkeypatch,
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "rm" in err
+        assert "experiment_plan.yaml" in err or "planned" in err
+
+    def test_allows_ad_hoc_escape_hatch(self, tmp_path, monkeypatch, capsys):
+        _write_plan(tmp_path, [{
+            "arm_id": "h-main",
+            "conditions": [{"name": "baseline", "command": "./blis run"}],
+        }])
+        rc = _run_hook(
+            _hook_event("# nous: ad-hoc\nls -la results/", str(tmp_path)),
+            env={"NOUS_ITER_DIR": str(tmp_path), "NOUS_PLAN_ENFORCEMENT": "strict"},
+            monkeypatch=monkeypatch,
+        )
+        assert rc == 0
+        violations = _read_violations(tmp_path)
+        # Ad-hoc escapes are still LOGGED for audit, just not blocked.
+        assert len(violations) == 1
+        assert violations[0]["kind"] == "ad-hoc"
+
+
+# ─── Warn mode (default) ────────────────────────────────────────────────────
+
+class TestWarnMode:
+
+    def test_warn_allows_unplanned_and_logs(self, tmp_path, monkeypatch, capsys):
+        _write_plan(tmp_path, [{
+            "arm_id": "h-main",
+            "conditions": [{"name": "baseline", "command": "./blis run"}],
+        }])
+        rc = _run_hook(
+            _hook_event("curl https://example.com", str(tmp_path)),
+            env={"NOUS_ITER_DIR": str(tmp_path)},  # default = warn
+            monkeypatch=monkeypatch,
+        )
+        assert rc == 0  # warn mode never blocks
+        violations = _read_violations(tmp_path)
+        assert len(violations) == 1
+        assert violations[0]["kind"] == "unplanned"
+        assert "curl" in violations[0]["command"]
+        assert violations[0]["arm"] is not None or violations[0]["arm"] == ""
+        assert "timestamp" in violations[0]
+
+    def test_warn_does_not_log_planned_commands(self, tmp_path, monkeypatch):
+        _write_plan(tmp_path, [{
+            "arm_id": "h-main",
+            "conditions": [{"name": "baseline", "command": "./blis run"}],
+        }])
+        rc = _run_hook(
+            _hook_event("./blis run --threads 8", str(tmp_path)),
+            env={"NOUS_ITER_DIR": str(tmp_path)},
+            monkeypatch=monkeypatch,
+        )
+        assert rc == 0
+        assert _read_violations(tmp_path) == []
+
+
+# ─── No false positives across plan shapes ─────────────────────────────────
+
+class TestNoFalsePositives:
+    """Exercise representative plan shapes and assert every planned command
+    is recognized as planned (no false positives in strict mode)."""
+
+    PLANS = [
+        # Single arm, single condition.
+        [{"arm_id": "h-main", "conditions": [
+            {"name": "x", "command": "python run.py --seed 1"},
+        ]}],
+        # Multiple conditions per arm.
+        [{"arm_id": "h-main", "conditions": [
+            {"name": "a", "command": "./blis run --workload a"},
+            {"name": "b", "command": "./blis run --workload b"},
+        ]}],
+        # Multiple arms, mixed binaries.
+        [
+            {"arm_id": "h-main", "conditions": [
+                {"name": "x", "command": "./sim --batch=4"}]},
+            {"arm_id": "h-ablation", "conditions": [
+                {"name": "y", "command": "/usr/bin/perf record -g ./sim"}]},
+        ],
+        # Absolute paths.
+        [{"arm_id": "h-main", "conditions": [
+            {"name": "x", "command": "/usr/local/bin/custom-bench --duration 60"}]}],
+    ]
+
+    def test_strict_allows_every_planned_command(self, tmp_path, monkeypatch):
+        for i, arms in enumerate(self.PLANS):
+            iter_dir = tmp_path / f"iter-{i}"
+            _write_plan(iter_dir, arms)
+            for arm in arms:
+                for cond in arm["conditions"]:
+                    rc = _run_hook(
+                        _hook_event(cond["command"], str(iter_dir)),
+                        env={
+                            "NOUS_ITER_DIR": str(iter_dir),
+                            "NOUS_PLAN_ENFORCEMENT": "strict",
+                        },
+                        monkeypatch=monkeypatch,
+                    )
+                    assert rc == 0, (
+                        f"Strict mode blocked a planned command in plan #{i}: "
+                        f"{cond['command']!r}"
+                    )
+
+
+# ─── Edge cases ─────────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+
+    def test_missing_iter_dir_warns_but_allows(self, tmp_path, monkeypatch):
+        # If the env var isn't set, we can't enforce; allow + log nothing.
+        # (The wider campaign won't have wired up the hook in this case.)
+        monkeypatch.delenv("NOUS_ITER_DIR", raising=False)
+        rc = _run_hook(
+            _hook_event("./blis run", str(tmp_path)),
+            env={},
+            monkeypatch=monkeypatch,
+        )
+        assert rc == 0
+
+    def test_non_bash_tool_call_is_ignored(self, tmp_path, monkeypatch):
+        _write_plan(tmp_path, [{
+            "arm_id": "h-main",
+            "conditions": [{"name": "x", "command": "./blis run"}],
+        }])
+        # Read tool — not Bash; should pass through.
+        payload = json.dumps({
+            "session_id": "t",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/etc/passwd"},
+            "cwd": str(tmp_path),
+        })
+        rc = _run_hook(
+            payload,
+            env={
+                "NOUS_ITER_DIR": str(tmp_path),
+                "NOUS_PLAN_ENFORCEMENT": "strict",
+            },
+            monkeypatch=monkeypatch,
+        )
+        assert rc == 0
+        assert _read_violations(tmp_path) == []

--- a/tests/test_settings_template.py
+++ b/tests/test_settings_template.py
@@ -1,0 +1,216 @@
+"""Behavioral tests for the per-campaign permission policy (issue #135).
+
+These tests describe the contract of ``render_campaign_settings`` and
+``write_campaign_settings``: given inputs (work_dir, repo_path, plan,
+hook paths), the resulting on-disk ``.claude/settings.json`` has
+specific, externally-visible properties — what's in ``allowOnly``,
+which Bash commands are allowed, where outbound network is denied.
+
+No assertions here about how the function organized its work, what
+helpers it called, or the literal Python control flow. The contract
+is the file's contents.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from orchestrator.settings_template import (
+    render_campaign_settings,
+    settings_path_for,
+    write_campaign_settings,
+)
+
+
+# ─── Generator: shape of the returned dict ──────────────────────────────────
+
+class TestRenderCampaignSettings:
+
+    def test_allow_only_includes_work_dir(self, tmp_path):
+        work_dir = tmp_path / "campaign-A"
+        work_dir.mkdir()
+
+        settings = render_campaign_settings(work_dir=work_dir)
+
+        assert str(work_dir.resolve()) in settings["permissions"]["allowOnly"]
+
+    def test_allow_only_includes_repo_path_when_provided(self, tmp_path):
+        work_dir = tmp_path / "campaign-A"
+        repo = tmp_path / "target-repo"
+        work_dir.mkdir()
+        repo.mkdir()
+
+        settings = render_campaign_settings(work_dir=work_dir, repo_path=repo)
+
+        allow_only = settings["permissions"]["allowOnly"]
+        assert str(work_dir.resolve()) in allow_only
+        assert str(repo.resolve()) in allow_only
+
+    def test_default_bin_allowlist_contains_python_and_git(self, tmp_path):
+        settings = render_campaign_settings(work_dir=tmp_path)
+
+        allow = settings["permissions"]["allow"]
+        # Each Bash allow entry has shape ``Bash(<bin>:*)`` — assert a few
+        # canonical ones are present without prescribing their order.
+        assert any("Bash(python:*)" == entry for entry in allow)
+        assert any("Bash(git:*)" == entry for entry in allow)
+        assert any("Bash(grep:*)" == entry for entry in allow)
+
+    def test_plan_binaries_added_to_allowlist(self, tmp_path):
+        plan = {
+            "arms": [
+                {
+                    "arm_id": "h-main",
+                    "conditions": [
+                        {"name": "baseline", "command": "./blis run --workload x"},
+                        {"name": "treatment", "command": "/usr/local/bin/sim --batch=4"},
+                    ],
+                },
+            ],
+        }
+        settings = render_campaign_settings(
+            work_dir=tmp_path, experiment_plan=plan,
+        )
+        allow = settings["permissions"]["allow"]
+
+        assert "Bash(blis:*)" in allow
+        assert "Bash(sim:*)" in allow
+
+    def test_extra_bin_allowlist_extends_defaults(self, tmp_path):
+        settings = render_campaign_settings(
+            work_dir=tmp_path,
+            extra_bin_allowlist=["custom-bench", "trace-tool"],
+        )
+        allow = settings["permissions"]["allow"]
+
+        assert "Bash(custom-bench:*)" in allow
+        assert "Bash(trace-tool:*)" in allow
+        # Defaults still present.
+        assert "Bash(git:*)" in allow
+
+    def test_deny_blocks_outbound_https(self, tmp_path):
+        settings = render_campaign_settings(work_dir=tmp_path)
+
+        deny = settings["permissions"]["deny"]
+        assert any("https" in entry for entry in deny)
+
+    def test_no_hooks_section_when_no_hook_paths(self, tmp_path):
+        settings = render_campaign_settings(work_dir=tmp_path)
+
+        assert "hooks" not in settings
+
+    def test_stop_hook_registered_when_path_provided(self, tmp_path):
+        hook = tmp_path / "bin" / "nous-execute-stop"
+        hook.parent.mkdir(parents=True)
+        hook.write_text("#!/bin/sh\nexit 0\n")
+
+        settings = render_campaign_settings(
+            work_dir=tmp_path, stop_hook_path=hook,
+        )
+
+        assert "Stop" in settings["hooks"]
+        stop_cfg = settings["hooks"]["Stop"]
+        assert stop_cfg[0]["hooks"][0]["command"] == str(hook.resolve())
+        assert stop_cfg[0]["hooks"][0]["type"] == "command"
+
+    def test_pre_tool_use_hook_registered_when_path_provided(self, tmp_path):
+        hook = tmp_path / "bin" / "nous-plan-enforcer"
+        hook.parent.mkdir(parents=True)
+        hook.write_text("#!/bin/sh\nexit 0\n")
+
+        settings = render_campaign_settings(
+            work_dir=tmp_path, pre_tool_use_hook_path=hook,
+        )
+
+        assert "PreToolUse" in settings["hooks"]
+        ptu = settings["hooks"]["PreToolUse"]
+        assert ptu[0]["matcher"] == "Bash"
+        assert ptu[0]["hooks"][0]["command"] == str(hook.resolve())
+
+
+# ─── Disk write ─────────────────────────────────────────────────────────────
+
+class TestWriteCampaignSettings:
+
+    def test_write_creates_parent_dir_and_writes_json(self, tmp_path):
+        work_dir = tmp_path / "campaign-X"
+        work_dir.mkdir()
+        settings = render_campaign_settings(work_dir=work_dir)
+
+        target = settings_path_for(work_dir)
+        path = write_campaign_settings(target, settings)
+
+        assert path.exists()
+        # Re-read and confirm round-trip equivalence — that's the contract:
+        # whatever the renderer produced is what's on disk.
+        on_disk = json.loads(path.read_text())
+        assert on_disk == settings
+
+    def test_settings_path_for_returns_dot_claude_subdir(self, tmp_path):
+        path = settings_path_for(tmp_path)
+
+        assert path.parent.name == ".claude"
+        assert path.name == "settings.json"
+
+
+# ─── No-`--dangerously` invariant ───────────────────────────────────────────
+
+class TestSetupWorkDirWritesSettings:
+    """Init-time wiring: ``setup_work_dir`` writes ``.claude/settings.json``
+    so the dispatcher can pick it up automatically."""
+
+    def test_init_writes_settings_in_dot_claude(self, tmp_path):
+        from orchestrator.iteration import setup_work_dir
+
+        repo = tmp_path / "target-repo"
+        repo.mkdir()
+        work_dir = setup_work_dir("run-123", repo_path=str(repo))
+
+        settings_path = work_dir / ".claude" / "settings.json"
+        assert settings_path.exists()
+
+        on_disk = json.loads(settings_path.read_text())
+        # work_dir and repo are both in allowOnly.
+        assert str(work_dir.resolve()) in on_disk["permissions"]["allowOnly"]
+        assert str(repo.resolve()) in on_disk["permissions"]["allowOnly"]
+
+    def test_init_does_not_overwrite_existing_settings(self, tmp_path):
+        from orchestrator.iteration import setup_work_dir
+
+        repo = tmp_path / "target-repo"
+        repo.mkdir()
+        work_dir = Path(repo) / ".nous" / "run-456"
+        work_dir.mkdir(parents=True)
+        settings_dir = work_dir / ".claude"
+        settings_dir.mkdir()
+        custom_settings = {"permissions": {"allowOnly": ["/custom"], "allow": [], "deny": []}}
+        (settings_dir / "settings.json").write_text(json.dumps(custom_settings))
+
+        # Re-running setup must NOT clobber the user's hand edits.
+        setup_work_dir("run-456", repo_path=str(repo))
+
+        on_disk = json.loads((settings_dir / "settings.json").read_text())
+        assert on_disk == custom_settings
+
+
+class TestNoDangerouslyFlag:
+    """Settings file is the *replacement* for ``--dangerously-skip-permissions``.
+
+    The contract is: when the dispatcher invokes claude with ``--settings <path>``
+    and this file is at <path>, the agent operates under deny-by-default rules
+    rather than auto-approval. We assert the produced file imposes a non-empty
+    allowOnly and at least one deny rule — the two properties that make the
+    settings file *meaningfully* restrictive vs ``--dangerously``.
+    """
+
+    def test_settings_imposes_allowonly_and_deny(self, tmp_path):
+        settings = render_campaign_settings(work_dir=tmp_path)
+
+        assert settings["permissions"]["allowOnly"], (
+            "allowOnly must be non-empty; otherwise everything is permitted, "
+            "which is the very property --dangerously gave us."
+        )
+        assert settings["permissions"]["deny"], (
+            "deny must be non-empty so writes/network outside the worktree "
+            "are blocked."
+        )


### PR DESCRIPTION
> **⚠️ Stacked on #138 (security/135-permission-policy).** This PR's diff includes #135's commits. Once #138 lands on \`reflective\`, this branch should be rebased and the diff will shrink to only #128's changes.

## Summary

- New \`bin/nous-plan-enforcer\` Python entrypoint suitable for use as a Claude Code PreToolUse hook.
- Intercepts proposed Bash tool calls and compares the proposed command's head binary against the head binaries in the iteration's \`experiment_plan.yaml\`.
- Two modes: **strict** (block unplanned commands; exit 2 with reason) and **warn** (default; log to \`plan_violations.jsonl\` and allow).
- Escape hatch: \`# nous: ad-hoc\` annotation allows one-off out-of-plan commands and logs them distinctly.

## Why

5/18 mech-design-enforcement showed two executor processes racing on the same iter dir partly because nothing inside the agent enforced the plan. Hooks intercept tool calls deterministically before the LLM acts — defense in depth on top of #135's permission policy.

## Wire-up

\`setup_work_dir\` (#135 changes) auto-registers this hook in the rendered \`.claude/settings.json\` when \`bin/nous-plan-enforcer\` exists, alongside the Stop hook from #129.

## Behavioral tests (8)

| Class | Cases |
|---|---|
| Strict mode | planned-binary allowed; unplanned blocked with stderr; ad-hoc escape allowed + logged |
| Warn mode | unplanned allowed + logged; planned not logged |
| No false positives | parametric over 4 representative plan shapes (single-arm, multi-condition, multi-arm, absolute path) |
| Edge cases | missing iter_dir fails open; non-Bash tool calls pass through |

All assertions describe externally-visible behavior: exit code, stderr substrings, JSON rows in \`plan_violations.jsonl\`. None inspect internal helpers.

## Test plan

- [x] \`pytest tests/test_plan_enforcer_hook.py\` — 8/8 pass
- [x] \`pytest\` (full suite, with #135 stack) — 360/360 pass
- [ ] Manual: live executor session with \`NOUS_PLAN_ENFORCEMENT=strict\` and observe denial of an unplanned command, then ad-hoc escape behavior.

Closes #128.
Refs #120, #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)