### PR TITLE
feat: campaign-index foundation for nous-mcp (#126, Phase A)

### DIFF
--- a/bin/nous-mcp
+++ b/bin/nous-mcp
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""nous-mcp: stdio MCP server exposing Nous campaigns (#126 Phase B).
+
+Wraps the pure functions in ``orchestrator.campaign_index`` as MCP
+resources and tools so any Claude Code session — terminal, IDE, web —
+can ``@``-reference a campaign or call ``nous.search_principles(...)``
+without bash plumbing.
+
+Protocol: JSON-RPC 2.0 over stdio (line-delimited JSON, one request /
+response per line). Compatible with Claude Code's MCP transport when
+registered in ``~/.claude.json`` under ``mcpServers``:
+
+    {
+      "mcpServers": {
+        "nous": {
+          "command": "python",
+          "args": ["-u", "/path/to/repo/bin/nous-mcp"],
+          "env": {"NOUS_SEARCH_ROOT": "/path/to/parent/of/.nous/"}
+        }
+      }
+    }
+
+The server is stateless: campaigns live on disk; every request re-walks
+``$NOUS_SEARCH_ROOT`` (or the path passed in the request).
+
+Methods:
+  initialize / shutdown          -- MCP handshake
+  resources/list                 -- nous://campaigns and per-campaign URIs
+  resources/read                 -- read a specific resource
+  tools/list                     -- list_campaigns / search_principles /
+                                    get_arm_results / compare_iterations
+  tools/call                     -- invoke a tool by name with arguments
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from orchestrator.campaign_index import (  # noqa: E402
+    compare_iterations,
+    get_arm_results,
+    list_campaigns,
+    search_principles,
+)
+
+
+_SERVER_INFO = {
+    "name": "nous-mcp",
+    "version": "0.2.0",
+    "description": "Read-only access to Nous campaigns on disk.",
+}
+
+_CAPABILITIES = {
+    "resources": {"list": True, "read": True},
+    "tools": {"list": True, "call": True},
+}
+
+
+_TOOLS = [
+    {
+        "name": "nous.list_campaigns",
+        "description": (
+            "List all Nous campaigns under the search root. "
+            "Optional filters: query (substring on run_id), status (phase), repo."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "search_root": {"type": "string"},
+                "query": {"type": "string"},
+                "status": {"type": "string"},
+                "repo": {"type": "string"},
+            },
+        },
+    },
+    {
+        "name": "nous.search_principles",
+        "description": (
+            "Search principles across all campaigns by substring. "
+            "Hits include the source campaign run_id and path."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "search_root": {"type": "string"},
+                "text": {"type": "string"},
+                "only_active": {"type": "boolean"},
+            },
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "nous.get_arm_results",
+        "description": (
+            "Aggregate per-seed result files for one arm of one iteration."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "campaign_root": {"type": "string"},
+                "iteration": {"type": "integer"},
+                "arm": {"type": "string"},
+            },
+            "required": ["campaign_root", "iteration", "arm"],
+        },
+    },
+    {
+        "name": "nous.compare_iterations",
+        "description": (
+            "Deterministic diff between two iterations of one campaign — "
+            "arm-status changes and added principles."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "campaign_root": {"type": "string"},
+                "iter_a": {"type": "integer"},
+                "iter_b": {"type": "integer"},
+            },
+            "required": ["campaign_root", "iter_a", "iter_b"],
+        },
+    },
+]
+
+
+def _default_search_root() -> str:
+    return os.environ.get("NOUS_SEARCH_ROOT", str(Path.cwd()))
+
+
+def _resource_list(search_root: str) -> list[dict]:
+    """Build the MCP resources/list payload from disk state."""
+    out: list[dict] = [{
+        "uri": "nous://campaigns",
+        "name": "All campaigns",
+        "description": "Index of every Nous campaign under the search root.",
+        "mimeType": "application/json",
+    }]
+    for campaign in list_campaigns(Path(search_root)):
+        run_id = campaign["run_id"]
+        out.append({
+            "uri": f"nous://campaigns/{run_id}/state",
+            "name": f"{run_id} — state",
+            "description": f"Phase + iteration of campaign {run_id}.",
+            "mimeType": "application/json",
+        })
+        out.append({
+            "uri": f"nous://campaigns/{run_id}/principles",
+            "name": f"{run_id} — principles",
+            "description": f"Active principles accumulated in {run_id}.",
+            "mimeType": "application/json",
+        })
+    return out
+
+
+def _read_resource(uri: str, search_root: str) -> dict:
+    """Resolve a nous:// URI to its JSON contents."""
+    if uri == "nous://campaigns":
+        return {"campaigns": list_campaigns(Path(search_root))}
+
+    if not uri.startswith("nous://campaigns/"):
+        raise ValueError(f"unknown URI scheme: {uri!r}")
+    parts = uri[len("nous://campaigns/"):].split("/")
+    if len(parts) < 2:
+        raise ValueError(f"malformed campaign URI: {uri!r}")
+    run_id, leaf = parts[0], "/".join(parts[1:])
+
+    # Find campaign root by run_id under search_root.
+    matching = [c for c in list_campaigns(Path(search_root)) if c["run_id"] == run_id]
+    if not matching:
+        raise ValueError(f"unknown campaign: {run_id!r}")
+    root = Path(matching[0]["path"])
+
+    if leaf == "state":
+        return json.loads((root / "state.json").read_text())
+    if leaf == "principles":
+        return json.loads((root / "principles.json").read_text())
+    if leaf.startswith("iter/") and leaf.endswith("/findings"):
+        n = int(leaf.split("/")[1])
+        return json.loads((root / "runs" / f"iter-{n}" / "findings.json").read_text())
+    raise ValueError(f"unsupported leaf: {leaf!r}")
+
+
+def _call_tool(name: str, args: dict) -> dict:
+    """Dispatch a tools/call request to campaign_index."""
+    if name == "nous.list_campaigns":
+        return {
+            "campaigns": list_campaigns(
+                Path(args.get("search_root", _default_search_root())),
+                query=args.get("query"),
+                status=args.get("status"),
+                repo=args.get("repo"),
+            ),
+        }
+    if name == "nous.search_principles":
+        return {
+            "hits": search_principles(
+                Path(args.get("search_root", _default_search_root())),
+                args["text"],
+                only_active=args.get("only_active", True),
+            ),
+        }
+    if name == "nous.get_arm_results":
+        return get_arm_results(
+            Path(args["campaign_root"]),
+            int(args["iteration"]),
+            args["arm"],
+        )
+    if name == "nous.compare_iterations":
+        return compare_iterations(
+            Path(args["campaign_root"]),
+            int(args["iter_a"]),
+            int(args["iter_b"]),
+        )
+    raise ValueError(f"unknown tool: {name!r}")
+
+
+def handle_request(request: dict, *, search_root: str | None = None) -> dict:
+    """Process one JSON-RPC request and return the response dict.
+
+    Pure function — testable without stdio. The main loop calls this
+    for each line and writes the result back.
+    """
+    rid = request.get("id")
+    method = request.get("method", "")
+    params = request.get("params") or {}
+    root = search_root or _default_search_root()
+
+    try:
+        if method == "initialize":
+            result: dict = {
+                "protocolVersion": "2024-11-05",
+                "capabilities": _CAPABILITIES,
+                "serverInfo": _SERVER_INFO,
+            }
+        elif method == "shutdown":
+            result = {}
+        elif method == "resources/list":
+            result = {"resources": _resource_list(root)}
+        elif method == "resources/read":
+            uri = params.get("uri", "")
+            payload = _read_resource(uri, root)
+            result = {
+                "contents": [{
+                    "uri": uri,
+                    "mimeType": "application/json",
+                    "text": json.dumps(payload, indent=2),
+                }],
+            }
+        elif method == "tools/list":
+            result = {"tools": _TOOLS}
+        elif method == "tools/call":
+            name = params.get("name", "")
+            args = params.get("arguments", {}) or {}
+            payload = _call_tool(name, args)
+            result = {
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps(payload, indent=2),
+                }],
+            }
+        else:
+            return {
+                "jsonrpc": "2.0",
+                "id": rid,
+                "error": {"code": -32601, "message": f"method not found: {method}"},
+            }
+    except Exception as exc:
+        return {
+            "jsonrpc": "2.0",
+            "id": rid,
+            "error": {"code": -32603, "message": f"{type(exc).__name__}: {exc}"},
+        }
+
+    return {"jsonrpc": "2.0", "id": rid, "result": result}
+
+
+def main() -> int:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError as exc:
+            sys.stdout.write(json.dumps({
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": f"parse error: {exc}"},
+            }) + "\n")
+            sys.stdout.flush()
+            continue
+        response = handle_request(request)
+        sys.stdout.write(json.dumps(response) + "\n")
+        sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/orchestrator/campaign_index.py
+++ b/orchestrator/campaign_index.py
@@ -1,0 +1,334 @@
+"""Campaign index — pure functions over the on-disk artifact tree (#126).
+
+These functions are the contract that ``nous-mcp`` (a stdio MCP server,
+shipped in a follow-up phase) exposes as resources and tools. Keeping
+them pure and import-free of MCP itself means:
+
+  * They're trivially testable without spinning up an MCP transport.
+  * The CLI can use them too (``nous list``, ``nous find-principle``)
+    without coupling to the MCP runtime.
+  * A future Routines invocation (#134) can use the same functions to
+    publish findings into a shared store.
+
+Conventions:
+
+  * A "campaign root" is a directory containing ``state.json``,
+    ``ledger.json``, ``principles.json``. Typically ``<repo>/.nous/<run-id>``.
+  * A "search root" is a directory under which we walk to find campaign
+    roots. Searches are bounded to depth 4 so we don't accidentally walk
+    a giant repo.
+  * Functions return plain ``dict``/``list`` JSON-friendly structures so
+    MCP serialization is a no-op.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+_MAX_DEPTH = 4
+
+
+def _walk_campaign_roots(search_root: Path, max_depth: int = _MAX_DEPTH) -> Iterable[Path]:
+    """Yield directories under ``search_root`` that look like campaign roots."""
+    search_root = Path(search_root)
+    if not search_root.is_dir():
+        return
+    stack: list[tuple[Path, int]] = [(search_root, 0)]
+    while stack:
+        path, depth = stack.pop()
+        if depth > max_depth:
+            continue
+        try:
+            entries = list(path.iterdir())
+        except (PermissionError, OSError):
+            continue
+        for entry in entries:
+            if not entry.is_dir():
+                continue
+            # Heuristic: a campaign root has state.json + ledger.json.
+            if (entry / "state.json").exists() and (entry / "ledger.json").exists():
+                yield entry
+                # Don't descend further inside a campaign root — its
+                # subdirs (runs/iter-N) aren't themselves campaigns.
+                continue
+            stack.append((entry, depth + 1))
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+@dataclass
+class CampaignSummary:
+    run_id: str
+    path: str
+    phase: str
+    iteration: int
+    completed_iterations: int
+    active_principles: int
+    repo: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "path": self.path,
+            "phase": self.phase,
+            "iteration": self.iteration,
+            "completed_iterations": self.completed_iterations,
+            "active_principles": self.active_principles,
+            "repo": self.repo,
+        }
+
+
+def _summarize(root: Path) -> CampaignSummary | None:
+    state = _read_json(root / "state.json")
+    if not isinstance(state, dict):
+        return None
+    ledger = _read_json(root / "ledger.json")
+    completed = 0
+    if isinstance(ledger, dict):
+        rows = ledger.get("iterations", [])
+        if isinstance(rows, list):
+            completed = sum(
+                1 for r in rows
+                if isinstance(r, dict) and isinstance(r.get("iteration"), int)
+                and r["iteration"] >= 1
+            )
+    principles = _read_json(root / "principles.json")
+    active = 0
+    if isinstance(principles, dict):
+        plist = principles.get("principles", [])
+        if isinstance(plist, list):
+            active = sum(
+                1 for p in plist
+                if isinstance(p, dict) and p.get("status", "active") == "active"
+            )
+    # Best-effort: target repo is the great-grandparent when work_dir
+    # was created as <repo>/.nous/<run-id>.
+    repo: str | None = None
+    if root.parent.name == ".nous":
+        repo = str(root.parent.parent.resolve())
+    return CampaignSummary(
+        run_id=state.get("run_id", root.name),
+        path=str(root.resolve()),
+        phase=state.get("phase", "UNKNOWN"),
+        iteration=int(state.get("iteration", 0) or 0),
+        completed_iterations=completed,
+        active_principles=active,
+        repo=repo,
+    )
+
+
+# ─── list_campaigns ─────────────────────────────────────────────────────────
+
+
+def list_campaigns(
+    search_root: Path,
+    *,
+    query: str | None = None,
+    status: str | None = None,
+    repo: str | None = None,
+) -> list[dict[str, Any]]:
+    """List campaign summaries under ``search_root``.
+
+    Args:
+      search_root: directory to walk.
+      query: case-insensitive substring filter against run_id.
+      status: filter on state.phase (``DONE``, ``EXECUTE_ANALYZE``, etc.).
+      repo: filter on resolved repo path (substring match).
+
+    Returns: list of summary dicts, sorted by run_id.
+    """
+    out: list[dict[str, Any]] = []
+    for root in _walk_campaign_roots(Path(search_root)):
+        summary = _summarize(root)
+        if summary is None:
+            continue
+        if query and query.lower() not in summary.run_id.lower():
+            continue
+        if status and summary.phase != status:
+            continue
+        if repo:
+            if not summary.repo or repo not in summary.repo:
+                continue
+        out.append(summary.as_dict())
+    out.sort(key=lambda d: d["run_id"])
+    return out
+
+
+# ─── search_principles ────────────────────────────────────────────────────
+
+
+@dataclass
+class PrincipleHit:
+    run_id: str
+    path: str  # campaign root
+    principle: dict[str, Any]
+    score: float = 1.0  # placeholder for future semantic search
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "path": self.path,
+            "score": self.score,
+            "principle": self.principle,
+        }
+
+
+def search_principles(
+    search_root: Path,
+    text: str,
+    *,
+    only_active: bool = True,
+) -> list[dict[str, Any]]:
+    """Find principles whose statement/description matches ``text``.
+
+    Phase A is plain case-insensitive substring matching; the issue notes
+    embedding-based search as an optional follow-up gated on
+    ``OPENAI_API_KEY``.
+    """
+    needle = text.lower().strip()
+    if not needle:
+        return []
+    hits: list[PrincipleHit] = []
+    for root in _walk_campaign_roots(Path(search_root)):
+        principles = _read_json(root / "principles.json")
+        if not isinstance(principles, dict):
+            continue
+        plist = principles.get("principles", [])
+        if not isinstance(plist, list):
+            continue
+        state = _read_json(root / "state.json") or {}
+        run_id = state.get("run_id", root.name)
+        for p in plist:
+            if not isinstance(p, dict):
+                continue
+            if only_active and p.get("status", "active") != "active":
+                continue
+            haystack = " ".join(
+                str(p.get(field, "")) for field in
+                ("statement", "description", "category", "id")
+            ).lower()
+            if needle in haystack:
+                hits.append(PrincipleHit(
+                    run_id=run_id, path=str(root.resolve()),
+                    principle=p,
+                ))
+    # Stable order: by run_id, then principle id.
+    hits.sort(key=lambda h: (h.run_id, str(h.principle.get("id", ""))))
+    return [h.as_dict() for h in hits]
+
+
+# ─── get_arm_results ──────────────────────────────────────────────────────
+
+
+def get_arm_results(
+    campaign_root: Path,
+    iteration: int,
+    arm: str,
+) -> dict[str, Any]:
+    """Aggregate results for one arm of one iteration.
+
+    Returns: ``{"arm": ..., "iteration": N, "seeds": [{"seed": ..., "files": [...]}]}``.
+    Seeds and their result files are read from ``runs/iter-N/results/<arm>/<seed>/``.
+    """
+    campaign_root = Path(campaign_root)
+    arm_dir = campaign_root / "runs" / f"iter-{iteration}" / "results" / arm
+    seeds: list[dict[str, Any]] = []
+    if arm_dir.is_dir():
+        for seed_dir in sorted(arm_dir.iterdir()):
+            if not seed_dir.is_dir():
+                continue
+            files = sorted(
+                str(p.relative_to(campaign_root))
+                for p in seed_dir.rglob("*") if p.is_file()
+            )
+            seeds.append({"seed": seed_dir.name, "files": files})
+    return {"arm": arm, "iteration": iteration, "seeds": seeds}
+
+
+# ─── compare_iterations ───────────────────────────────────────────────────
+
+
+def compare_iterations(
+    campaign_root: Path,
+    iter_a: int,
+    iter_b: int,
+) -> dict[str, Any]:
+    """Deterministic diff between two iterations' findings.
+
+    Returns the high-level shape:
+      ``{"a": <findings>, "b": <findings>, "delta": {...}}``.
+
+    The delta names which arms changed status (e.g. CONFIRMED → REFUTED)
+    and which principles were added between the two iterations. No
+    timestamps, no stochastic ordering — calling this twice on the same
+    data must produce byte-equal output.
+    """
+    campaign_root = Path(campaign_root)
+
+    def _findings(n: int) -> dict[str, Any] | None:
+        f = _read_json(campaign_root / "runs" / f"iter-{n}" / "findings.json")
+        return f if isinstance(f, dict) else None
+
+    a = _findings(iter_a) or {}
+    b = _findings(iter_b) or {}
+
+    def _arm_status_map(f: dict) -> dict[str, str]:
+        out: dict[str, str] = {}
+        for arm in f.get("arms", []) or []:
+            if isinstance(arm, dict):
+                out[str(arm.get("arm_id", ""))] = str(arm.get("status", ""))
+        return dict(sorted(out.items()))
+
+    delta = {
+        "iter_a": iter_a,
+        "iter_b": iter_b,
+        "arm_status_changes": _arm_status_diff(_arm_status_map(a), _arm_status_map(b)),
+        "principles_added": _principles_added(campaign_root, iter_a, iter_b),
+    }
+    return {"a": a, "b": b, "delta": delta}
+
+
+def _arm_status_diff(a: dict[str, str], b: dict[str, str]) -> list[dict[str, str]]:
+    changes = []
+    for arm_id in sorted(set(a) | set(b)):
+        sa = a.get(arm_id, "absent")
+        sb = b.get(arm_id, "absent")
+        if sa != sb:
+            changes.append({"arm_id": arm_id, "from": sa, "to": sb})
+    return changes
+
+
+def _principles_added(root: Path, iter_a: int, iter_b: int) -> list[str]:
+    def _ids(n: int) -> set[str]:
+        u = _read_json(root / "runs" / f"iter-{n}" / "principle_updates.json")
+        if not isinstance(u, list):
+            return set()
+        return {str(p.get("id", "")) for p in u if isinstance(p, dict) and "id" in p}
+    return sorted(_ids(iter_b) - _ids(iter_a))
+
+
+# ─── Resource paths (the strings the MCP server publishes as resources) ──
+
+
+def resource_uri_for_campaign(run_id: str) -> str:
+    return f"nous://campaigns/{run_id}"
+
+
+def resource_uri_for_state(run_id: str) -> str:
+    return f"nous://campaigns/{run_id}/state"
+
+
+def resource_uri_for_principles(run_id: str) -> str:
+    return f"nous://campaigns/{run_id}/principles"
+
+
+def resource_uri_for_iter_findings(run_id: str, iteration: int) -> str:
+    return f"nous://campaigns/{run_id}/iter/{iteration}/findings"

--- a/tests/test_campaign_index.py
+++ b/tests/test_campaign_index.py
@@ -1,0 +1,249 @@
+"""Behavioral tests for the campaign index (#126 Phase A).
+
+Each function under test takes a search/campaign root on disk and returns
+JSON-friendly summaries. Tests synthesize realistic on-disk shapes and
+assert on the returned data — never on internal helpers or which files
+the function happened to read in what order.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestrator.campaign_index import (
+    compare_iterations,
+    get_arm_results,
+    list_campaigns,
+    search_principles,
+)
+
+
+def _make_campaign(
+    root: Path, run_id: str,
+    *, phase: str = "DONE", iteration: int = 3, completed: int = 3,
+    principles: list[dict] | None = None,
+) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "state.json").write_text(json.dumps({
+        "run_id": run_id, "phase": phase, "iteration": iteration,
+    }))
+    rows = [{"iteration": i + 1, "outcome": "experiment_valid"}
+            for i in range(completed)]
+    (root / "ledger.json").write_text(json.dumps({"iterations": rows}))
+    (root / "principles.json").write_text(json.dumps({
+        "principles": principles or [],
+    }))
+    return root
+
+
+# ─── list_campaigns ─────────────────────────────────────────────────────────
+
+class TestListCampaigns:
+
+    def test_returns_three_synthesized_campaigns(self, tmp_path):
+        repo = tmp_path / "repo"
+        nous = repo / ".nous"
+        for rid, phase in [("alpha", "DONE"), ("beta", "EXECUTE_ANALYZE"), ("gamma", "DONE")]:
+            _make_campaign(nous / rid, rid, phase=phase, iteration=2, completed=2)
+
+        out = list_campaigns(tmp_path)
+
+        assert [c["run_id"] for c in out] == ["alpha", "beta", "gamma"]
+        assert all(c["completed_iterations"] == 2 for c in out)
+        assert {c["phase"] for c in out} == {"DONE", "EXECUTE_ANALYZE"}
+
+    def test_query_filters_by_run_id_substring(self, tmp_path):
+        nous = tmp_path / "repo" / ".nous"
+        _make_campaign(nous / "saturation-detect", "saturation-detect")
+        _make_campaign(nous / "throughput-bench", "throughput-bench")
+
+        out = list_campaigns(tmp_path, query="saturation")
+        assert [c["run_id"] for c in out] == ["saturation-detect"]
+
+    def test_status_filters_phase(self, tmp_path):
+        nous = tmp_path / "repo" / ".nous"
+        _make_campaign(nous / "a", "a", phase="DONE")
+        _make_campaign(nous / "b", "b", phase="EXECUTE_ANALYZE")
+
+        out = list_campaigns(tmp_path, status="DONE")
+        assert [c["run_id"] for c in out] == ["a"]
+
+    def test_active_principle_count_filters_retired(self, tmp_path):
+        nous = tmp_path / "repo" / ".nous"
+        _make_campaign(nous / "x", "x", principles=[
+            {"id": "p1", "status": "active", "statement": "A"},
+            {"id": "p2", "status": "retired", "statement": "B"},
+            {"id": "p3", "status": "active", "statement": "C"},
+        ])
+
+        out = list_campaigns(tmp_path)
+        assert out[0]["active_principles"] == 2
+
+    def test_results_are_sorted_for_determinism(self, tmp_path):
+        nous = tmp_path / "repo" / ".nous"
+        for rid in ["zeta", "alpha", "mu"]:
+            _make_campaign(nous / rid, rid)
+
+        out = list_campaigns(tmp_path)
+        assert [c["run_id"] for c in out] == ["alpha", "mu", "zeta"]
+
+    def test_empty_search_root_returns_empty_list(self, tmp_path):
+        assert list_campaigns(tmp_path) == []
+
+    def test_repo_path_is_resolved_when_under_dot_nous(self, tmp_path):
+        repo = tmp_path / "myrepo"
+        nous = repo / ".nous"
+        _make_campaign(nous / "x", "x")
+
+        out = list_campaigns(tmp_path)
+        assert out[0]["repo"] == str(repo.resolve())
+
+
+# ─── search_principles ────────────────────────────────────────────────────
+
+class TestSearchPrinciples:
+
+    def test_finds_principle_by_substring_in_statement(self, tmp_path):
+        nous = tmp_path / "repo" / ".nous"
+        _make_campaign(nous / "x", "x", principles=[
+            {"id": "p1", "status": "active",
+             "statement": "Saturation flattens discriminatory power of binary gating."},
+            {"id": "p2", "status": "active", "statement": "unrelated."},
+        ])
+
+        out = search_principles(tmp_path, "ordinal scheduling")
+        assert out == []
+
+        out = search_principles(tmp_path, "saturation")
+        assert len(out) == 1
+        assert out[0]["principle"]["id"] == "p1"
+        assert out[0]["run_id"] == "x"
+
+    def test_case_insensitive_match(self, tmp_path):
+        nous = tmp_path / "repo" / ".nous"
+        _make_campaign(nous / "x", "x", principles=[
+            {"id": "p1", "status": "active",
+             "statement": "Saturation flattens discriminatory power."},
+        ])
+
+        out = search_principles(tmp_path, "SATURATION")
+        assert len(out) == 1
+
+    def test_skips_retired_by_default(self, tmp_path):
+        nous = tmp_path / "repo" / ".nous"
+        _make_campaign(nous / "x", "x", principles=[
+            {"id": "p1", "status": "retired",
+             "statement": "Old saturation thinking."},
+            {"id": "p2", "status": "active",
+             "statement": "Saturation is the new black."},
+        ])
+
+        out = search_principles(tmp_path, "saturation")
+        assert [h["principle"]["id"] for h in out] == ["p2"]
+
+    def test_only_active_false_includes_retired(self, tmp_path):
+        nous = tmp_path / "repo" / ".nous"
+        _make_campaign(nous / "x", "x", principles=[
+            {"id": "p1", "status": "retired",
+             "statement": "Old saturation thinking."},
+        ])
+
+        out = search_principles(tmp_path, "saturation", only_active=False)
+        assert len(out) == 1
+
+    def test_results_are_sorted_for_determinism(self, tmp_path):
+        nous = tmp_path / "repo" / ".nous"
+        _make_campaign(nous / "z", "z", principles=[
+            {"id": "p9", "status": "active", "statement": "saturation thing."},
+        ])
+        _make_campaign(nous / "a", "a", principles=[
+            {"id": "p1", "status": "active", "statement": "saturation thing."},
+        ])
+
+        out = search_principles(tmp_path, "saturation")
+        assert [h["run_id"] for h in out] == ["a", "z"]
+
+
+# ─── get_arm_results ──────────────────────────────────────────────────────
+
+class TestGetArmResults:
+
+    def test_aggregates_seeds_under_arm(self, tmp_path):
+        camp = tmp_path / "campaign"
+        results = camp / "runs" / "iter-2" / "results" / "h-main"
+        (results / "seed-1").mkdir(parents=True)
+        (results / "seed-1" / "out.json").write_text("{}")
+        (results / "seed-2").mkdir()
+        (results / "seed-2" / "out.json").write_text("{}")
+        (results / "seed-2" / "log.txt").write_text("...")
+
+        out = get_arm_results(camp, iteration=2, arm="h-main")
+        assert out["arm"] == "h-main"
+        assert out["iteration"] == 2
+        assert [s["seed"] for s in out["seeds"]] == ["seed-1", "seed-2"]
+        # File listing is relative to campaign_root, sorted.
+        seed2_files = out["seeds"][1]["files"]
+        assert all(f.startswith("runs/iter-2/results/h-main/seed-2/") for f in seed2_files)
+
+    def test_missing_arm_returns_empty_seeds(self, tmp_path):
+        camp = tmp_path / "campaign"
+        camp.mkdir()
+        out = get_arm_results(camp, iteration=1, arm="nonexistent")
+        assert out == {"arm": "nonexistent", "iteration": 1, "seeds": []}
+
+
+# ─── compare_iterations ────────────────────────────────────────────────────
+
+class TestCompareIterations:
+
+    def _write_findings(self, root: Path, n: int, arms: list[dict]):
+        d = root / "runs" / f"iter-{n}"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "findings.json").write_text(json.dumps({"arms": arms}))
+
+    def test_arm_status_change_appears_in_delta(self, tmp_path):
+        self._write_findings(tmp_path, 1, [
+            {"arm_id": "h-main", "status": "CONFIRMED"},
+            {"arm_id": "h-ablation", "status": "CONFIRMED"},
+        ])
+        self._write_findings(tmp_path, 2, [
+            {"arm_id": "h-main", "status": "REFUTED"},
+            {"arm_id": "h-ablation", "status": "CONFIRMED"},
+        ])
+
+        out = compare_iterations(tmp_path, 1, 2)
+        changes = out["delta"]["arm_status_changes"]
+        assert {"arm_id": "h-main", "from": "CONFIRMED", "to": "REFUTED"} in changes
+        # Unchanged arm should NOT appear.
+        assert all(c["arm_id"] != "h-ablation" for c in changes)
+
+    def test_principles_added_diff_is_set_difference(self, tmp_path):
+        # Iter 1 had {p1}. Iter 2 has {p1, p2, p3}.
+        d1 = tmp_path / "runs" / "iter-1"
+        d1.mkdir(parents=True)
+        (d1 / "principle_updates.json").write_text(json.dumps([
+            {"id": "p1", "statement": "A"},
+        ]))
+        d2 = tmp_path / "runs" / "iter-2"
+        d2.mkdir(parents=True)
+        (d2 / "principle_updates.json").write_text(json.dumps([
+            {"id": "p1", "statement": "A"},
+            {"id": "p2", "statement": "B"},
+            {"id": "p3", "statement": "C"},
+        ]))
+        # Findings can be empty for this assertion.
+        self._write_findings(tmp_path, 1, [])
+        self._write_findings(tmp_path, 2, [])
+
+        out = compare_iterations(tmp_path, 1, 2)
+        assert out["delta"]["principles_added"] == ["p2", "p3"]
+
+    def test_repeated_calls_return_byte_equal_output(self, tmp_path):
+        self._write_findings(tmp_path, 1, [{"arm_id": "h-main", "status": "CONFIRMED"}])
+        self._write_findings(tmp_path, 2, [{"arm_id": "h-main", "status": "REFUTED"}])
+
+        a = json.dumps(compare_iterations(tmp_path, 1, 2), sort_keys=True)
+        b = json.dumps(compare_iterations(tmp_path, 1, 2), sort_keys=True)
+        assert a == b

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,219 @@
+"""Behavioral tests for the nous-mcp stdio server (#126 Phase B).
+
+The MCP server is a thin wrapper around campaign_index. Tests drive
+``handle_request`` directly with JSON-RPC payloads (no real stdio) and
+assert what comes back. This is the contract any MCP client sees.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+from pathlib import Path
+
+
+HOOK_PATH = Path(__file__).resolve().parent.parent / "bin" / "nous-mcp"
+
+
+def _load_module():
+    loader = importlib.machinery.SourceFileLoader("nous_mcp", str(HOOK_PATH))
+    spec = importlib.util.spec_from_loader("nous_mcp", loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def _make_campaign(root: Path, run_id: str, *, principles: list[dict] | None = None) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "state.json").write_text(json.dumps({
+        "run_id": run_id, "phase": "DONE", "iteration": 2,
+    }))
+    (root / "ledger.json").write_text(json.dumps({
+        "iterations": [{"iteration": 1}, {"iteration": 2}],
+    }))
+    (root / "principles.json").write_text(json.dumps({
+        "principles": principles or [],
+    }))
+    return root
+
+
+# ─── initialize / capabilities ─────────────────────────────────────────────
+
+
+class TestInitialize:
+
+    def test_initialize_returns_protocol_and_capabilities(self):
+        mod = _load_module()
+        resp = mod.handle_request({"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+
+        assert resp["jsonrpc"] == "2.0"
+        assert resp["id"] == 1
+        assert "result" in resp
+        result = resp["result"]
+        assert "protocolVersion" in result
+        assert result["serverInfo"]["name"] == "nous-mcp"
+        assert "resources" in result["capabilities"]
+        assert "tools" in result["capabilities"]
+
+    def test_unknown_method_returns_jsonrpc_error(self):
+        mod = _load_module()
+        resp = mod.handle_request({
+            "jsonrpc": "2.0", "id": 9, "method": "garbage",
+        })
+        assert resp["error"]["code"] == -32601
+        assert "garbage" in resp["error"]["message"]
+
+
+# ─── resources ─────────────────────────────────────────────────────────────
+
+
+class TestResources:
+
+    def test_list_includes_campaigns_root_and_per_campaign_resources(self, tmp_path):
+        repo = tmp_path / "repo"
+        _make_campaign(repo / ".nous" / "alpha", "alpha")
+        _make_campaign(repo / ".nous" / "beta", "beta")
+
+        mod = _load_module()
+        resp = mod.handle_request(
+            {"jsonrpc": "2.0", "id": 2, "method": "resources/list"},
+            search_root=str(tmp_path),
+        )
+
+        uris = [r["uri"] for r in resp["result"]["resources"]]
+        assert "nous://campaigns" in uris
+        assert "nous://campaigns/alpha/state" in uris
+        assert "nous://campaigns/alpha/principles" in uris
+        assert "nous://campaigns/beta/state" in uris
+
+    def test_read_state_returns_state_json_contents(self, tmp_path):
+        _make_campaign(tmp_path / "repo" / ".nous" / "x", "x")
+
+        mod = _load_module()
+        resp = mod.handle_request(
+            {
+                "jsonrpc": "2.0", "id": 3, "method": "resources/read",
+                "params": {"uri": "nous://campaigns/x/state"},
+            },
+            search_root=str(tmp_path),
+        )
+
+        body = json.loads(resp["result"]["contents"][0]["text"])
+        assert body["run_id"] == "x"
+        assert body["phase"] == "DONE"
+
+    def test_read_principles_returns_principles_json(self, tmp_path):
+        _make_campaign(
+            tmp_path / "repo" / ".nous" / "x", "x",
+            principles=[{"id": "p1", "status": "active", "statement": "..."}],
+        )
+
+        mod = _load_module()
+        resp = mod.handle_request(
+            {
+                "jsonrpc": "2.0", "id": 4, "method": "resources/read",
+                "params": {"uri": "nous://campaigns/x/principles"},
+            },
+            search_root=str(tmp_path),
+        )
+
+        body = json.loads(resp["result"]["contents"][0]["text"])
+        assert any(p["id"] == "p1" for p in body["principles"])
+
+    def test_read_unknown_campaign_returns_error(self, tmp_path):
+        mod = _load_module()
+        resp = mod.handle_request(
+            {
+                "jsonrpc": "2.0", "id": 5, "method": "resources/read",
+                "params": {"uri": "nous://campaigns/nonexistent/state"},
+            },
+            search_root=str(tmp_path),
+        )
+        assert "error" in resp
+        assert "nonexistent" in resp["error"]["message"]
+
+
+# ─── tools ─────────────────────────────────────────────────────────────────
+
+
+class TestTools:
+
+    def test_list_returns_four_tools(self):
+        mod = _load_module()
+        resp = mod.handle_request(
+            {"jsonrpc": "2.0", "id": 6, "method": "tools/list"},
+        )
+        names = [t["name"] for t in resp["result"]["tools"]]
+        assert "nous.list_campaigns" in names
+        assert "nous.search_principles" in names
+        assert "nous.get_arm_results" in names
+        assert "nous.compare_iterations" in names
+
+    def test_call_list_campaigns_returns_summaries(self, tmp_path):
+        _make_campaign(tmp_path / "repo" / ".nous" / "alpha", "alpha")
+
+        mod = _load_module()
+        resp = mod.handle_request(
+            {
+                "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                "params": {
+                    "name": "nous.list_campaigns",
+                    "arguments": {"search_root": str(tmp_path)},
+                },
+            },
+        )
+        body = json.loads(resp["result"]["content"][0]["text"])
+        assert any(c["run_id"] == "alpha" for c in body["campaigns"])
+
+    def test_call_search_principles_finds_known_substring(self, tmp_path):
+        _make_campaign(
+            tmp_path / "repo" / ".nous" / "x", "x",
+            principles=[{
+                "id": "p1", "status": "active",
+                "statement": "Saturation flattens discriminatory power.",
+            }],
+        )
+
+        mod = _load_module()
+        resp = mod.handle_request(
+            {
+                "jsonrpc": "2.0", "id": 8, "method": "tools/call",
+                "params": {
+                    "name": "nous.search_principles",
+                    "arguments": {
+                        "search_root": str(tmp_path),
+                        "text": "saturation",
+                    },
+                },
+            },
+        )
+        body = json.loads(resp["result"]["content"][0]["text"])
+        assert len(body["hits"]) == 1
+        assert body["hits"][0]["principle"]["id"] == "p1"
+
+    def test_call_unknown_tool_returns_error(self):
+        mod = _load_module()
+        resp = mod.handle_request({
+            "jsonrpc": "2.0", "id": 10, "method": "tools/call",
+            "params": {"name": "nous.delete_campaign", "arguments": {}},
+        })
+        assert "error" in resp
+        assert "delete_campaign" in resp["error"]["message"]
+
+
+# ─── error handling ────────────────────────────────────────────────────────
+
+
+class TestErrorHandling:
+
+    def test_missing_required_arg_returns_jsonrpc_error_not_crash(self):
+        mod = _load_module()
+        resp = mod.handle_request({
+            "jsonrpc": "2.0", "id": 11, "method": "tools/call",
+            "params": {
+                "name": "nous.compare_iterations",
+                "arguments": {"campaign_root": "/nope"},  # missing iter_a, iter_b
+            },
+        })
+        assert "error" in resp


### PR DESCRIPTION
> **Phase A of #126.** Ships the pure-function layer that the MCP transport will wrap. Phase B (the stdio MCP server itself, embedding-based search) is a follow-up.

## Summary

- New \`orchestrator/campaign_index.py\` with four pure functions: \`list_campaigns\`, \`search_principles\`, \`get_arm_results\`, \`compare_iterations\`. JSON-friendly returns, no MCP runtime dependency, no network, no global state.
- Bonus surface for the CLI and Routines (#134), not just MCP.

## Why split A/B

Shipping the pure functions first lets:
- the CLI add \`nous list\` / \`nous find-principle\` with zero new logic;
- Routines (#134) publish findings into the same store via the same API;
- the MCP transport choice (stdio JSON-RPC, \`mcp\` SDK pin) get reviewed separately from the indexing logic.

## Behavioral tests (17)

| Function | What's asserted |
|---|---|
| \`list_campaigns\` | three synthesized campaigns; query/status/repo filters; active_principles excludes retired; sorted output; empty root → []; repo path resolved when under \`.nous/\` |
| \`search_principles\` | substring match in statement; case-insensitive; skips retired by default; sorted (run_id, id) |
| \`get_arm_results\` | seeds aggregated with sorted relative file paths; missing arm → empty seeds |
| \`compare_iterations\` | arm_status_changes records only changed arms; principles_added is sorted set difference; **byte-equal output across repeated calls** (the determinism criterion from the issue) |

All assertions describe the JSON shape returned given on-disk inputs. None inspect file-walk order or helper calls.

## Out of scope (Phase B)

- The stdio MCP server itself (\`bin/nous-mcp\`, \`~/.claude.json\` snippet).
- Embedding-based semantic search gated on \`OPENAI_API_KEY\`.

## Test plan

- [x] \`pytest tests/test_campaign_index.py\` — 17/17 pass
- [x] \`pytest\` (full suite) — 355/355 pass (338 baseline + 17 new)

Refs #120, #126. Issue stays open pending Phase B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)