### PR TITLE
feat: package nous as a Claude Code plugin (#125)

### DIFF
--- a/plugin/nous/plugin.json
+++ b/plugin/nous/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "nous",
+  "version": "0.2.0",
+  "description": "Hypothesis-driven experimentation for software systems. Wraps the `nous` CLI as discoverable Claude Code skills.",
+  "author": "AI-native Systems Research",
+  "homepage": "https://github.com/AI-native-Systems-Research/agentic-strategy-evolution",
+  "license": "Apache-2.0",
+  "skills": [
+    "skills/nous-run.md",
+    "skills/nous-status.md",
+    "skills/nous-resume.md",
+    "skills/nous-list.md",
+    "skills/nous-bisect.md",
+    "skills/nous-find-principle.md"
+  ]
+}

--- a/plugin/nous/skills/nous-bisect.md
+++ b/plugin/nous/skills/nous-bisect.md
@@ -1,0 +1,38 @@
+---
+name: nous-bisect
+description: Compare two iterations of the same Nous campaign — what changed in arm statuses, which principles were added between them. Use when the user wants to understand iteration deltas or debug regressions across a campaign's history.
+---
+
+# `nous-bisect`
+
+Compare two iterations of one campaign. Powered by `compare_iterations` (#126).
+
+## When to use
+
+- The user asks "what changed between iter 2 and iter 3", "which principles got added in iter 4", "did h-main flip from CONFIRMED to REFUTED".
+- The user is debugging a regression and wants to bisect across the campaign timeline.
+
+## Inputs
+
+- `campaign-root` (required): the campaign work-dir (e.g. `<repo>/.nous/<run-id>`).
+- `iter-a` (required): first iteration number.
+- `iter-b` (required): second iteration number.
+
+## Run
+
+```bash
+python -c "
+import json
+from pathlib import Path
+from orchestrator.campaign_index import compare_iterations
+
+out = compare_iterations(Path('$CAMPAIGN_ROOT'), $ITER_A, $ITER_B)
+print(json.dumps(out['delta'], indent=2))
+"
+```
+
+## Notes
+
+- Output is deterministic — calling it twice on unchanged data produces byte-equal output (no timestamps, no map-ordering leaks).
+- The `delta.arm_status_changes` array names only arms whose status differs between the two iterations.
+- The `delta.principles_added` array is the sorted set difference of principle IDs in `principle_updates.json` between the two iterations.

--- a/plugin/nous/skills/nous-find-principle.md
+++ b/plugin/nous/skills/nous-find-principle.md
@@ -1,0 +1,41 @@
+---
+name: nous-find-principle
+description: Search Nous principles across one or more campaigns by substring. Use when the user wants to find prior learnings ("what have we learned about ordinal scheduling"), see if a principle exists already before adding a new one, or trace a principle back to the campaign that produced it.
+---
+
+# `nous-find-principle`
+
+Search principles across all campaigns under a search root.
+
+## When to use
+
+- The user asks "what principles do we have about saturation", "have we already concluded X", "where was this principle first proposed".
+- The user is authoring a new campaign and wants to check existing principles for overlap.
+
+## Inputs
+
+- `search-root` (required): directory to walk for campaign roots.
+- `text` (required): case-insensitive substring to match against principle statements / descriptions / categories / IDs.
+- `include-retired` (optional, default false): also search principles with `status: retired`.
+
+## Run
+
+```bash
+python -c "
+import json
+from pathlib import Path
+from orchestrator.campaign_index import search_principles
+
+out = search_principles(
+    Path('$SEARCH_ROOT'), '$TEXT',
+    only_active=$([ "$INCLUDE_RETIRED" = "true" ] && echo False || echo True),
+)
+print(json.dumps(out, indent=2))
+"
+```
+
+## Notes
+
+- Phase A is plain substring matching. Embedding-based semantic search is gated on `OPENAI_API_KEY` and lands in #126 Phase B.
+- Hits include both the principle and its source campaign (`run_id`, `path`) so you can jump to the originating findings.
+- Sorted by `(run_id, principle.id)` for stable output.

--- a/plugin/nous/skills/nous-list.md
+++ b/plugin/nous/skills/nous-list.md
@@ -1,0 +1,43 @@
+---
+name: nous-list
+description: List all Nous campaigns under a search root (typically a target repo). Use when the user wants to see what campaigns exist, filter by status or substring, or get an overview of running vs completed work. Powered by the campaign_index module shipped in #126.
+---
+
+# `nous-list`
+
+List Nous campaigns under a search root.
+
+## When to use
+
+- The user asks "what campaigns exist on this repo", "list all my Nous runs", "show me all DONE campaigns".
+- The user wants to filter by run_id substring, phase, or repo.
+
+## Inputs
+
+- `search-root` (required): directory to walk. Typically the parent of one or more `<repo>/.nous/` directories.
+- `query` (optional): case-insensitive substring filter against run_id.
+- `status` (optional): filter to a specific phase (`DONE`, `EXECUTE_ANALYZE`, `INIT`, etc.).
+- `repo` (optional): substring filter against the resolved repo path.
+
+## Run
+
+```bash
+python -c "
+import json, sys
+from pathlib import Path
+from orchestrator.campaign_index import list_campaigns
+
+out = list_campaigns(
+    Path('$SEARCH_ROOT'),
+    query=$([ -n "$QUERY" ] && echo "'$QUERY'" || echo None),
+    status=$([ -n "$STATUS" ] && echo "'$STATUS'" || echo None),
+    repo=$([ -n "$REPO" ] && echo "'$REPO'" || echo None),
+)
+print(json.dumps(out, indent=2))
+"
+```
+
+## Notes
+
+- Uses the `campaign_index` foundation (#126) — pure Python, no MCP runtime needed.
+- Output is JSON sorted by `run_id` for stable comparison across runs.

--- a/plugin/nous/skills/nous-resume.md
+++ b/plugin/nous/skills/nous-resume.md
@@ -1,0 +1,30 @@
+---
+name: nous-resume
+description: Resume a Nous campaign that was interrupted mid-flight (timeout, crash, ctrl-c). Picks up at the last checkpointed phase. Use when the user says "resume", "continue", or references a campaign that already has a state.json.
+---
+
+# `nous-resume`
+
+Resume an interrupted Nous campaign from the latest checkpoint (#91).
+
+## When to use
+
+- The user says "resume the saturation campaign" or "pick up where it left off".
+- A previous run was killed and the campaign's `state.json` is mid-flight (phase != INIT, != DONE).
+
+## Inputs
+
+- `target` (required): campaign.yaml path. The orchestrator reads the matching `<repo>/.nous/<run-id>/state.json` to find the resume point.
+- `max-iterations` (optional): override the campaign's cap.
+- `agent` (optional): backend to use on resume — usually matches the original.
+
+## Run
+
+```bash
+nous resume "$TARGET" --max-iterations "${MAX:-$(yq '.max_iterations' "$TARGET")}" --agent "${AGENT:-api}"
+```
+
+## Notes
+
+- Resume is idempotent — running it on a DONE campaign starts the next iteration if `max_iterations` allows.
+- If the campaign was killed mid-EXECUTE_ANALYZE, the agent receives a continuation hint and picks up from existing artifacts in the iter dir (no full re-run).

--- a/plugin/nous/skills/nous-run.md
+++ b/plugin/nous/skills/nous-run.md
@@ -1,0 +1,35 @@
+---
+name: nous-run
+description: Start a Nous campaign from a campaign.yaml. Use when the user wants to run a hypothesis-driven experiment, kick off a new investigation, or has just authored a campaign.yaml. Accepts the campaign path and an optional max-iterations override.
+---
+
+# `nous-run`
+
+Start (or resume) a Nous campaign from a `campaign.yaml`.
+
+## When to use
+
+- The user wants to run a new experiment described in a campaign file.
+- The user says "kick off the saturation campaign", "start a Nous run", or refers to a specific campaign yaml.
+
+## What this does
+
+Shells out to the `nous run` CLI with the campaign path. The orchestrator drives the standard 6-phase loop (DESIGN → HUMAN_DESIGN_GATE → EXECUTE_ANALYZE → HUMAN_FINDINGS_GATE → DONE → next iteration) until `max_iterations` is reached or the user aborts at a gate.
+
+## Inputs
+
+- `campaign` (required): path to a `campaign.yaml`. May be relative or absolute.
+- `max-iterations` (optional): override the iteration cap declared in the campaign.
+- `auto-approve` (optional, default false): skip human gates for unattended runs. Sets `NOUS_ALLOW_AUTO_APPROVE=1`.
+- `agent` (optional, default `api`): one of `inline`, `api`, `sdk`.
+
+## Run
+
+```bash
+nous run "$CAMPAIGN" --max-iterations "$MAX" --agent "$AGENT" $([ "$AUTO_APPROVE" = "true" ] && echo --auto-approve)
+```
+
+## Notes
+
+- For unattended overnight runs, prefer `--agent sdk --auto-approve` and configure `channels:` in the campaign so gate approvals can come from Slack (#130).
+- If the campaign already has a state.json mid-flight, use `nous-resume` instead.

--- a/plugin/nous/skills/nous-status.md
+++ b/plugin/nous/skills/nous-status.md
@@ -1,0 +1,38 @@
+---
+name: nous-status
+description: Show the current status of a Nous campaign — phase, iteration, completed runs, active principles, last tool call. Use when the user asks "where is the campaign", "is it stuck", "report progress", or wants a live watch view.
+---
+
+# `nous-status`
+
+Read-only campaign status. Supports one-shot, single-line, and live `--watch` views (#127).
+
+## When to use
+
+- The user asks where a campaign is, what phase it's in, whether it's stuck.
+- The user wants a live view to monitor an in-flight EXECUTE_ANALYZE.
+- The user wants a single-line summary suitable for a shell prompt or CI log.
+
+## Inputs
+
+- `target` (required): a campaign yaml, run_id, or work-dir path. The CLI auto-resolves.
+- `watch` (optional): loop and redraw every 2 seconds until interrupted.
+- `line` (optional): print a single-line summary instead of the multi-line panel.
+- `interval` (optional, default 2.0): seconds between redraws when `watch` is set.
+
+## Run
+
+```bash
+if [ "$WATCH" = "true" ]; then
+  nous status "$TARGET" --watch --interval "${INTERVAL:-2}"
+elif [ "$LINE" = "true" ]; then
+  nous status "$TARGET" --line
+else
+  nous status "$TARGET"
+fi
+```
+
+## Notes
+
+- A `STUCK` marker fires when the most recent `executor_log.jsonl` event is more than 5 minutes old.
+- This skill is a pure read — no LLM calls — so it's free to call repeatedly.

--- a/tests/test_plugin_package.py
+++ b/tests/test_plugin_package.py
@@ -1,0 +1,96 @@
+"""Behavioral tests for the plugin package (#125)."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent / "plugin" / "nous"
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+class TestPluginManifest:
+
+    def test_plugin_json_exists_with_required_fields(self):
+        path = PLUGIN_ROOT / "plugin.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        for required in ("name", "version", "description", "skills"):
+            assert required in data, f"plugin.json missing {required!r}"
+        assert data["name"] == "nous"
+        assert isinstance(data["skills"], list)
+
+    def test_plugin_lists_at_least_five_skills(self):
+        data = json.loads((PLUGIN_ROOT / "plugin.json").read_text())
+        assert len(data["skills"]) >= 5
+
+    def test_each_listed_skill_file_exists(self):
+        data = json.loads((PLUGIN_ROOT / "plugin.json").read_text())
+        for rel in data["skills"]:
+            assert (PLUGIN_ROOT / rel).exists(), f"missing skill file: {rel}"
+
+
+class TestSkillFrontmatter:
+    """Each skill markdown must have YAML frontmatter with name + description.
+
+    The description is what Claude Code reads to decide whether to suggest
+    the skill. A vague or missing description is the difference between a
+    discoverable skill and a dead one.
+    """
+
+    def _frontmatter(self, path: Path) -> dict[str, str]:
+        match = _FRONTMATTER_RE.match(path.read_text())
+        if not match:
+            return {}
+        out: dict[str, str] = {}
+        for line in match.group(1).splitlines():
+            if ":" in line:
+                k, _, v = line.partition(":")
+                out[k.strip()] = v.strip()
+        return out
+
+    def test_every_skill_has_name_and_description(self):
+        data = json.loads((PLUGIN_ROOT / "plugin.json").read_text())
+        for rel in data["skills"]:
+            fm = self._frontmatter(PLUGIN_ROOT / rel)
+            assert "name" in fm and fm["name"], f"{rel}: missing name"
+            assert "description" in fm and fm["description"], f"{rel}: missing description"
+
+    def test_descriptions_describe_when_to_use(self):
+        """The description should include cue words that help Claude Code
+        match user intent ("when the user wants", "use when", etc.)."""
+        data = json.loads((PLUGIN_ROOT / "plugin.json").read_text())
+        for rel in data["skills"]:
+            fm = self._frontmatter(PLUGIN_ROOT / rel)
+            desc = fm.get("description", "").lower()
+            assert "use when" in desc or "when the user" in desc or "use this" in desc, (
+                f"{rel}: description should hint at when to use the skill"
+            )
+
+    def test_each_skill_body_references_nous_cli(self):
+        """Phase A skills are CLI wrappers — each markdown body must
+        reference the nous command it shells out to."""
+        data = json.loads((PLUGIN_ROOT / "plugin.json").read_text())
+        for rel in data["skills"]:
+            body = (PLUGIN_ROOT / rel).read_text()
+            assert "nous " in body or "campaign_index" in body, (
+                f"{rel}: body should invoke a nous command or campaign_index"
+            )
+
+
+class TestSkillCoverage:
+    """Acceptance criterion: at least 5 skills must be present and
+    cover the documented operations."""
+
+    EXPECTED_SKILLS = {
+        "nous-run", "nous-status", "nous-resume",
+        "nous-list", "nous-bisect", "nous-find-principle",
+    }
+
+    def test_all_expected_skills_present(self):
+        present = {p.stem for p in (PLUGIN_ROOT / "skills").glob("*.md")}
+        assert self.EXPECTED_SKILLS <= present, (
+            f"missing skills: {self.EXPECTED_SKILLS - present}"
+        )


### PR DESCRIPTION
## Summary

- New \`plugin/nous/\` directory with \`plugin.json\` manifest and 6 skill markdown files.
- Each skill is a CLI wrapper with frontmatter that helps Claude Code suggest it from the \`/<tab>\` palette: \`nous-run\`, \`nous-status\`, \`nous-resume\`, \`nous-list\`, \`nous-bisect\`, \`nous-find-principle\`.

## Skill coverage

| Skill | Wraps | Notes |
|---|---|---|
| nous-run | \`nous run\` | --auto-approve + Slack channels (#130) for unattended runs |
| nous-status | \`nous status --watch / --line\` (#127) | Pure read; free to call repeatedly |
| nous-resume | \`nous resume\` | Idempotent; resumes from state.json checkpoint (#91) |
| nous-list | \`campaign_index.list_campaigns\` (#126) | Filter by query / status / repo |
| nous-bisect | \`campaign_index.compare_iterations\` (#126) | Byte-deterministic delta |
| nous-find-principle | \`campaign_index.search_principles\` (#126) | Embedding search is Phase B of #126 |

## Behavioral tests (7)

| Group | What's asserted |
|---|---|
| Manifest | \`plugin.json\` has required fields; lists ≥ 5 skills (acceptance criterion); every listed file exists on disk |
| Frontmatter | every skill has \`name\` + \`description\`; descriptions include "use when"/"when the user" cues so the harness can match user intent (vague descriptions = dead skills) |
| Coverage | all six documented skills present |

All assertions describe what's on disk and what Claude Code's discovery layer will read. None inspect implementation internals.

## Out of scope (Phase B)

- \`claude plugin install\` integration test (needs live Claude Code with plugin support).
- Publishing to a plugin registry.
- Typed skill input contracts (currently shell substitution).

## Test plan

- [x] \`pytest tests/test_plugin_package.py\` — 7/7 pass
- [x] \`pytest\` (full suite) — 345/345 pass

Closes #125.
Refs #120, #126, #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)