### PR TITLE
fix(pyproject): use license table form so install works on setuptools <77

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nous"
 version = "0.1.0"
 description = "Nous — hypothesis-driven experimentation framework for software systems"
 requires-python = ">=3.11"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 dependencies = [
     "jsonschema>=4.20.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary

\`pip install\` from \`reflective\` currently fails on the homebrew \`python@3.11\` setuptools with:

\`\`\`
configuration error: \`project.license\` must be valid exactly by one definition (2 matches found):
    - keys: 'file': {type: string}, required: ['file']
    - keys: 'text': {type: string}, required: ['text']
GIVEN VALUE: "Apache-2.0"
\`\`\`

## Root cause

The SPDX-string form (\`license = "Apache-2.0"\`) is PEP 639. Only \`setuptools >= 77\` accepts it. Older setuptools (which homebrew's \`python@3.11\` still ships) wants the PEP 621 table form.

## Fix

\`license = "Apache-2.0"\` → \`license = {text = "Apache-2.0"}\`.

The table form is **universally compatible** — works on every setuptools version Nous claims to support (\`[build-system].requires = ["setuptools>=68.0"]\`).

## Verification

Locally, against the same homebrew \`python@3.11\` that hit the original error:

\`\`\`
$ /opt/homebrew/opt/python@3.11/bin/python3.11 -c "
from setuptools.config.pyprojecttoml import read_configuration
import pathlib
cfg = read_configuration(pathlib.Path('pyproject.toml'))
print('OK, license parsed as:', cfg['project'].get('license'))
"
OK, license parsed as: {'text': 'Apache-2.0'}
\`\`\`

The CI on this PR will rebuild via \`pip install -e ".[dev]"\` on Python 3.11 and 3.12, which exercises the same validation path the user hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)