### PR TITLE
Tracking #160: Self-improving Nous (5 children — meta-findings, repo cache, richer arms, parsimony)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,28 @@ Beyond tests, Nous itself must be frugal with tokens:
 5. Stack PRs when one logical change builds on another rather than waiting
    for merge — see `docs/plans/CHECKPOINT.md` for the pattern.
 
+## Graded-complexity tier discipline (issue #159)
+
+Each iteration's bundle declares an optional ``complexity_tier`` (1..4):
+
+| Tier | Description |
+|---|---|
+| 1 | single mechanism, single knob, treatment vs control |
+| 2 | single mechanism + multi-knob OR ablation OR dose-response on one knob |
+| 3 | multi-mechanism interactions, super-additivity, dose-response across knobs |
+| 4 | cross-system / cross-workload generalization, robustness across regimes |
+
+**Rule: iteration N may use any tier ≤ N.** Iter 1 → tier 1 only. Iter 2
+→ tier 1 or 2. Etc. Sophisticated hypotheses are allowed, just *deferred
+until simpler ones are ruled out*. The bundle's ``tier_justification``
+explains the chosen tier given the iteration index and prior refutations.
+
+The discipline is enforced through visibility, not refusal. The design
+gate (``orchestrator.complexity_tier.format_tier_summary``) prints the
+tier and prior-iteration tiers, and prominently flags jumps of more than
+one tier across iterations. Humans can override; agents cannot
+silently leap from tier 1 to tier 3.
+
 ## Meta-findings emit at campaign end (issue #155)
 
 Every campaign's terminal transition writes `meta_findings.json` at the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,24 @@ Beyond tests, Nous itself must be frugal with tokens:
 5. Stack PRs when one logical change builds on another rather than waiting
    for merge — see `docs/plans/CHECKPOINT.md` for the pattern.
 
+## Meta-findings emit at campaign end (issue #155)
+
+Every campaign's terminal transition writes `meta_findings.json` at the
+campaign work-dir. Three streams:
+
+1. `campaign_design_lessons` — how to structure future campaigns better.
+2. `target_system_asks` — what the target repo could improve.
+3. `nous_asks` — what Nous itself could improve.
+
+The emitter (`orchestrator.meta_findings.emit_meta_findings`) is **pure
+Python** — zero LLM tokens. Heuristics over `ledger.json`,
+`principles.json`, per-iteration `findings.json`, `retry_log.jsonl`,
+and `llm_metrics.jsonl` produce structured entries with concrete
+citations (iter-N, file path, tool name, error string, numeric
+measurement). The validator floor (`validate_evidence`) rejects
+aspirational platitudes regardless of source. See `docs/data-model.md`
+for the schema.
+
 ## See also
 
 - `docs/contributing/workflow.md` — full workflow doc.

--- a/orchestrator/campaign.py
+++ b/orchestrator/campaign.py
@@ -61,6 +61,43 @@ def _resolve_model(campaign: dict, phase_key: str, cli_model: str | None) -> str
     return cli_model or "aws/claude-sonnet-4-5"
 
 
+def _write_repo_cache(work_dir: Path, campaign: dict) -> None:
+    """Persist repo-level knowledge cache for the next campaign (issue #156).
+
+    Pure-Python: reads handoff.md + campaign.yaml and writes the cache
+    files. Skipped when there's no target_system.repo_path (no place
+    to put the cache). Best-effort — failures are logged, not fatal.
+    """
+    target = campaign.get("target_system", {}) if isinstance(campaign, dict) else {}
+    repo_path = target.get("repo_path")
+    if not repo_path:
+        return
+    try:
+        from orchestrator.repo_cache import (
+            build_cache_from_campaign,
+            write_repo_cache,
+        )
+        exploration, knobs, metrics, build = build_cache_from_campaign(
+            work_dir, campaign,
+        )
+        if not (exploration or knobs or metrics or build):
+            logger.info("No cache content extracted; skipping repo cache write.")
+            return
+        cache_dir = write_repo_cache(
+            Path(repo_path),
+            exploration=exploration,
+            knobs=knobs,
+            metrics=metrics,
+            build=build,
+        )
+        print(
+            f"  -> repo cache written to {cache_dir}  "
+            f"({len(knobs)} knob(s), {len(metrics)} metric(s))"
+        )
+    except Exception as exc:
+        logger.warning("Repo cache write failed: %s", exc)
+
+
 def _emit_meta_findings(work_dir: Path, campaign: dict) -> None:
     """Emit meta_findings.json at campaign end (issue #155).
 
@@ -320,6 +357,7 @@ def run_campaign(
             append_ledger_row(work_dir, i)
             print(f"\n  Campaign complete after {i} iteration(s).")
             _emit_meta_findings(work_dir, campaign)
+            _write_repo_cache(work_dir, campaign)
             _generate_report(campaign, work_dir, model, agent=agent, timeout=timeout)
             _write_metrics_summary(work_dir)
             return
@@ -328,6 +366,7 @@ def run_campaign(
             print(f"\n  Campaign aborted at iteration {i}.")
             print("  Engine state preserved for potential resume.")
             _emit_meta_findings(work_dir, campaign)
+            _write_repo_cache(work_dir, campaign)
             _write_metrics_summary(work_dir)
             return
 
@@ -377,6 +416,7 @@ def run_campaign(
             engine.transition("DONE")
             print(f"\n  Campaign stopped after {i} iteration(s).")
             _emit_meta_findings(work_dir, campaign)
+            _write_repo_cache(work_dir, campaign)
             _generate_report(campaign, work_dir, model, agent=agent, timeout=timeout)
             _write_metrics_summary(work_dir)
             return
@@ -389,6 +429,7 @@ def run_campaign(
 
     print(f"\n  Campaign reached max_iterations ({max_iterations}).")
     _emit_meta_findings(work_dir, campaign)
+    _write_repo_cache(work_dir, campaign)
     _generate_report(campaign, work_dir, model, agent=agent, timeout=timeout)
     _write_metrics_summary(work_dir)
 

--- a/orchestrator/campaign.py
+++ b/orchestrator/campaign.py
@@ -61,6 +61,37 @@ def _resolve_model(campaign: dict, phase_key: str, cli_model: str | None) -> str
     return cli_model or "aws/claude-sonnet-4-5"
 
 
+def _emit_meta_findings(work_dir: Path, campaign: dict) -> None:
+    """Emit meta_findings.json at campaign end (issue #155).
+
+    Pure-Python deterministic emitter — zero LLM tokens. Reads on-disk
+    artifacts (ledger, principles, findings, retry_log, llm_metrics)
+    and writes a structured set of triagable lessons across three
+    streams. Best-effort: failure is logged but never blocks the
+    campaign from exiting.
+    """
+    try:
+        from orchestrator.meta_findings import emit_meta_findings, write_meta_findings
+        from orchestrator.validate import validate_meta_findings
+        payload = emit_meta_findings(work_dir, campaign)
+        target = write_meta_findings(work_dir, payload)
+        result = validate_meta_findings(work_dir)
+        if result["status"] == "fail":
+            logger.warning(
+                "meta_findings.json failed self-validation: %s", result["errors"],
+            )
+        n_lessons = len(payload.get("campaign_design_lessons") or [])
+        n_repo = len(payload.get("target_system_asks") or [])
+        n_nous = len(payload.get("nous_asks") or [])
+        print(
+            f"  -> {target}  "
+            f"({n_lessons} design lesson(s), {n_repo} repo ask(s), "
+            f"{n_nous} nous ask(s))"
+        )
+    except Exception as exc:
+        logger.warning("Meta-findings emission failed: %s", exc)
+
+
 def _write_metrics_summary(work_dir: Path) -> None:
     """Write llm_metrics_summary.json and print a one-liner. Never raises."""
     try:
@@ -288,6 +319,7 @@ def run_campaign(
         if outcome == IterationOutcome.COMPLETED:
             append_ledger_row(work_dir, i)
             print(f"\n  Campaign complete after {i} iteration(s).")
+            _emit_meta_findings(work_dir, campaign)
             _generate_report(campaign, work_dir, model, agent=agent, timeout=timeout)
             _write_metrics_summary(work_dir)
             return
@@ -295,6 +327,7 @@ def run_campaign(
         if outcome == IterationOutcome.ABORTED:
             print(f"\n  Campaign aborted at iteration {i}.")
             print("  Engine state preserved for potential resume.")
+            _emit_meta_findings(work_dir, campaign)
             _write_metrics_summary(work_dir)
             return
 
@@ -343,6 +376,7 @@ def run_campaign(
             engine = Engine(work_dir)
             engine.transition("DONE")
             print(f"\n  Campaign stopped after {i} iteration(s).")
+            _emit_meta_findings(work_dir, campaign)
             _generate_report(campaign, work_dir, model, agent=agent, timeout=timeout)
             _write_metrics_summary(work_dir)
             return
@@ -354,6 +388,7 @@ def run_campaign(
         print(f"\n  Advancing to iteration {i + 1}...")
 
     print(f"\n  Campaign reached max_iterations ({max_iterations}).")
+    _emit_meta_findings(work_dir, campaign)
     _generate_report(campaign, work_dir, model, agent=agent, timeout=timeout)
     _write_metrics_summary(work_dir)
 

--- a/orchestrator/complexity_tier.py
+++ b/orchestrator/complexity_tier.py
@@ -1,0 +1,175 @@
+"""Graded-complexity tier discipline (issue #159).
+
+A bundle declares a ``complexity_tier`` (1..4) at the top level. The
+discipline is:
+
+  Tier 1: single mechanism, single knob, treatment vs control.
+  Tier 2: single mechanism, multi-knob OR ablation OR dose-response on one knob.
+  Tier 3: multi-mechanism interactions, super-additivity, dose-response across knobs.
+  Tier 4: cross-system / cross-workload generalization, robustness across regimes.
+
+  Iteration N may use any tier <= N. So iter 1 is forced to tier 1;
+  iter 2 may use tier 1 or 2; etc.
+
+This module is pure Python — zero LLM tokens. It surfaces tier and
+flags suspicious jumps (>1 across iterations) at the design gate so a
+human can probe whether the simpler tier was actually skipped for a
+defensible reason. We do **not** hard-reject tier overruns; the
+discipline is enforced through visibility, not refusal — so an
+agent that has good cause to escalate (e.g. iter 1's hypothesis was
+already refuted) is not blocked.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+TIER_NAMES: dict[int, str] = {
+    1: "single mechanism, single knob, treatment vs control",
+    2: "single mechanism + multi-knob OR ablation OR dose-response on one knob",
+    3: "multi-mechanism interactions, super-additivity, dose-response across knobs",
+    4: "cross-system / cross-workload generalization, robustness across regimes",
+}
+
+
+def _read_bundle_tier(path: Path) -> int | None:
+    """Read complexity_tier from a bundle.yaml. None if missing or malformed."""
+    if not path.exists():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text())
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    tier = data.get("complexity_tier")
+    if isinstance(tier, int) and 1 <= tier <= 4:
+        return tier
+    return None
+
+
+def prior_iteration_tiers(work_dir: Path, *, up_to: int) -> dict[int, int]:
+    """Return {iteration: tier} for completed prior iterations.
+
+    Looks at ``<work_dir>/runs/iter-N/bundle.yaml`` for N < ``up_to``.
+    Iterations whose bundle lacks ``complexity_tier`` are omitted.
+    """
+    out: dict[int, int] = {}
+    runs_dir = Path(work_dir) / "runs"
+    if not runs_dir.is_dir():
+        return out
+    for entry in runs_dir.iterdir():
+        if not entry.is_dir() or not entry.name.startswith("iter-"):
+            continue
+        try:
+            n = int(entry.name.split("-", 1)[1])
+        except (IndexError, ValueError):
+            continue
+        if n >= up_to:
+            continue
+        tier = _read_bundle_tier(entry / "bundle.yaml")
+        if tier is not None:
+            out[n] = tier
+    return out
+
+
+def detect_jump(
+    *,
+    iteration: int,
+    current_tier: int | None,
+    prior_tiers: dict[int, int],
+) -> str | None:
+    """Return a human-readable warning string if tier escalates abruptly.
+
+    Conditions:
+      * iter 1 + current_tier > 1 → "iter 1 should start at tier 1"
+      * current_tier > max(prior_tiers) + 1 → "skipped tier(s)"
+
+    Returns None when no jump is detected, or when current_tier is
+    missing (we don't pressure callers to declare it for legacy bundles).
+    """
+    if current_tier is None:
+        return None
+    if iteration <= 1 and current_tier > 1:
+        return (
+            f"Iteration 1 declared tier {current_tier} — the methodology "
+            f"asks iter 1 to start at tier 1 ('{TIER_NAMES[1]}'). "
+            f"Confirm this leap is justified by external evidence."
+        )
+    if not prior_tiers:
+        return None
+    prior_max = max(prior_tiers.values())
+    if current_tier > prior_max + 1:
+        skipped = list(range(prior_max + 1, current_tier))
+        return (
+            f"Tier jumped from {prior_max} (prior max) to {current_tier} — "
+            f"skipped tier(s) {skipped}. Confirm earlier tier(s) were "
+            f"refuted before escalating."
+        )
+    return None
+
+
+def format_tier_summary(
+    *,
+    iteration: int,
+    bundle_path: Path,
+    work_dir: Path | None = None,
+) -> str:
+    """Render the tier panel that gates.py prints before the design gate.
+
+    Always returns a non-empty string for a bundle that declares a
+    tier. For a bundle without ``complexity_tier``, returns an empty
+    string so the gate display is unaffected (additive).
+    """
+    tier = _read_bundle_tier(bundle_path)
+    if tier is None:
+        return ""
+
+    lines = [
+        "─" * 60,
+        f"  COMPLEXITY TIER (issue #159)",
+        "─" * 60,
+        f"  Iteration {iteration} declared tier {tier}: {TIER_NAMES.get(tier, '(unknown)')}",
+    ]
+
+    # Show justification if present.
+    try:
+        bundle = yaml.safe_load(Path(bundle_path).read_text())
+        justification = bundle.get("tier_justification") if isinstance(bundle, dict) else None
+    except (OSError, yaml.YAMLError):
+        justification = None
+    if justification:
+        lines.append(f"  Justification: {justification}")
+
+    if work_dir is not None:
+        priors = prior_iteration_tiers(work_dir, up_to=iteration)
+        if priors:
+            prior_str = ", ".join(f"iter-{n}=tier{t}" for n, t in sorted(priors.items()))
+            lines.append(f"  Prior tiers: {prior_str}")
+        warning = detect_jump(
+            iteration=iteration, current_tier=tier, prior_tiers=priors,
+        )
+        if warning:
+            lines.append("")
+            lines.append(f"  ⚠ TIER ESCALATION FLAGGED: {warning}")
+
+    lines.append("─" * 60)
+    return "\n".join(lines)
+
+
+def collect_tier_warnings(
+    iteration: int,
+    bundle_path: Path,
+    work_dir: Path,
+) -> list[str]:
+    """Pure-data version of format_tier_summary for tests / programmatic use."""
+    tier = _read_bundle_tier(bundle_path)
+    priors = prior_iteration_tiers(work_dir, up_to=iteration)
+    warning = detect_jump(
+        iteration=iteration, current_tier=tier, prior_tiers=priors,
+    )
+    return [warning] if warning else []

--- a/orchestrator/findings_classifier.py
+++ b/orchestrator/findings_classifier.py
@@ -1,0 +1,200 @@
+"""Deterministic classifiers for findings.json arm verdicts (issues #157, #158).
+
+These are pure-Python rules that turn raw observed data into a categorical
+verdict. They are the deterministic floor under the executor agent's
+narrative ``observed`` / ``status`` fields — when the agent emits
+structured numeric data alongside, the classifier checks whether the
+agent's verdict is consistent with the data.
+
+  * H-dose-response: shape (monotone, u-shape, saturating, flat).
+  * H-tradeoff:      verdict (confirmed / primary_failed / cost_too_high / both_failed).
+
+No LLM is consulted — the rules operate on numbers.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+# ─── Dose-response shape classification (#157) ────────────────────────────
+
+
+VALID_SHAPES = (
+    "monotone_decreasing",
+    "monotone_increasing",
+    "u_shaped",
+    "inverted_u",
+    "saturating",
+    "flat",
+)
+
+
+def _signed_diff_signs(metrics: Sequence[float]) -> list[int]:
+    """Sign of consecutive differences. +1, -1, or 0 (within tolerance)."""
+    signs: list[int] = []
+    for a, b in zip(metrics, metrics[1:]):
+        d = b - a
+        # Tolerance: 1% of mean magnitude (or absolute 1e-9 floor) — protects
+        # against floating-point noise reading as a real direction.
+        tolerance = max(abs((a + b) / 2) * 0.01, 1e-9)
+        if d > tolerance:
+            signs.append(1)
+        elif d < -tolerance:
+            signs.append(-1)
+        else:
+            signs.append(0)
+    return signs
+
+
+def classify_dose_shape(
+    metrics: Sequence[float], *,
+    saturation_ratio: float = 0.20,
+    flat_threshold: float = 0.05,
+) -> str:
+    """Return the observed shape from a sequence of metric values.
+
+    The shape is classified from the sequence's signed differences:
+
+      * All non-decreasing (with at least one +1): monotone_increasing
+        — UNLESS the late differences shrink to <saturation_ratio of
+        the early differences, in which case ``saturating``.
+      * All non-increasing (with at least one -1): monotone_decreasing.
+      * Sign flips from - to +: u_shaped.
+      * Sign flips from + to -: inverted_u.
+      * Total relative range < flat_threshold: flat.
+      * None of the above: noisy.
+
+    Args:
+      metrics: ordered metric values, one per increasing knob value.
+      saturation_ratio: threshold below which late slope counts as flat.
+      flat_threshold: max relative spread for the whole series to be "flat".
+
+    The returned string is always a valid value of the
+    findings.schema.json ``observed_shape`` enum (or ``"noisy"``).
+    """
+    if not metrics or len(metrics) < 3:
+        return "noisy"
+
+    spread = max(metrics) - min(metrics)
+    mean = sum(metrics) / len(metrics)
+    if mean and abs(spread / mean) < flat_threshold:
+        return "flat"
+
+    signs = _signed_diff_signs(metrics)
+
+    # Pure monotonicity (allowing zeros).
+    if all(s >= 0 for s in signs) and any(s > 0 for s in signs):
+        # Saturating: late slope much smaller than early slope.
+        diffs = [b - a for a, b in zip(metrics, metrics[1:])]
+        if len(diffs) >= 2 and abs(diffs[0]) > 0:
+            late_avg = sum(abs(d) for d in diffs[len(diffs) // 2:]) / (len(diffs) - len(diffs) // 2)
+            early = abs(diffs[0])
+            if early > 0 and late_avg / early < saturation_ratio:
+                return "saturating"
+        return "monotone_increasing"
+
+    if all(s <= 0 for s in signs) and any(s < 0 for s in signs):
+        diffs = [b - a for a, b in zip(metrics, metrics[1:])]
+        if len(diffs) >= 2 and abs(diffs[0]) > 0:
+            late_avg = sum(abs(d) for d in diffs[len(diffs) // 2:]) / (len(diffs) - len(diffs) // 2)
+            early = abs(diffs[0])
+            if early > 0 and late_avg / early < saturation_ratio:
+                return "saturating"
+        return "monotone_decreasing"
+
+    # Look for a single sign flip — indicates a turning point.
+    nonzero = [s for s in signs if s != 0]
+    if len(nonzero) >= 2:
+        flips = sum(1 for a, b in zip(nonzero, nonzero[1:]) if a != b)
+        if flips == 1:
+            if nonzero[0] < 0 and nonzero[-1] > 0:
+                return "u_shaped"
+            if nonzero[0] > 0 and nonzero[-1] < 0:
+                return "inverted_u"
+
+    return "noisy"
+
+
+def shape_matches(expected: str | None, observed: str | None) -> bool:
+    """True iff the expected and observed shapes are compatible.
+
+    Some shapes have looser equivalents — saturating is an acceptable
+    realisation of monotone, since saturation is monotone with declining
+    slope. ``noisy`` never matches.
+    """
+    if not expected or not observed or observed == "noisy":
+        return False
+    if expected == observed:
+        return True
+    if expected == "monotone_decreasing" and observed == "saturating":
+        return True
+    if expected == "monotone_increasing" and observed == "saturating":
+        return True
+    return False
+
+
+# ─── Tradeoff verdict classification (#158) ───────────────────────────────
+
+
+@dataclass
+class TradeoffVerdict:
+    """Outcome of an H-tradeoff arm given measured deltas and budgets."""
+
+    primary_predicate_met: bool
+    secondary_predicate_met: bool
+    verdict: str   # "confirmed" | "primary_failed" | "cost_too_high" | "both_failed"
+
+
+def classify_tradeoff(
+    *,
+    primary_change_observed: float,
+    primary_change_predicted: float,
+    secondary_change_observed: float,
+    secondary_budget: float,
+    secondary_direction: str,
+) -> TradeoffVerdict:
+    """Apply the predicate truth table to determine the verdict.
+
+    Primary predicate: the observed primary change is consistent with
+    the prediction direction and meets its magnitude (>= predicted if
+    predicted is positive, <= predicted if predicted is negative).
+
+    Secondary predicate: the observed secondary change is within budget
+    in the named "worse" direction. ``secondary_direction`` is "increase"
+    (worse means going up) or "decrease" (worse means going down). The
+    budget is positive; secondary changes in the *better* direction
+    always pass.
+    """
+    if primary_change_predicted == 0:
+        primary_ok = abs(primary_change_observed) >= 0
+    elif primary_change_predicted > 0:
+        primary_ok = primary_change_observed >= primary_change_predicted
+    else:
+        primary_ok = primary_change_observed <= primary_change_predicted
+
+    if secondary_direction not in {"increase", "decrease"}:
+        raise ValueError(f"invalid secondary_direction: {secondary_direction!r}")
+    if secondary_budget < 0:
+        raise ValueError(f"secondary_budget must be >= 0, got {secondary_budget}")
+
+    if secondary_direction == "increase":
+        # Worse is up — observation must be at most +budget.
+        secondary_ok = secondary_change_observed <= secondary_budget
+    else:
+        # Worse is down — observation must be at least -budget.
+        secondary_ok = secondary_change_observed >= -secondary_budget
+
+    if primary_ok and secondary_ok:
+        verdict = "confirmed"
+    elif not primary_ok and secondary_ok:
+        verdict = "primary_failed"
+    elif primary_ok and not secondary_ok:
+        verdict = "cost_too_high"
+    else:
+        verdict = "both_failed"
+
+    return TradeoffVerdict(
+        primary_predicate_met=primary_ok,
+        secondary_predicate_met=secondary_ok,
+        verdict=verdict,
+    )

--- a/orchestrator/gates.py
+++ b/orchestrator/gates.py
@@ -66,7 +66,12 @@ class HumanGate:
         reviews: list[str] | None = None,
         summary_path: str | None = None,
         files: list[str] | None = None,
+        tier_panel: str | None = None,
     ) -> tuple[str, str | None]:
+        # Complexity-tier panel (issue #159) — shown before the LLM
+        # summary so a tier escalation flag isn't buried.
+        if tier_panel:
+            print(f"\n{tier_panel}")
         # Show summary if available (before raw artifact and auto-response)
         if summary_path:
             spath = Path(summary_path)

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -404,10 +404,23 @@ def run_iteration(
         print(f"  HUMAN DESIGN GATE")
         print(f"{'='*60}")
         summary_path = _generate_gate_summary(llm_dispatcher, iter_dir, iteration, "design", campaign=campaign)
+        # Issue #159: render complexity-tier panel from the bundle so tier
+        # escalations are surfaced for human review (deterministic Python,
+        # no LLM cost).
+        try:
+            from orchestrator.complexity_tier import format_tier_summary
+            tier_panel = format_tier_summary(
+                iteration=iteration,
+                bundle_path=iter_dir / "bundle.yaml",
+                work_dir=work_dir,
+            )
+        except (OSError, RuntimeError):
+            tier_panel = None
         decision, reason = gate.prompt(
             "Review the hypothesis bundle. Approve?",
             summary_path=str(summary_path) if summary_path else None,
             files=[str(iter_dir / "bundle.yaml"), str(iter_dir / "problem.md")],
+            tier_panel=tier_panel or None,
         )
         if decision == "reject":
             _save_human_feedback(iter_dir, "design", reason or "(Rejected without specific feedback)")

--- a/orchestrator/meta_findings.py
+++ b/orchestrator/meta_findings.py
@@ -1,0 +1,433 @@
+"""Deterministic emitter for ``meta_findings.json`` (issue #155).
+
+Reads the campaign's on-disk artifacts (ledger.json, principles.json,
+findings.json across iterations, retry_log.jsonl, llm_metrics.jsonl)
+and emits a structured ``meta_findings.json`` with three streams of
+lessons:
+
+  * ``campaign_design_lessons`` — how to structure future campaigns better.
+  * ``target_system_asks``      — what the target repo should improve.
+  * ``nous_asks``               — what Nous itself should improve.
+
+This is **pure Python** — zero LLM tokens. The bottom-line goal of the
+issue (capturing a triagable feedback signal that today lives only in
+chat history) is met by deterministic heuristics over artifacts the
+orchestrator already writes. Each emitted entry carries a concrete
+``evidence`` citation that points at a specific iter-N, file path,
+tool name, or error string — never a vague aspirational claim.
+
+This file is also the home of citation enforcement. ``validate_evidence``
+classifies an evidence string as concrete or vague; the validator in
+``orchestrator.validate`` uses the same classifier so an LLM-emitted
+meta_findings.json (a future enhancement) is held to the same floor.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from orchestrator.util import atomic_write
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "1"
+
+# ─── Citation enforcement ────────────────────────────────────────────────
+#
+# An evidence string is "concrete" if it cites a specific moment in the
+# campaign. The patterns below are intentionally permissive — descriptive
+# long-form text with a number and a name is fine; what we reject is
+# pure platitudes ("things were slow", "it didn't work"). The patterns
+# match anywhere in the string.
+
+_CITATION_PATTERNS = (
+    re.compile(r"\biter[-_ ]?\d+\b", re.IGNORECASE),
+    re.compile(r"\b\w+\.(py|yaml|yml|json|md|toml|jsonl|txt|sh|patch)\b"),
+    re.compile(r"/[\w./-]{3,}"),
+    re.compile(r'"[^"]{4,}"'),
+    re.compile(r"\b(Read|Write|Bash|Edit|Glob|Grep|TodoWrite|Task|Skill|"
+               r"claude_agent_sdk|subprocess|cli_dispatch|sdk_dispatch|"
+               r"llm_dispatch|inline_dispatch|StubDispatcher)\b"),
+    re.compile(r"\barm[_-]?(?:id\s*=|\s+)[\w-]+", re.IGNORECASE),
+    re.compile(r"\bh-(main|ablation|super-additivity|control-negative|"
+               r"robustness|dose-response|tradeoff)\b", re.IGNORECASE),
+    re.compile(r"\b\d+(?:\.\d+)?\s*(ms|s|tokens?|%|MB|GB|x)\b"),
+    re.compile(r"\b\d{2,}\b"),
+)
+
+
+def evidence_is_concrete(text: str) -> bool:
+    """True iff the evidence string carries at least one citation marker.
+
+    Used by both the emitter (to self-check) and the validator (to
+    reject vague entries from any source — Python or future LLM).
+    """
+    if not text or len(text) < 8:
+        return False
+    return any(p.search(text) for p in _CITATION_PATTERNS)
+
+
+def validate_evidence(text: str) -> str | None:
+    """Return None if evidence passes the citation floor, else an error.
+
+    The error is human-readable so the validator can surface it as
+    ``meta_findings.json: <stream>[i].evidence is too vague: ...``.
+    """
+    if not isinstance(text, str):
+        return f"evidence must be a string, got {type(text).__name__}"
+    if len(text) < 8:
+        return f"evidence too short ({len(text)} chars; need >= 8)"
+    if not evidence_is_concrete(text):
+        return (
+            "evidence is vague: must cite at least one concrete marker "
+            "(iter-N, file path, tool name, quoted error, arm id, or "
+            "a numeric measurement). Got: "
+            + (text[:80] + ("…" if len(text) > 80 else ""))
+        )
+    return None
+
+
+# ─── Artifact readers ────────────────────────────────────────────────────
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    entries: list[dict] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return entries
+
+
+def _read_json(path: Path) -> dict | list | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _iter_findings(work_dir: Path) -> Iterable[tuple[int, dict]]:
+    runs_dir = work_dir / "runs"
+    if not runs_dir.is_dir():
+        return
+    for child in sorted(runs_dir.iterdir()):
+        if not child.is_dir() or not child.name.startswith("iter-"):
+            continue
+        try:
+            iteration = int(child.name.split("-", 1)[1])
+        except (IndexError, ValueError):
+            continue
+        f = _read_json(child / "findings.json")
+        if isinstance(f, dict):
+            yield iteration, f
+
+
+# ─── Heuristic detectors ─────────────────────────────────────────────────
+
+
+def _detect_target_system_asks(
+    campaign: dict, retry_entries: list[dict],
+) -> list[dict]:
+    """Find concrete asks of the target repo from retry log and campaign.
+
+    Heuristics:
+      * Repeated retries of the same dispatch failure point at flaky
+        tooling or missing instrumentation.
+      * Empty observable_metrics / controllable_knobs in campaign.yaml
+        means the planner had to discover them — a documentation gap.
+    """
+    asks: list[dict] = []
+
+    if retry_entries:
+        # Bucket by phase + failure_type — repeated bucket entries are signal.
+        by_bucket: Counter[tuple[str, str]] = Counter()
+        sample_error: dict[tuple[str, str], str] = {}
+        for entry in retry_entries:
+            phase = entry.get("phase") or "unknown"
+            kind = entry.get("failure_type") or "unknown"
+            key = (phase, kind)
+            by_bucket[key] += 1
+            if key not in sample_error:
+                sample_error[key] = (entry.get("error") or "")[:120]
+        for (phase, kind), count in by_bucket.most_common(3):
+            if count < 2:
+                continue
+            err = sample_error.get((phase, kind), "")
+            asks.append({
+                "ask": (
+                    f"Reduce {kind} failures during {phase}: the dispatcher "
+                    f"retried {count} times in this campaign."
+                ),
+                "evidence": (
+                    f"retry_log.jsonl: phase={phase} failure_type={kind} "
+                    f"count={count} sample=\"{err}\""
+                ),
+                "kind": "reproducibility",
+            })
+
+    target = campaign.get("target_system", {}) if isinstance(campaign, dict) else {}
+    if not target.get("observable_metrics"):
+        asks.append({
+            "ask": (
+                "Declare observable_metrics in campaign.yaml so the planner "
+                "doesn't have to rediscover them via Explore."
+            ),
+            "evidence": (
+                "campaign.yaml: target_system.observable_metrics is unset; "
+                "planner had to infer from code in iter-1 design phase."
+            ),
+            "kind": "instrumentation",
+        })
+    if not target.get("controllable_knobs"):
+        asks.append({
+            "ask": (
+                "Declare controllable_knobs in campaign.yaml so the planner "
+                "can pick from a known list rather than discovering them."
+            ),
+            "evidence": (
+                "campaign.yaml: target_system.controllable_knobs is unset; "
+                "planner had to infer from code in iter-1 design phase."
+            ),
+            "kind": "documentation",
+        })
+
+    return asks
+
+
+def _detect_nous_asks(
+    metrics_entries: list[dict], retry_entries: list[dict],
+) -> list[dict]:
+    """Find concrete asks of Nous itself from llm_metrics + retry log."""
+    asks: list[dict] = []
+
+    if metrics_entries:
+        total_in = sum((e.get("input_tokens") or 0) for e in metrics_entries)
+        cache_read = sum((e.get("cache_read_input_tokens") or 0) for e in metrics_entries)
+        calls = len(metrics_entries)
+        if total_in > 0 and calls > 0:
+            avg_in = total_in / calls
+            cache_ratio = (cache_read / total_in) if total_in else 0.0
+            if avg_in > 30000:
+                asks.append({
+                    "ask": (
+                        "Per-call input tokens are high — investigate "
+                        "whether more of the system block can be cached "
+                        "or whether handoff.md is unbounded."
+                    ),
+                    "evidence": (
+                        f"llm_metrics.jsonl: avg input_tokens per call "
+                        f"= {int(avg_in)} across {calls} calls "
+                        f"(total_input={total_in})."
+                    ),
+                    "kind": "token_budget",
+                })
+            if total_in > 5000 and cache_ratio < 0.30:
+                asks.append({
+                    "ask": (
+                        "Prompt cache hit rate is low — verify the static "
+                        "system block is being cached and not perturbed by "
+                        "per-call substitution."
+                    ),
+                    "evidence": (
+                        f"llm_metrics.jsonl: cache_read_input_tokens / "
+                        f"total_input_tokens = {cache_ratio:.0%} "
+                        f"({cache_read}/{total_in}); expected >= 30%."
+                    ),
+                    "kind": "token_budget",
+                })
+
+    if len(retry_entries) >= 5:
+        kinds = Counter(e.get("failure_type") or "unknown" for e in retry_entries)
+        top_kind, top_count = kinds.most_common(1)[0]
+        if top_count >= 3:
+            asks.append({
+                "ask": (
+                    "Investigate root cause of repeated dispatch retries — "
+                    "the retry path is masking a recurrent failure."
+                ),
+                "evidence": (
+                    f"retry_log.jsonl: failure_type={top_kind} occurred "
+                    f"{top_count} times across the campaign."
+                ),
+                "kind": "dispatch",
+            })
+
+    return asks
+
+
+def _detect_design_lessons(work_dir: Path) -> list[dict]:
+    """Find lessons about campaign design from per-iteration findings."""
+    lessons: list[dict] = []
+
+    findings_by_iter: dict[int, dict] = dict(_iter_findings(work_dir))
+    if not findings_by_iter:
+        return lessons
+
+    h_main_status: dict[int, str] = {}
+    invalid_iters: list[int] = []
+    for it, f in findings_by_iter.items():
+        if not f.get("experiment_valid", True):
+            invalid_iters.append(it)
+        for arm in f.get("arms", []) or []:
+            if arm.get("arm_type") == "h-main":
+                h_main_status[it] = arm.get("status", "")
+                break
+
+    if invalid_iters:
+        lessons.append({
+            "lesson": (
+                "Tighten experiment_plan validation upstream: at least one "
+                "iteration produced findings.json with experiment_valid=false."
+            ),
+            "evidence": (
+                f"findings.json reported experiment_valid=false in "
+                f"iter-{','.join(str(i) for i in invalid_iters)}"
+            ),
+        })
+
+    refuted_then_confirmed = [
+        i for i in sorted(h_main_status)
+        if h_main_status[i] == "CONFIRMED"
+        and any(h_main_status.get(j) == "REFUTED" for j in h_main_status if j < i)
+    ]
+    if refuted_then_confirmed:
+        first_confirm = refuted_then_confirmed[0]
+        first_refute = next(
+            j for j in sorted(h_main_status)
+            if h_main_status[j] == "REFUTED" and j < first_confirm
+        )
+        lessons.append({
+            "lesson": (
+                "Initial mechanism hypothesis was wrong — schedule simpler "
+                "alternative arms in iter 1 next time."
+            ),
+            "evidence": (
+                f"h-main was REFUTED in iter-{first_refute} and only "
+                f"CONFIRMED in iter-{first_confirm}."
+            ),
+        })
+
+    if h_main_status and all(s == "REFUTED" for s in h_main_status.values()):
+        iters_str = ",".join(str(i) for i in sorted(h_main_status))
+        lessons.append({
+            "lesson": (
+                "Every h-main arm was refuted — the family of mechanisms "
+                "explored may not be the right one for this research question."
+            ),
+            "evidence": (
+                f"h-main status = REFUTED in iter-{iters_str} (every "
+                f"completed iteration)."
+            ),
+        })
+
+    return lessons
+
+
+# ─── Top-level emitter ───────────────────────────────────────────────────
+
+
+def emit_meta_findings(
+    work_dir: Path, campaign: dict, *, now: datetime | None = None,
+) -> dict:
+    """Build the meta_findings.json payload for a completed campaign.
+
+    Pure function — does not write to disk. Caller passes it through
+    ``write_meta_findings``. Heuristics are deterministic and depend
+    only on the on-disk artifacts already produced by the orchestrator;
+    no LLM is consulted.
+    """
+    work_dir = Path(work_dir)
+    metrics = _read_jsonl(work_dir / "llm_metrics.jsonl")
+    retries = _read_jsonl(work_dir / "retry_log.jsonl")
+
+    ledger = _read_json(work_dir / "ledger.json")
+    iterations_completed = 0
+    if isinstance(ledger, dict):
+        iterations_completed = sum(
+            1 for row in ledger.get("iterations", [])
+            if isinstance(row, dict)
+            and isinstance(row.get("iteration"), int)
+            and row["iteration"] >= 1
+        )
+
+    state = _read_json(work_dir / "state.json")
+    run_id = (
+        state.get("run_id", work_dir.name)
+        if isinstance(state, dict) else work_dir.name
+    )
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": (now or datetime.now(timezone.utc)).isoformat(),
+        "run_id": run_id,
+        "iterations_completed": iterations_completed,
+        "campaign_design_lessons": _detect_design_lessons(work_dir),
+        "target_system_asks": _detect_target_system_asks(campaign, retries),
+        "nous_asks": _detect_nous_asks(metrics, retries),
+    }
+
+    if not (
+        payload["campaign_design_lessons"]
+        or payload["target_system_asks"]
+        or payload["nous_asks"]
+    ):
+        payload["notes"] = (
+            "No surprises detected from artifacts. This is rare — typically "
+            "indicates a very short campaign (single iteration, no retries, "
+            "no token-budget anomalies)."
+        )
+
+    return payload
+
+
+def write_meta_findings(work_dir: Path, payload: dict) -> Path:
+    """Atomically write meta_findings.json and return the path."""
+    work_dir = Path(work_dir)
+    target = work_dir / "meta_findings.json"
+    atomic_write(target, json.dumps(payload, indent=2) + "\n")
+    return target
+
+
+def render_meta_findings_markdown(payload: dict) -> str:
+    """Render the three streams as a markdown section for nous report."""
+    lines = ["## Meta-findings", ""]
+    sections = [
+        ("Campaign-design lessons", payload.get("campaign_design_lessons") or [], "lesson"),
+        ("Target-system asks", payload.get("target_system_asks") or [], "ask"),
+        ("Nous asks", payload.get("nous_asks") or [], "ask"),
+    ]
+    any_content = False
+    for title, items, key in sections:
+        lines.append(f"### {title}")
+        lines.append("")
+        if not items:
+            lines.append("_None._")
+            lines.append("")
+            continue
+        any_content = True
+        for item in items:
+            text = item.get(key, "")
+            evidence = item.get("evidence", "")
+            kind = item.get("kind")
+            kind_str = f" _[{kind}]_" if kind else ""
+            lines.append(f"- {text}{kind_str}")
+            if evidence:
+                lines.append(f"  - Evidence: {evidence}")
+        lines.append("")
+    if not any_content and payload.get("notes"):
+        lines.append(f"_{payload['notes']}_")
+        lines.append("")
+    return "\n".join(lines)

--- a/orchestrator/repo_cache.py
+++ b/orchestrator/repo_cache.py
@@ -1,0 +1,411 @@
+"""Repo-level knowledge cache (issue #156).
+
+Persists a small, factual set of repo facts at ``<target_repo>/.nous/repo/``
+so subsequent campaigns can skip the most expensive part of DESIGN —
+rediscovering the same build commands, knob locations, and metric
+sources every time. The interpretive layer (what the bottleneck is,
+which mechanism explains a metric) is **not** cached; that's the
+campaign's job, every time.
+
+Layout:
+
+  <repo>/.nous/repo/
+    exploration.md         narrative tour for the planner to read first
+    knobs.yaml             discovered tunables (name, location, type, range)
+    metrics.yaml           observable metrics (capture mechanics)
+    build.yaml             build/test/run commands and prerequisites
+    schema_version.txt     forward-compat anchor
+    last_verified_at.txt   "<git_sha>\\n<iso_timestamp>\\n" — drives freshness
+
+This module is pure Python with no LLM call. Higher-level code (the
+campaign-end writer in ``campaign.py`` and the design-time loader)
+adds the bridges to disk-level cache content. The verify-before-use
+discipline is enforced by ``is_fresh`` — when ``last_verified_at`` does
+not match HEAD, the cache is considered stale and callers fall back
+to today's behavior (full Explore re-discovery).
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+import jsonschema
+import yaml
+
+from orchestrator.util import atomic_write
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "1"
+CACHE_SUBDIR = Path(".nous") / "repo"
+
+_SCHEMAS_DIR = Path(__file__).resolve().parent / "schemas"
+
+
+def cache_dir_for(repo_path: Path) -> Path:
+    """Return the absolute path to the repo cache directory."""
+    return Path(repo_path) / CACHE_SUBDIR
+
+
+def _read_yaml(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        loaded = yaml.safe_load(path.read_text())
+        return loaded if isinstance(loaded, dict) else None
+    except (OSError, yaml.YAMLError):
+        return None
+
+
+def _validate_against_def(payload: dict | None, def_name: str) -> bool:
+    """Validate ``payload`` against ``$defs/<def_name>`` in the cache schema.
+
+    Returns True iff the payload is non-None and conforms. The schema
+    file is the same one shipped with the orchestrator; a malformed
+    cache file is treated as missing rather than fatal.
+    """
+    if not isinstance(payload, dict):
+        return False
+    try:
+        schema = yaml.safe_load((_SCHEMAS_DIR / "repo_cache.schema.yaml").read_text())
+    except (OSError, yaml.YAMLError):
+        return False
+    sub = schema.get("$defs", {}).get(def_name)
+    if not sub:
+        return False
+    try:
+        jsonschema.validate(payload, sub)
+    except jsonschema.ValidationError:
+        return False
+    return True
+
+
+def _git_head_sha(repo_path: Path) -> str | None:
+    """Best-effort `git rev-parse HEAD`. None if not a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() or None
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return None
+
+
+@dataclass
+class RepoCache:
+    """In-memory view of a repo cache directory.
+
+    The ``fresh`` flag is computed at read time using ``head_sha`` (the
+    current HEAD of the target repo) and ``verified_sha`` (the sha
+    recorded when the cache was last written). Treat ``fresh=False``
+    as "do not trust" and fall back to full re-discovery — the cache
+    is an optimisation, never authoritative.
+    """
+
+    exploration: str = ""
+    knobs: list[dict] = field(default_factory=list)
+    metrics: list[dict] = field(default_factory=list)
+    build: dict = field(default_factory=dict)
+    verified_sha: str | None = None
+    verified_at: str | None = None
+    head_sha: str | None = None
+    fresh: bool = False
+
+    def is_empty(self) -> bool:
+        return not (self.exploration or self.knobs or self.metrics or self.build)
+
+    def to_dict(self) -> dict:
+        """Stable dict view, suitable for assertions in tests."""
+        return {
+            "exploration": self.exploration,
+            "knobs": self.knobs,
+            "metrics": self.metrics,
+            "build": self.build,
+            "verified_sha": self.verified_sha,
+            "verified_at": self.verified_at,
+            "head_sha": self.head_sha,
+            "fresh": self.fresh,
+        }
+
+
+def write_repo_cache(
+    repo_path: Path,
+    *,
+    exploration: str | None = None,
+    knobs: list[dict] | None = None,
+    metrics: list[dict] | None = None,
+    build: dict | None = None,
+    git_sha: str | None = None,
+    now: datetime | None = None,
+    head_sha_fn: Callable[[Path], str | None] | None = None,
+) -> Path:
+    """Write the cache directory atomically. Returns the cache dir path.
+
+    The on-disk shape is the documented layout; ``schema_version.txt``
+    and ``last_verified_at.txt`` are always written so freshness is
+    always answerable. Writes only the files for which the caller
+    supplied content — partial caches are valid (e.g. exploration-only
+    on the first campaign that runs).
+    """
+    repo_path = Path(repo_path)
+    cache_dir = cache_dir_for(repo_path)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    if exploration:
+        atomic_write(cache_dir / "exploration.md", exploration)
+
+    if knobs is not None:
+        payload = {"schema_version": SCHEMA_VERSION, "knobs": knobs}
+        atomic_write(
+            cache_dir / "knobs.yaml",
+            yaml.safe_dump(payload, default_flow_style=False, sort_keys=False),
+        )
+
+    if metrics is not None:
+        payload = {"schema_version": SCHEMA_VERSION, "metrics": metrics}
+        atomic_write(
+            cache_dir / "metrics.yaml",
+            yaml.safe_dump(payload, default_flow_style=False, sort_keys=False),
+        )
+
+    if build is not None:
+        payload = {"schema_version": SCHEMA_VERSION, **build}
+        atomic_write(
+            cache_dir / "build.yaml",
+            yaml.safe_dump(payload, default_flow_style=False, sort_keys=False),
+        )
+
+    atomic_write(cache_dir / "schema_version.txt", f"{SCHEMA_VERSION}\n")
+
+    sha = git_sha
+    if sha is None:
+        sha_fn = head_sha_fn or _git_head_sha
+        sha = sha_fn(repo_path)
+    sha = sha or "unknown"
+    ts = (now or datetime.now(timezone.utc)).isoformat()
+    atomic_write(cache_dir / "last_verified_at.txt", f"{sha}\n{ts}\n")
+
+    logger.info(
+        "Wrote repo cache to %s (sha=%s, knobs=%d, metrics=%d)",
+        cache_dir, sha,
+        len(knobs or []), len(metrics or []),
+    )
+    return cache_dir
+
+
+def read_repo_cache(
+    repo_path: Path,
+    *,
+    head_sha_fn: Callable[[Path], str | None] | None = None,
+) -> RepoCache | None:
+    """Load the cache. Returns None if the cache directory does not exist.
+
+    A directory with corrupt or missing files yields a partially-populated
+    ``RepoCache``; callers should check ``is_empty()`` before trusting it.
+    Freshness is computed against the target repo's HEAD via
+    ``head_sha_fn`` (defaults to ``git rev-parse HEAD``).
+    """
+    cache_dir = cache_dir_for(repo_path)
+    if not cache_dir.is_dir():
+        return None
+
+    cache = RepoCache()
+
+    explore_path = cache_dir / "exploration.md"
+    if explore_path.exists():
+        try:
+            cache.exploration = explore_path.read_text()
+        except OSError:
+            cache.exploration = ""
+
+    knobs_payload = _read_yaml(cache_dir / "knobs.yaml")
+    if _validate_against_def(knobs_payload, "knobs_file") and knobs_payload:
+        cache.knobs = knobs_payload.get("knobs", []) or []
+
+    metrics_payload = _read_yaml(cache_dir / "metrics.yaml")
+    if _validate_against_def(metrics_payload, "metrics_file") and metrics_payload:
+        cache.metrics = metrics_payload.get("metrics", []) or []
+
+    build_payload = _read_yaml(cache_dir / "build.yaml")
+    if _validate_against_def(build_payload, "build_file") and build_payload:
+        cache.build = {k: v for k, v in build_payload.items() if k != "schema_version"}
+
+    verified_path = cache_dir / "last_verified_at.txt"
+    if verified_path.exists():
+        try:
+            lines = [ln for ln in verified_path.read_text().splitlines() if ln.strip()]
+            if lines:
+                cache.verified_sha = lines[0].strip()
+            if len(lines) >= 2:
+                cache.verified_at = lines[1].strip()
+        except OSError:
+            pass
+
+    sha_fn = head_sha_fn or _git_head_sha
+    cache.head_sha = sha_fn(repo_path)
+    cache.fresh = bool(
+        cache.verified_sha
+        and cache.head_sha
+        and cache.verified_sha == cache.head_sha
+        and cache.verified_sha != "unknown"
+    )
+
+    return cache
+
+
+def is_fresh(repo_path: Path, *, head_sha_fn: Callable[[Path], str | None] | None = None) -> bool:
+    """Top-level convenience: is the cache present and at HEAD?"""
+    cache = read_repo_cache(repo_path, head_sha_fn=head_sha_fn)
+    return bool(cache and cache.fresh)
+
+
+def render_cache_for_design_prompt(cache: RepoCache) -> str:
+    """Render the cache as a markdown block to include in DESIGN context.
+
+    Used both by CLAUDE.md-style auto-loading and by direct prompt
+    composition. Empty caches render as an empty string so callers
+    can ``if rendered:`` cleanly.
+    """
+    if cache.is_empty() or not cache.fresh:
+        return ""
+    parts: list[str] = ["## Repo cache (verified, skip rediscovery)\n"]
+    if cache.exploration:
+        parts.append(cache.exploration.strip() + "\n")
+    if cache.knobs:
+        parts.append("### Known knobs")
+        for k in cache.knobs:
+            location = f" (`{k['location']}`)" if k.get("location") else ""
+            type_str = f" — _{k['type']}_" if k.get("type") else ""
+            parts.append(f"- **{k['name']}**{location}{type_str}")
+        parts.append("")
+    if cache.metrics:
+        parts.append("### Known metrics")
+        for m in cache.metrics:
+            unit = f" [{m['unit']}]" if m.get("unit") else ""
+            capture = f" — {m['capture']}" if m.get("capture") else ""
+            parts.append(f"- **{m['name']}**{unit}{capture}")
+        parts.append("")
+    if cache.build:
+        parts.append("### Build")
+        for key in ("build_command", "test_command", "run_command"):
+            if cache.build.get(key):
+                parts.append(f"- {key.replace('_', ' ')}: `{cache.build[key]}`")
+        if cache.build.get("prerequisites"):
+            prereqs = ", ".join(cache.build["prerequisites"])
+            parts.append(f"- prerequisites: {prereqs}")
+        if cache.build.get("env_vars"):
+            envs = ", ".join(cache.build["env_vars"])
+            parts.append(f"- env vars: {envs}")
+        parts.append("")
+    return "\n".join(parts) + "\n"
+
+
+# ─── Heuristic builder from existing campaign artifacts ──────────────────
+
+
+def _extract_handoff_section(handoff_md: str, *header_options: str) -> str:
+    """Pull a named section out of a handoff.md by markdown header."""
+    if not handoff_md:
+        return ""
+    lines = handoff_md.splitlines()
+    for option in header_options:
+        target = option.strip().lower()
+        for i, line in enumerate(lines):
+            stripped = line.strip().lstrip("#").strip().lower()
+            if stripped == target:
+                # Capture until next heading at same or higher level
+                level = len(line) - len(line.lstrip("#"))
+                buf: list[str] = []
+                for follow in lines[i + 1:]:
+                    if follow.lstrip().startswith("#"):
+                        next_level = len(follow) - len(follow.lstrip("#"))
+                        if next_level <= level:
+                            break
+                    buf.append(follow)
+                return "\n".join(buf).strip()
+    return ""
+
+
+def build_cache_from_campaign(
+    work_dir: Path, campaign: dict,
+) -> tuple[str, list[dict], list[dict], dict]:
+    """Build cache content from completed-campaign artifacts.
+
+    Pure-Python heuristic. The caller (campaign.py end-of-run) feeds
+    these into ``write_repo_cache``. Notes:
+
+      * ``exploration.md`` is sourced from the latest ``handoff.md``,
+        truncated to the most useful sections — the LLM's narrative,
+        not principles.
+      * ``knobs.yaml`` and ``metrics.yaml`` are seeded from
+        campaign.yaml's declared lists; the planner can refine them
+        in subsequent campaigns.
+      * ``build.yaml`` pulls from the System Interface section of
+        handoff.md when present.
+    """
+    work_dir = Path(work_dir)
+
+    # Exploration.md from handoff.md — the campaign-level living doc.
+    handoff_path = work_dir / "handoff.md"
+    handoff_text = handoff_path.read_text() if handoff_path.exists() else ""
+    exploration = handoff_text.strip()
+
+    # Knobs / metrics — bootstrap from campaign.yaml. These are the
+    # declared facts the campaign told us; on subsequent runs the
+    # planner may augment them.
+    target = campaign.get("target_system", {}) if isinstance(campaign, dict) else {}
+    knobs: list[dict] = []
+    for raw in target.get("controllable_knobs", []) or []:
+        if isinstance(raw, str):
+            knobs.append({"name": raw})
+        elif isinstance(raw, dict) and "name" in raw:
+            knobs.append({k: v for k, v in raw.items() if k in {
+                "name", "location", "type", "default", "range", "notes",
+            }})
+
+    metrics: list[dict] = []
+    for raw in target.get("observable_metrics", []) or []:
+        if isinstance(raw, str):
+            metrics.append({"name": raw})
+        elif isinstance(raw, dict) and "name" in raw:
+            metrics.append({k: v for k, v in raw.items() if k in {
+                "name", "unit", "capture", "source", "notes",
+            }})
+
+    # Build — pull System Interface section from handoff.md.
+    build: dict = {}
+    sys_iface = _extract_handoff_section(
+        handoff_text, "System Interface", "## System Interface",
+    )
+    if sys_iface:
+        # Heuristic: scan the section for `Build:`, `Run baseline:`, etc.
+        for line in sys_iface.splitlines():
+            stripped = line.strip().lstrip("-*").strip()
+            for label, key in (
+                ("Build:", "build_command"),
+                ("Test:", "test_command"),
+                ("Run baseline:", "run_command"),
+                ("Run:", "run_command"),
+            ):
+                if stripped.startswith(label) or stripped.startswith(f"**{label}"):
+                    val = stripped.split(":", 1)[-1].strip()
+                    # Clean markdown decoration: leading `**` (bold close)
+                    # and surrounding backticks.
+                    val = val.lstrip("*").strip()
+                    val = val.strip("`").strip()
+                    if val and key not in build:
+                        build[key] = val
+                    break
+
+    return exploration, knobs, metrics, build

--- a/orchestrator/schemas/bundle.schema.yaml
+++ b/orchestrator/schemas/bundle.schema.yaml
@@ -49,6 +49,7 @@ $defs:
           - h-super-additivity
           - h-control-negative
           - h-robustness
+          - h-dose-response
       component:
         type: string
         description: "Component name, used for h-ablation arms."
@@ -67,6 +68,39 @@ $defs:
       metadata:
         type: object
         description: "Optional domain-specific metadata for this arm."
+
+      # ─── H-dose-response fields (issue #157) ───────────────────────────
+      # Required when type == h-dose-response (cross-checked in
+      # orchestrator.validate). Schema keeps them optional to preserve
+      # additive-only backward compatibility for existing arm types.
+      knob:
+        type: string
+        minLength: 1
+        description: "Name of the knob being varied. h-dose-response only."
+      values:
+        type: array
+        minItems: 3
+        uniqueItems: true
+        items:
+          oneOf:
+            - { type: number }
+            - { type: string, minLength: 1 }
+        description: "Distinct knob settings to test. h-dose-response only; >= 3 values."
+      metric:
+        type: string
+        minLength: 1
+        description: "Observable metric whose response shape is being tested."
+      expected_shape:
+        type: string
+        enum:
+          - monotone_decreasing
+          - monotone_increasing
+          - u_shaped
+          - inverted_u
+          - saturating
+          - flat
+        description: "Predicted shape of metric vs. knob value."
+
       code_changes:
         type: array
         description: "Optional code change intents. Planner says what and why, not how."

--- a/orchestrator/schemas/bundle.schema.yaml
+++ b/orchestrator/schemas/bundle.schema.yaml
@@ -29,6 +29,20 @@ properties:
     type: string
     description: "Brief explanation of which arms were chosen and why."
 
+  complexity_tier:
+    type: integer
+    minimum: 1
+    maximum: 4
+    description: >
+      Iteration's complexity tier (issue #159). 1 = single mechanism +
+      single knob + treatment-vs-control; 2 = single mechanism + multi-knob
+      OR ablation OR dose-response; 3 = multi-mechanism interactions,
+      super-additivity; 4 = cross-system / cross-workload generalization.
+      Iteration N may use any tier <= N — so iter 1 is forced to tier 1.
+  tier_justification:
+    type: string
+    description: "Brief reason for the chosen tier given the iteration index and prior refutations."
+
   arms:
     type: array
     minItems: 1

--- a/orchestrator/schemas/bundle.schema.yaml
+++ b/orchestrator/schemas/bundle.schema.yaml
@@ -50,6 +50,7 @@ $defs:
           - h-control-negative
           - h-robustness
           - h-dose-response
+          - h-tradeoff
       component:
         type: string
         description: "Component name, used for h-ablation arms."
@@ -100,6 +101,30 @@ $defs:
           - saturating
           - flat
         description: "Predicted shape of metric vs. knob value."
+
+      # ─── H-tradeoff fields (issue #158) ────────────────────────────────
+      # Required when type == h-tradeoff (cross-checked in
+      # orchestrator.validate). The arm declares an intervention's
+      # improvement on `metric` and the maximum acceptable degradation
+      # of `secondary_metric` (in the named "worse" direction).
+      secondary_metric:
+        type: string
+        minLength: 1
+        description: "Cost metric paired with `metric` for h-tradeoff arms; must differ from `metric`."
+      secondary_budget:
+        type: number
+        minimum: 0
+        description: "Maximum acceptable degradation in secondary_metric, in the worse direction. h-tradeoff only."
+      secondary_direction:
+        type: string
+        enum: [increase, decrease]
+        description: "Which way is 'worse' for secondary_metric (e.g., increase for memory, decrease for accuracy)."
+      primary_change:
+        type: number
+        description: "Predicted directional change in `metric` (signed). h-tradeoff only."
+      intervention_ref:
+        type: string
+        description: "Optional reference to the intervention (other arm id or description)."
 
       code_changes:
         type: array

--- a/orchestrator/schemas/execute_analyze.schema.json
+++ b/orchestrator/schemas/execute_analyze.schema.json
@@ -77,7 +77,7 @@
             "required": ["arm_type", "predicted", "observed", "status", "error_type", "diagnostic_note"],
             "additionalProperties": false,
             "properties": {
-              "arm_type": { "type": "string", "enum": ["h-main", "h-ablation", "h-super-additivity", "h-control-negative", "h-robustness", "h-dose-response"] },
+              "arm_type": { "type": "string", "enum": ["h-main", "h-ablation", "h-super-additivity", "h-control-negative", "h-robustness", "h-dose-response", "h-tradeoff"] },
               "predicted": { "type": "string", "minLength": 1 },
               "observed": { "type": "string", "minLength": 1 },
               "status": { "type": "string", "enum": ["CONFIRMED", "REFUTED", "PARTIALLY_CONFIRMED"] },
@@ -97,7 +97,12 @@
                     "metric": { "type": ["number", "null"] }
                   }
                 }
-              }
+              },
+              "primary_change_observed": { "type": ["number", "null"] },
+              "secondary_change_observed": { "type": ["number", "null"] },
+              "primary_predicate_met": { "type": ["boolean", "null"] },
+              "secondary_predicate_met": { "type": ["boolean", "null"] },
+              "tradeoff_verdict": { "type": ["string", "null"], "enum": ["confirmed", "primary_failed", "cost_too_high", "both_failed", null] }
             }
           }
         },

--- a/orchestrator/schemas/execute_analyze.schema.json
+++ b/orchestrator/schemas/execute_analyze.schema.json
@@ -77,13 +77,27 @@
             "required": ["arm_type", "predicted", "observed", "status", "error_type", "diagnostic_note"],
             "additionalProperties": false,
             "properties": {
-              "arm_type": { "type": "string", "enum": ["h-main", "h-ablation", "h-super-additivity", "h-control-negative", "h-robustness"] },
+              "arm_type": { "type": "string", "enum": ["h-main", "h-ablation", "h-super-additivity", "h-control-negative", "h-robustness", "h-dose-response"] },
               "predicted": { "type": "string", "minLength": 1 },
               "observed": { "type": "string", "minLength": 1 },
               "status": { "type": "string", "enum": ["CONFIRMED", "REFUTED", "PARTIALLY_CONFIRMED"] },
-              "error_type": { "type": ["string", "null"], "enum": ["direction", "magnitude", "regime", null] },
+              "error_type": { "type": ["string", "null"], "enum": ["direction", "magnitude", "regime", "shape_mismatch", null] },
               "diagnostic_note": { "type": ["string", "null"] },
-              "metadata": { "type": "object" }
+              "metadata": { "type": "object" },
+              "observed_shape": { "type": ["string", "null"], "enum": ["monotone_decreasing", "monotone_increasing", "u_shaped", "inverted_u", "saturating", "flat", "noisy", null] },
+              "shape_match": { "type": ["boolean", "null"] },
+              "dose_points": {
+                "type": ["array", "null"],
+                "items": {
+                  "type": "object",
+                  "required": ["value", "metric"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "value": { "oneOf": [{"type": "number"}, {"type": "string", "minLength": 1}] },
+                    "metric": { "type": ["number", "null"] }
+                  }
+                }
+              }
             }
           }
         },

--- a/orchestrator/schemas/findings.schema.json
+++ b/orchestrator/schemas/findings.schema.json
@@ -34,7 +34,7 @@
       "properties": {
         "arm_type": {
           "type": "string",
-          "enum": ["h-main", "h-ablation", "h-super-additivity", "h-control-negative", "h-robustness"]
+          "enum": ["h-main", "h-ablation", "h-super-additivity", "h-control-negative", "h-robustness", "h-dose-response"]
         },
         "predicted": { "type": "string", "minLength": 1 },
         "observed": { "type": "string", "minLength": 1 },
@@ -44,12 +44,36 @@
         },
         "error_type": {
           "type": ["string", "null"],
-          "enum": ["direction", "magnitude", "regime", null]
+          "enum": ["direction", "magnitude", "regime", "shape_mismatch", null]
         },
         "diagnostic_note": { "type": ["string", "null"] },
         "metadata": {
           "type": "object",
           "description": "Optional domain-specific metadata for this arm result."
+        },
+        "observed_shape": {
+          "type": ["string", "null"],
+          "enum": ["monotone_decreasing", "monotone_increasing", "u_shaped", "inverted_u", "saturating", "flat", "noisy", null],
+          "description": "Classified shape for h-dose-response arms."
+        },
+        "shape_match": {
+          "type": ["boolean", "null"],
+          "description": "True if observed_shape matches the arm's expected_shape."
+        },
+        "dose_points": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "object",
+            "required": ["value", "metric"],
+            "additionalProperties": false,
+            "properties": {
+              "value": {
+                "oneOf": [{ "type": "number" }, { "type": "string", "minLength": 1 }]
+              },
+              "metric": { "type": ["number", "null"] }
+            }
+          },
+          "description": "Observed (knob_value, metric_value) pairs for h-dose-response arms."
         }
       }
     }

--- a/orchestrator/schemas/findings.schema.json
+++ b/orchestrator/schemas/findings.schema.json
@@ -34,7 +34,7 @@
       "properties": {
         "arm_type": {
           "type": "string",
-          "enum": ["h-main", "h-ablation", "h-super-additivity", "h-control-negative", "h-robustness", "h-dose-response"]
+          "enum": ["h-main", "h-ablation", "h-super-additivity", "h-control-negative", "h-robustness", "h-dose-response", "h-tradeoff"]
         },
         "predicted": { "type": "string", "minLength": 1 },
         "observed": { "type": "string", "minLength": 1 },
@@ -74,6 +74,25 @@
             }
           },
           "description": "Observed (knob_value, metric_value) pairs for h-dose-response arms."
+        },
+        "primary_change_observed": {
+          "type": ["number", "null"],
+          "description": "Observed change in primary metric for h-tradeoff arms."
+        },
+        "secondary_change_observed": {
+          "type": ["number", "null"],
+          "description": "Observed change in secondary metric for h-tradeoff arms."
+        },
+        "primary_predicate_met": {
+          "type": ["boolean", "null"]
+        },
+        "secondary_predicate_met": {
+          "type": ["boolean", "null"]
+        },
+        "tradeoff_verdict": {
+          "type": ["string", "null"],
+          "enum": ["confirmed", "primary_failed", "cost_too_high", "both_failed", null],
+          "description": "Verdict for h-tradeoff arms; cost_too_high is the new failure mode this arm unlocks."
         }
       }
     }

--- a/orchestrator/schemas/meta_findings.schema.json
+++ b/orchestrator/schemas/meta_findings.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/schemas/meta_findings.schema.json",
+  "title": "Campaign Meta-Findings",
+  "description": "Three streams of lessons emitted at campaign DONE: how to design future campaigns better, what the target system should improve to support Nous, what Nous itself should improve. Each entry must cite a concrete moment from the campaign so the file is triagable rather than aspirational.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "campaign_design_lessons",
+    "target_system_asks",
+    "nous_asks"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "type": "string", "const": "1" },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "iterations_completed": { "type": "integer", "minimum": 0 },
+    "campaign_design_lessons": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/design_lesson" }
+    },
+    "target_system_asks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/system_ask" }
+    },
+    "nous_asks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/nous_ask" }
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional free text — used to explain when a stream is intentionally empty (no surprises observed)."
+    }
+  },
+  "$defs": {
+    "design_lesson": {
+      "type": "object",
+      "required": ["lesson", "evidence"],
+      "additionalProperties": false,
+      "properties": {
+        "lesson": { "type": "string", "minLength": 12 },
+        "evidence": { "type": "string", "minLength": 8 }
+      }
+    },
+    "system_ask": {
+      "type": "object",
+      "required": ["ask", "evidence", "kind"],
+      "additionalProperties": false,
+      "properties": {
+        "ask": { "type": "string", "minLength": 12 },
+        "evidence": { "type": "string", "minLength": 8 },
+        "kind": {
+          "type": "string",
+          "enum": ["instrumentation", "reproducibility", "controllability", "documentation", "other"]
+        }
+      }
+    },
+    "nous_ask": {
+      "type": "object",
+      "required": ["ask", "evidence", "kind"],
+      "additionalProperties": false,
+      "properties": {
+        "ask": { "type": "string", "minLength": 12 },
+        "evidence": { "type": "string", "minLength": 8 },
+        "kind": {
+          "type": "string",
+          "enum": ["token_budget", "observability", "dispatch", "api", "gates", "schemas", "other"]
+        }
+      }
+    }
+  }
+}

--- a/orchestrator/schemas/repo_cache.schema.yaml
+++ b/orchestrator/schemas/repo_cache.schema.yaml
@@ -1,0 +1,71 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/schemas/repo_cache.schema.yaml"
+title: Repo Knowledge Cache
+description: >
+  Schemas for the four files that make up a Nous repo-level knowledge cache
+  at <target_repo>/.nous/repo/. Survives across campaigns to skip
+  rediscovery; verified against the current git sha before use.
+
+$defs:
+  knobs_file:
+    type: object
+    required: [schema_version, knobs]
+    additionalProperties: false
+    properties:
+      schema_version: { type: string, const: "1" }
+      knobs:
+        type: array
+        items:
+          type: object
+          required: [name]
+          additionalProperties: false
+          properties:
+            name: { type: string, minLength: 1 }
+            location:
+              type: string
+              description: "file:line or file path where the knob is exposed."
+            type:
+              type: string
+              description: "Free-form: int, float, enum, bool, string, etc."
+            default: {}
+            range:
+              type: array
+              minItems: 1
+              maxItems: 2
+            notes: { type: string }
+
+  metrics_file:
+    type: object
+    required: [schema_version, metrics]
+    additionalProperties: false
+    properties:
+      schema_version: { type: string, const: "1" }
+      metrics:
+        type: array
+        items:
+          type: object
+          required: [name]
+          additionalProperties: false
+          properties:
+            name: { type: string, minLength: 1 }
+            unit: { type: string }
+            capture: { type: string, description: "How to capture this metric." }
+            source: { type: string, description: "Where the metric is emitted." }
+            notes: { type: string }
+
+  build_file:
+    type: object
+    required: [schema_version]
+    additionalProperties: false
+    properties:
+      schema_version: { type: string, const: "1" }
+      build_command: { type: string }
+      test_command: { type: string }
+      run_command: { type: string }
+      prerequisites:
+        type: array
+        items: { type: string }
+      env_vars:
+        type: array
+        items: { type: string }
+      notes: { type: string }

--- a/orchestrator/validate.py
+++ b/orchestrator/validate.py
@@ -55,6 +55,47 @@ def _check_unexpected_files(iter_dir: Path) -> list[str]:
     return errors
 
 
+def _validate_typed_arm_fields(bundle: dict) -> list[str]:
+    """Cross-field rules per arm type that JSON Schema can't easily express.
+
+    H-dose-response (issue #157) requires knob, values (>=3 distinct),
+    metric, and expected_shape. JSON Schema accepts these as optional
+    so existing arm types stay valid; this function enforces them
+    when the arm type asks for them.
+
+    H-tradeoff (issue #158) requires metric, secondary_metric, and
+    a tradeoff prediction with secondary_budget — see #158's
+    extension to this function.
+    """
+    errors: list[str] = []
+    arms = bundle.get("arms") or []
+    if not isinstance(arms, list):
+        return errors
+    for i, arm in enumerate(arms):
+        if not isinstance(arm, dict):
+            continue
+        arm_type = arm.get("type")
+        if arm_type == "h-dose-response":
+            for field in ("knob", "values", "metric", "expected_shape"):
+                if field not in arm:
+                    errors.append(
+                        f"arms[{i}] (h-dose-response) missing required field {field!r}"
+                    )
+            values = arm.get("values")
+            if isinstance(values, list):
+                if len(values) < 3:
+                    errors.append(
+                        f"arms[{i}] (h-dose-response) has < 3 values "
+                        f"({len(values)}); dose-response needs >= 3."
+                    )
+                if len(values) != len(set(map(repr, values))):
+                    errors.append(
+                        f"arms[{i}] (h-dose-response) has duplicate values; "
+                        f"distinct knob settings required."
+                    )
+    return errors
+
+
 def validate_design(iter_dir: Path) -> dict:
     """Check design artifacts exist and conform to schemas."""
     iter_dir = Path(iter_dir)
@@ -76,6 +117,7 @@ def validate_design(iter_dir: Path) -> dict:
             bundle = yaml.safe_load(bundle_path.read_text())
             schema = _load_yaml_schema("bundle.schema.yaml")
             jsonschema.validate(bundle, schema)
+            errors.extend(_validate_typed_arm_fields(bundle))
         except yaml.YAMLError as exc:
             errors.append(f"bundle.yaml is not valid YAML: {exc}")
         except jsonschema.ValidationError as exc:

--- a/orchestrator/validate.py
+++ b/orchestrator/validate.py
@@ -3,6 +3,7 @@
 Usage:
     python -m orchestrator.validate design --dir runs/iter-1/
     python -m orchestrator.validate execution --dir runs/iter-1/
+    python -m orchestrator.validate meta-findings --dir <work_dir>/
 """
 import argparse
 import json
@@ -212,24 +213,72 @@ def validate_execution(iter_dir: Path) -> dict:
     return {"status": "pass"}
 
 
+def validate_meta_findings(work_dir: Path) -> dict:
+    """Check meta_findings.json conforms to schema and citation floor.
+
+    The citation floor (``orchestrator.meta_findings.evidence_is_concrete``)
+    rejects entries whose ``evidence`` is a vague platitude. Schema does
+    minLength + enum; the floor catches anything that passes minLength
+    but is still aspirational.
+    """
+    work_dir = Path(work_dir)
+    errors: list[str] = []
+
+    target = work_dir / "meta_findings.json"
+    if not target.exists():
+        return {"status": "fail", "errors": [f"{target.name} not found at {work_dir}"]}
+
+    try:
+        payload = json.loads(target.read_text())
+    except json.JSONDecodeError as exc:
+        return {"status": "fail", "errors": [f"meta_findings.json is not valid JSON: {exc}"]}
+
+    try:
+        schema = _load_json_schema("meta_findings.schema.json")
+        jsonschema.validate(payload, schema)
+    except jsonschema.ValidationError as exc:
+        errors.append(f"meta_findings.json schema error: {exc.message}")
+
+    # Citation floor — applied to every evidence string in every stream.
+    from orchestrator.meta_findings import validate_evidence
+
+    for stream_name in ("campaign_design_lessons", "target_system_asks", "nous_asks"):
+        items = payload.get(stream_name) or []
+        if not isinstance(items, list):
+            continue
+        for i, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            evidence = item.get("evidence", "")
+            err = validate_evidence(evidence)
+            if err:
+                errors.append(f"{stream_name}[{i}]: {err}")
+
+    if errors:
+        return {"status": "fail", "errors": errors}
+    return {"status": "pass"}
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Validate Nous artifacts for a given phase.",
     )
     parser.add_argument(
-        "phase", choices=["design", "execution"],
+        "phase", choices=["design", "execution", "meta-findings"],
         help="Which phase to validate",
     )
     parser.add_argument(
         "--dir", required=True, type=Path,
-        help="Path to the iteration directory (e.g., runs/iter-1/)",
+        help="Path to the iteration directory (or work_dir for meta-findings)",
     )
     args = parser.parse_args()
 
     if args.phase == "design":
         result = validate_design(args.dir)
-    else:
+    elif args.phase == "execution":
         result = validate_execution(args.dir)
+    else:
+        result = validate_meta_findings(args.dir)
 
     print(json.dumps(result, indent=2))
     sys.exit(0 if result["status"] == "pass" else 1)

--- a/orchestrator/validate.py
+++ b/orchestrator/validate.py
@@ -93,6 +93,23 @@ def _validate_typed_arm_fields(bundle: dict) -> list[str]:
                         f"arms[{i}] (h-dose-response) has duplicate values; "
                         f"distinct knob settings required."
                     )
+        elif arm_type == "h-tradeoff":
+            for field in (
+                "metric", "secondary_metric", "secondary_budget",
+                "secondary_direction",
+            ):
+                if field not in arm:
+                    errors.append(
+                        f"arms[{i}] (h-tradeoff) missing required field {field!r}"
+                    )
+            if (
+                arm.get("metric") is not None
+                and arm.get("metric") == arm.get("secondary_metric")
+            ):
+                errors.append(
+                    f"arms[{i}] (h-tradeoff): secondary_metric must differ "
+                    f"from primary metric (both = {arm.get('metric')!r})."
+                )
     return errors
 
 

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -77,6 +77,31 @@ $ grep -n "evict" src/cache.go
 
 Every command and file format in your design must come from something you observed — not assumed.
 
+## Repo Knowledge Cache — read this BEFORE rediscovering (issue #156)
+
+If `.nous/repo/` exists in the target repo, it contains a cache from a
+prior campaign:
+
+- `.nous/repo/exploration.md` — narrative tour of the codebase.
+- `.nous/repo/knobs.yaml` — discovered tunables (name, location, type, range).
+- `.nous/repo/metrics.yaml` — observable metrics and how to capture them.
+- `.nous/repo/build.yaml` — build/test/run commands and prerequisites.
+
+**Read those files first.** They are the cheapest way to learn the
+factual layer of the repo (paths, commands, knob locations) — much
+cheaper than a fresh Explore pass. Use them as a starting point.
+
+**Verify before trusting**: the cache may be stale. For each claim you
+plan to act on (a knob location, a build command, a metric source),
+do one targeted check (`Read`, `Bash --version`, `git log --oneline -1
+<file>`) to confirm the claim still holds at the current sha. If a
+claim has rotted, ignore it and re-discover that specific item.
+**Do NOT** re-walk the whole codebase if the cache exists — verify
+the bits you'll use, then proceed.
+
+The cache is advisory, never authoritative. Today's Explore work
+benefits next campaign's planner the same way.
+
 ## Instructions — Phase 1: Explore and Validate
 
 Before designing anything, ground yourself in the real system:

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -168,11 +168,12 @@ Now design a hypothesis bundle based on what you actually observed and verified:
    - `h-robustness`: Test under varied conditions.
    - `h-super-additivity`: Test whether combined factors produce more than the sum of parts.
    - `h-dose-response` *(issue #157)*: Vary a continuous knob across **>= 3 distinct values** and predict the **shape** of the metric response (`monotone_decreasing`, `monotone_increasing`, `u_shaped`, `inverted_u`, `saturating`, or `flat`). Use this when the natural question is "how should this knob be set" — not just "does this knob matter at value X". Required fields: `knob`, `values` (>= 3 distinct), `metric`, `expected_shape`.
+   - `h-tradeoff` *(issue #158)*: Declare an intervention's improvement on `metric` AND the maximum acceptable degradation in `secondary_metric` (cost). Use whenever the natural intuition is "but at what cost?" — caching (memory↑), parallelism (CPU↑), accuracy↔speed dials. If you can't name the suspected cost, the intervention isn't well understood enough to test. Required fields: `metric`, `secondary_metric` (must differ from `metric`), `secondary_budget` (max acceptable degradation, >= 0), `secondary_direction` (`increase` if "worse" means going up, `decrease` if going down). Optionally: `primary_change` (predicted directional change), `intervention_ref` (other arm id).
 
    Include a brief note explaining which arms you chose and why.
 
 3. Each arm must have:
-   - `type`: One of h-main, h-ablation, h-super-additivity, h-control-negative, h-robustness, h-dose-response.
+   - `type`: One of h-main, h-ablation, h-super-additivity, h-control-negative, h-robustness, h-dose-response, h-tradeoff.
    - `prediction`: A **directional**, falsifiable claim referencing observable metrics. State the expected direction and relative magnitude (e.g., "increasing X will decrease Y consistently across seeds"). Do NOT invent arbitrary numeric thresholds (e.g., ">10% improvement") unless the campaign.yaml specifies one. The hypothesis bundle's multi-seed design tests significance — your prediction tests direction and mechanism.
    - `mechanism`: A causal explanation grounded in the code you read.
    - `diagnostic`: What to investigate if the prediction is wrong.

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -167,11 +167,12 @@ Now design a hypothesis bundle based on what you actually observed and verified:
    - `h-ablation`: Remove one component to test if it's necessary.
    - `h-robustness`: Test under varied conditions.
    - `h-super-additivity`: Test whether combined factors produce more than the sum of parts.
+   - `h-dose-response` *(issue #157)*: Vary a continuous knob across **>= 3 distinct values** and predict the **shape** of the metric response (`monotone_decreasing`, `monotone_increasing`, `u_shaped`, `inverted_u`, `saturating`, or `flat`). Use this when the natural question is "how should this knob be set" — not just "does this knob matter at value X". Required fields: `knob`, `values` (>= 3 distinct), `metric`, `expected_shape`.
 
    Include a brief note explaining which arms you chose and why.
 
 3. Each arm must have:
-   - `type`: One of h-main, h-ablation, h-super-additivity, h-control-negative, h-robustness.
+   - `type`: One of h-main, h-ablation, h-super-additivity, h-control-negative, h-robustness, h-dose-response.
    - `prediction`: A **directional**, falsifiable claim referencing observable metrics. State the expected direction and relative magnitude (e.g., "increasing X will decrease Y consistently across seeds"). Do NOT invent arbitrary numeric thresholds (e.g., ">10% improvement") unless the campaign.yaml specifies one. The hypothesis bundle's multi-seed design tests significance — your prediction tests direction and mechanism.
    - `mechanism`: A causal explanation grounded in the code you read.
    - `diagnostic`: What to investigate if the prediction is wrong.

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -179,6 +179,29 @@ Now design a hypothesis bundle based on what you actually observed and verified:
    - `diagnostic`: What to investigate if the prediction is wrong.
    - `code_changes` *(optional)*: Include when the arm tests an algorithmic change rather than a flag/config variation. Each entry needs `file`, `intent` (plain English, not a patch), and `rationale`. The EXECUTE_ANALYZE agent will later turn each intent into a patch. If the hypothesis only varies existing CLI flags, omit this field.
 
+## Complexity tier (issue #159)
+
+Each bundle declares an optional `complexity_tier` (1..4) and a
+`tier_justification`:
+
+| Tier | When to use it |
+|---|---|
+| 1 | single mechanism, single knob, treatment vs control |
+| 2 | single mechanism + multi-knob OR ablation OR dose-response on one knob |
+| 3 | multi-mechanism interactions, super-additivity, dose-response across knobs |
+| 4 | cross-system / cross-workload generalization, robustness across regimes |
+
+**Rule: iteration N may use any tier ≤ N.** So iter 1 must be tier 1;
+iter 2 may be tier 1 or 2; etc. Choose the lowest tier that has not
+yet been refuted or shown insufficient by earlier iterations. State
+your tier and a one-line `tier_justification` ("iter 1, simplest
+mechanism" or "iter 3 — tier 1 was refuted in iter-1, tier 2 was
+inconclusive in iter-2, escalating to multi-mechanism").
+
+The design gate flags jumps of more than one tier across iterations.
+This is for visibility, not enforcement — but if you're escalating
+without a refutation to point at, the human will ask why.
+
 ## Constraints
 
 - Do NOT violate active principles.

--- a/tests/test_complexity_tier.py
+++ b/tests/test_complexity_tier.py
@@ -1,0 +1,248 @@
+"""Behavioral tests for the graded-complexity tier system (issue #159).
+
+Tests assert what's on disk (bundle.yaml) and what shows up in the
+gate panel string. The discipline is enforced through visibility,
+not refusal — these tests exercise the panel output, jump detection,
+and additive-only schema compatibility. No live LLM calls.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+from orchestrator.complexity_tier import (
+    TIER_NAMES,
+    collect_tier_warnings,
+    detect_jump,
+    format_tier_summary,
+    prior_iteration_tiers,
+)
+from orchestrator.validate import validate_design
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+
+
+def _load_bundle_schema() -> dict:
+    return yaml.safe_load((SCHEMAS_DIR / "bundle.schema.yaml").read_text())
+
+
+def _make_bundle(*, iteration: int, tier: int | None = None,
+                 justification: str | None = None) -> dict:
+    bundle: dict = {
+        "metadata": {
+            "iteration": iteration, "family": "test",
+            "research_question": "q?",
+        },
+        "arms": [
+            {"type": "h-main", "prediction": "p", "mechanism": "m",
+             "diagnostic": "d"},
+        ],
+    }
+    if tier is not None:
+        bundle["complexity_tier"] = tier
+    if justification is not None:
+        bundle["tier_justification"] = justification
+    return bundle
+
+
+def _setup_iter(work_dir: Path, iteration: int, bundle: dict) -> Path:
+    iter_dir = work_dir / "runs" / f"iter-{iteration}"
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    (iter_dir / "problem.md").write_text("## RQ\nq?\n")
+    (iter_dir / "bundle.yaml").write_text(yaml.safe_dump(bundle))
+    (iter_dir / "handoff_snapshot.md").write_text("## Handoff\n### Goal\nx\n")
+    return iter_dir
+
+
+# ─── Schema accepts complexity_tier as additive optional field ────────────
+
+
+class TestSchemaAcceptsTier:
+    def test_bundle_with_tier_validates(self) -> None:
+        bundle = _make_bundle(iteration=1, tier=1, justification="simplest")
+        jsonschema.validate(bundle, _load_bundle_schema())
+
+    def test_bundle_without_tier_still_validates(self) -> None:
+        """Backward compat: bundles without complexity_tier still pass."""
+        bundle = _make_bundle(iteration=1)
+        jsonschema.validate(bundle, _load_bundle_schema())
+
+    def test_bundle_with_invalid_tier_rejected(self) -> None:
+        bundle = _make_bundle(iteration=1, tier=5)
+        with self_assertions_raises(jsonschema.ValidationError):
+            jsonschema.validate(bundle, _load_bundle_schema())
+
+    def test_bundle_with_tier_zero_rejected(self) -> None:
+        bundle = _make_bundle(iteration=1, tier=0)
+        with self_assertions_raises(jsonschema.ValidationError):
+            jsonschema.validate(bundle, _load_bundle_schema())
+
+
+# Helper since pytest's raises has different ergonomics
+import pytest
+
+def self_assertions_raises(exc):
+    return pytest.raises(exc)
+
+
+# ─── prior_iteration_tiers reads sibling iter-N/bundle.yaml ───────────────
+
+
+class TestPriorTiersDiscovery:
+    def test_finds_tiers_from_prior_iters(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _setup_iter(work_dir, 1, _make_bundle(iteration=1, tier=1))
+        _setup_iter(work_dir, 2, _make_bundle(iteration=2, tier=2))
+        _setup_iter(work_dir, 3, _make_bundle(iteration=3))  # no tier
+
+        priors = prior_iteration_tiers(work_dir, up_to=3)
+        assert priors == {1: 1, 2: 2}
+
+    def test_excludes_self_iteration(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _setup_iter(work_dir, 1, _make_bundle(iteration=1, tier=1))
+        _setup_iter(work_dir, 2, _make_bundle(iteration=2, tier=3))
+        # Asking for priors of iter 2 should exclude iter 2 itself.
+        priors = prior_iteration_tiers(work_dir, up_to=2)
+        assert priors == {1: 1}
+
+    def test_empty_work_dir(self, tmp_path: Path) -> None:
+        assert prior_iteration_tiers(tmp_path / "nothing", up_to=1) == {}
+
+
+# ─── detect_jump rules ────────────────────────────────────────────────────
+
+
+class TestDetectJump:
+    def test_iter_1_must_be_tier_1(self) -> None:
+        warning = detect_jump(iteration=1, current_tier=2, prior_tiers={})
+        assert warning is not None
+        assert "iter 1" in warning.lower() or "iteration 1" in warning.lower()
+
+    def test_iter_1_tier_1_no_warning(self) -> None:
+        assert detect_jump(iteration=1, current_tier=1, prior_tiers={}) is None
+
+    def test_one_step_escalation_no_warning(self) -> None:
+        # iter 2, prior max = 1, current = 2 → fine.
+        assert detect_jump(
+            iteration=2, current_tier=2, prior_tiers={1: 1},
+        ) is None
+
+    def test_two_step_escalation_warns(self) -> None:
+        # iter 2, prior max = 1, current = 3 → flagged.
+        warning = detect_jump(
+            iteration=2, current_tier=3, prior_tiers={1: 1},
+        )
+        assert warning is not None
+        assert "tier" in warning.lower()
+        assert "1" in warning  # prior max
+        assert "3" in warning  # current
+
+    def test_descent_no_warning(self) -> None:
+        # iter 3, prior max = 2, current = 1 → tier dropped, fine.
+        assert detect_jump(
+            iteration=3, current_tier=1, prior_tiers={1: 2, 2: 2},
+        ) is None
+
+    def test_missing_tier_no_warning(self) -> None:
+        # Legacy bundles without tier should not trigger.
+        assert detect_jump(
+            iteration=2, current_tier=None, prior_tiers={1: 1},
+        ) is None
+
+
+# ─── format_tier_summary renders the human-facing panel ───────────────────
+
+
+class TestFormatTierSummary:
+    def test_includes_tier_and_name(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        bundle = _make_bundle(iteration=1, tier=1, justification="simplest start")
+        iter_dir = _setup_iter(work_dir, 1, bundle)
+
+        out = format_tier_summary(
+            iteration=1,
+            bundle_path=iter_dir / "bundle.yaml",
+            work_dir=work_dir,
+        )
+        assert "tier 1" in out.lower()
+        assert TIER_NAMES[1] in out
+        assert "simplest start" in out  # justification
+
+    def test_iter_2_tier_3_panel_contains_warning(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _setup_iter(work_dir, 1, _make_bundle(iteration=1, tier=1))
+        bundle = _make_bundle(
+            iteration=2, tier=3,
+            justification="iter-1 H-main was refuted, escalating to multi-mechanism",
+        )
+        iter_dir = _setup_iter(work_dir, 2, bundle)
+
+        out = format_tier_summary(
+            iteration=2, bundle_path=iter_dir / "bundle.yaml", work_dir=work_dir,
+        )
+        assert "tier 3" in out.lower()
+        assert "TIER ESCALATION FLAGGED" in out
+        assert "iter-1=tier1" in out  # prior summary
+
+    def test_no_tier_returns_empty(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        bundle = _make_bundle(iteration=1)  # no complexity_tier
+        iter_dir = _setup_iter(work_dir, 1, bundle)
+
+        out = format_tier_summary(
+            iteration=1, bundle_path=iter_dir / "bundle.yaml", work_dir=work_dir,
+        )
+        assert out == ""
+
+
+# ─── Validate-design still passes for tier-tagged bundles ─────────────────
+
+
+class TestValidateDesignAcceptsTier:
+    def test_tier_1_iter_1_bundle_validates(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        bundle = _make_bundle(iteration=1, tier=1, justification="x")
+        d.mkdir()
+        (d / "problem.md").write_text("## RQ\nq?\n")
+        (d / "bundle.yaml").write_text(yaml.safe_dump(bundle))
+        (d / "handoff_snapshot.md").write_text("## Handoff\n### Goal\nx\n")
+        result = validate_design(d)
+        assert result["status"] == "pass", result.get("errors")
+
+    def test_legacy_bundle_without_tier_validates(self, tmp_path: Path) -> None:
+        """Backward compat: pre-#159 bundles still validate."""
+        d = tmp_path / "iter-1"
+        bundle = _make_bundle(iteration=1)
+        d.mkdir()
+        (d / "problem.md").write_text("## RQ\nq?\n")
+        (d / "bundle.yaml").write_text(yaml.safe_dump(bundle))
+        (d / "handoff_snapshot.md").write_text("## Handoff\n### Goal\nx\n")
+        result = validate_design(d)
+        assert result["status"] == "pass", result.get("errors")
+
+
+# ─── Programmatic warnings list (for tests / CI) ──────────────────────────
+
+
+class TestCollectTierWarnings:
+    def test_clean_progression_yields_no_warnings(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _setup_iter(work_dir, 1, _make_bundle(iteration=1, tier=1))
+        bundle_path = _setup_iter(
+            work_dir, 2, _make_bundle(iteration=2, tier=2),
+        ) / "bundle.yaml"
+        assert collect_tier_warnings(2, bundle_path, work_dir) == []
+
+    def test_jump_warns(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _setup_iter(work_dir, 1, _make_bundle(iteration=1, tier=1))
+        bundle_path = _setup_iter(
+            work_dir, 2, _make_bundle(iteration=2, tier=4),
+        ) / "bundle.yaml"
+        warnings = collect_tier_warnings(2, bundle_path, work_dir)
+        assert len(warnings) == 1
+        assert "tier" in warnings[0].lower()

--- a/tests/test_dose_response.py
+++ b/tests/test_dose_response.py
@@ -1,0 +1,306 @@
+"""Behavioral tests for the H-dose-response arm (issue #157).
+
+Tests assert what's on disk (bundles, findings) and the deterministic
+classifier's verdicts on synthetic numeric series. No live LLM calls.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+from orchestrator.findings_classifier import (
+    classify_dose_shape,
+    shape_matches,
+    VALID_SHAPES,
+)
+from orchestrator.validate import validate_design
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+
+
+def _load_bundle_schema() -> dict:
+    return yaml.safe_load((SCHEMAS_DIR / "bundle.schema.yaml").read_text())
+
+
+def _load_findings_schema() -> dict:
+    return json.loads((SCHEMAS_DIR / "findings.schema.json").read_text())
+
+
+# ─── Shape classifier on synthetic numeric data ───────────────────────────
+
+
+class TestShapeClassifier:
+    """Each shape must be detected from a clean synthetic series."""
+
+    def test_monotone_increasing(self) -> None:
+        assert classify_dose_shape([1.0, 2.0, 3.0, 4.0]) == "monotone_increasing"
+
+    def test_monotone_decreasing(self) -> None:
+        assert classify_dose_shape([10.0, 8.0, 6.0, 4.0]) == "monotone_decreasing"
+
+    def test_u_shaped(self) -> None:
+        assert classify_dose_shape([5.0, 3.0, 2.0, 4.0, 7.0]) == "u_shaped"
+
+    def test_inverted_u(self) -> None:
+        assert classify_dose_shape([1.0, 4.0, 7.0, 5.0, 2.0]) == "inverted_u"
+
+    def test_saturating(self) -> None:
+        # Big jump, then near-flat — classic saturation curve.
+        assert classify_dose_shape([0.0, 10.0, 11.0, 11.2, 11.3]) == "saturating"
+
+    def test_flat(self) -> None:
+        # Variation < 5% of mean.
+        assert classify_dose_shape([100.0, 101.0, 99.5, 100.2]) == "flat"
+
+    def test_noisy_when_too_short(self) -> None:
+        assert classify_dose_shape([1.0, 2.0]) == "noisy"
+        assert classify_dose_shape([]) == "noisy"
+
+    def test_noisy_zigzag(self) -> None:
+        # Multiple sign flips → noisy, not a clean U or inverted-U.
+        assert classify_dose_shape([1.0, 5.0, 2.0, 6.0, 3.0]) == "noisy"
+
+    def test_classifier_returns_valid_enum(self) -> None:
+        # Every output is one of the schema's enum values OR "noisy".
+        all_valid = set(VALID_SHAPES) | {"noisy"}
+        for series in (
+            [1, 2, 3], [3, 2, 1], [1, 5, 1], [5, 1, 5], [1, 1, 1],
+            [0, 10, 11, 11], [1, 5, 2, 6, 3],
+        ):
+            assert classify_dose_shape(series) in all_valid
+
+
+class TestShapeMatching:
+    """shape_matches encodes loose equivalences (saturating ~ monotone)."""
+
+    def test_exact_match(self) -> None:
+        assert shape_matches("monotone_increasing", "monotone_increasing")
+        assert shape_matches("u_shaped", "u_shaped")
+
+    def test_saturating_satisfies_monotone(self) -> None:
+        assert shape_matches("monotone_increasing", "saturating")
+        assert shape_matches("monotone_decreasing", "saturating")
+
+    def test_monotone_does_not_satisfy_other_monotone(self) -> None:
+        assert not shape_matches("monotone_increasing", "monotone_decreasing")
+
+    def test_noisy_never_matches(self) -> None:
+        assert not shape_matches("monotone_increasing", "noisy")
+        assert not shape_matches("flat", "noisy")
+
+    def test_none_inputs_never_match(self) -> None:
+        assert not shape_matches(None, "monotone_increasing")
+        assert not shape_matches("monotone_increasing", None)
+
+
+# ─── Bundle schema accepts h-dose-response ────────────────────────────────
+
+
+VALID_DOSE_BUNDLE = {
+    "metadata": {"iteration": 1, "family": "test", "research_question": "How should X be set?"},
+    "arms": [
+        {
+            "type": "h-main",
+            "prediction": "Increasing batch_size decreases latency",
+            "mechanism": "Amortizes fixed overhead",
+            "diagnostic": "Check overhead per batch",
+        },
+        {
+            "type": "h-dose-response",
+            "prediction": "Latency decreases monotonically as batch_size increases",
+            "mechanism": "Per-call overhead amortizes across the batch",
+            "diagnostic": "If flat, overhead is not the bottleneck",
+            "knob": "batch_size",
+            "values": [1, 4, 16, 64],
+            "metric": "latency_ms",
+            "expected_shape": "monotone_decreasing",
+        },
+    ],
+}
+
+
+class TestBundleSchemaAcceptance:
+    def test_valid_dose_response_bundle_passes_schema(self) -> None:
+        schema = _load_bundle_schema()
+        jsonschema.validate(VALID_DOSE_BUNDLE, schema)  # no raise
+
+    def test_validate_design_accepts_dose_response(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        d.mkdir()
+        (d / "problem.md").write_text("## Research Question\n\nHow should batch_size be set?\n")
+        (d / "bundle.yaml").write_text(yaml.safe_dump(VALID_DOSE_BUNDLE))
+        (d / "handoff_snapshot.md").write_text("## Handoff\n### Goal\nTest\n")
+        result = validate_design(d)
+        assert result["status"] == "pass", result.get("errors")
+
+
+# ─── Cross-field validation rejects malformed dose-response arms ──────────
+
+
+def _bundle_with_dose_arm(**overrides: object) -> dict:
+    arm = {
+        "type": "h-dose-response",
+        "prediction": "monotone decrease in latency",
+        "mechanism": "amortization",
+        "diagnostic": "check overhead",
+        "knob": "batch_size",
+        "values": [1, 4, 16, 64],
+        "metric": "latency_ms",
+        "expected_shape": "monotone_decreasing",
+    }
+    arm.update(overrides)
+    return {
+        "metadata": {"iteration": 1, "family": "t", "research_question": "q?"},
+        "arms": [arm],
+    }
+
+
+def _setup_design_with_bundle(d: Path, bundle: dict) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "problem.md").write_text("## RQ\nq?\n")
+    (d / "bundle.yaml").write_text(yaml.safe_dump(bundle))
+    (d / "handoff_snapshot.md").write_text("## Handoff\n### Goal\nx\n")
+
+
+class TestDoseResponseCrossFieldValidation:
+    def test_rejects_too_few_values(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        # Schema has minItems 3, so 2 values is rejected at the JSON
+        # Schema level (jsonschema renders this as "is too short").
+        bundle = _bundle_with_dose_arm(values=[1, 2])
+        _setup_design_with_bundle(d, bundle)
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        joined = " | ".join(result["errors"]).lower()
+        assert "too short" in joined or "values" in joined or "minitems" in joined, result["errors"]
+
+    def test_rejects_duplicate_values(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        # uniqueItems will trip in schema first.
+        bundle = _bundle_with_dose_arm(values=[1, 2, 2, 3])
+        _setup_design_with_bundle(d, bundle)
+        result = validate_design(d)
+        assert result["status"] == "fail"
+
+    def test_rejects_invalid_expected_shape(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        bundle = _bundle_with_dose_arm(expected_shape="banana_curve")
+        _setup_design_with_bundle(d, bundle)
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        joined = " | ".join(result["errors"])
+        assert "banana_curve" in joined or "is not one of" in joined
+
+    def test_rejects_missing_knob(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        # Build arm without the knob field — schema accepts (it's optional);
+        # the cross-field validator must catch it.
+        arm = {
+            "type": "h-dose-response",
+            "prediction": "monotone decrease",
+            "mechanism": "amortization",
+            "diagnostic": "check overhead",
+            "values": [1, 4, 16],
+            "metric": "latency_ms",
+            "expected_shape": "monotone_decreasing",
+        }
+        bundle = {
+            "metadata": {"iteration": 1, "family": "t", "research_question": "q?"},
+            "arms": [arm],
+        }
+        _setup_design_with_bundle(d, bundle)
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        assert any("knob" in e for e in result["errors"])
+
+
+# ─── Findings schema accepts dose-response arm result fields ──────────────
+
+
+class TestFindingsSchemaAcceptance:
+    def test_dose_arm_result_with_shape_match_validates(self) -> None:
+        findings = {
+            "iteration": 1,
+            "bundle_ref": "runs/iter-1/bundle.yaml",
+            "arms": [
+                {
+                    "arm_type": "h-dose-response",
+                    "predicted": "monotone decrease in latency",
+                    "observed": "latency dropped from 100ms to 12ms",
+                    "status": "CONFIRMED",
+                    "error_type": None,
+                    "diagnostic_note": None,
+                    "observed_shape": "monotone_decreasing",
+                    "shape_match": True,
+                    "dose_points": [
+                        {"value": 1, "metric": 100.0},
+                        {"value": 4, "metric": 35.0},
+                        {"value": 16, "metric": 12.0},
+                    ],
+                },
+            ],
+            "experiment_valid": True,
+            "discrepancy_analysis": "Shape matched.",
+        }
+        schema = _load_findings_schema()
+        jsonschema.validate(findings, schema)
+
+    def test_shape_mismatch_error_type_validates(self) -> None:
+        findings = {
+            "iteration": 1,
+            "bundle_ref": "runs/iter-1/bundle.yaml",
+            "arms": [
+                {
+                    "arm_type": "h-dose-response",
+                    "predicted": "monotone increase",
+                    "observed": "flat",
+                    "status": "REFUTED",
+                    "error_type": "shape_mismatch",
+                    "diagnostic_note": "no response detected",
+                    "observed_shape": "flat",
+                    "shape_match": False,
+                    "dose_points": [
+                        {"value": 1, "metric": 50.0},
+                        {"value": 4, "metric": 50.5},
+                        {"value": 16, "metric": 49.8},
+                    ],
+                },
+            ],
+            "experiment_valid": True,
+            "discrepancy_analysis": "Knob has no effect on metric.",
+        }
+        schema = _load_findings_schema()
+        jsonschema.validate(findings, schema)
+
+
+# ─── End-to-end behavioral: classify synthetic data, judge against expected ──
+
+
+class TestEndToEndShapeJudgement:
+    """Simulate the executor: take the arm's expected_shape and synthetic
+    measurements, classify, and produce shape_match — no LLM."""
+
+    def test_predicted_increase_data_increases_confirmed(self) -> None:
+        expected = "monotone_increasing"
+        observed_metrics = [10.0, 20.0, 35.0, 50.0]
+        observed = classify_dose_shape(observed_metrics)
+        assert observed == "monotone_increasing"
+        assert shape_matches(expected, observed) is True
+
+    def test_predicted_decrease_data_flat_refuted(self) -> None:
+        expected = "monotone_decreasing"
+        observed_metrics = [50.0, 50.2, 50.1, 49.9]
+        observed = classify_dose_shape(observed_metrics)
+        assert observed == "flat"
+        assert shape_matches(expected, observed) is False
+
+    def test_predicted_u_data_inverted_u_refuted(self) -> None:
+        expected = "u_shaped"
+        observed_metrics = [1.0, 4.0, 7.0, 5.0, 2.0]
+        observed = classify_dose_shape(observed_metrics)
+        assert observed == "inverted_u"
+        assert shape_matches(expected, observed) is False

--- a/tests/test_meta_findings.py
+++ b/tests/test_meta_findings.py
@@ -1,0 +1,388 @@
+"""Behavioral tests for the deterministic meta-findings emitter (issue #155).
+
+These tests assert what's on disk after the emitter runs, not which
+internal helper was called. Per CLAUDE.md, every test uses synthetic
+inputs and the StubDispatcher / pure-Python paths — no live LLM calls.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestrator.meta_findings import (
+    SCHEMA_VERSION,
+    emit_meta_findings,
+    evidence_is_concrete,
+    render_meta_findings_markdown,
+    validate_evidence,
+    write_meta_findings,
+)
+from orchestrator.validate import validate_meta_findings
+
+
+# ─── Citation floor ────────────────────────────────────────────────────────
+
+
+class TestEvidenceFloor:
+    """The floor distinguishes triagable evidence from aspirational text."""
+
+    @pytest.mark.parametrize("text", [
+        "iter-3 design phase failed validation 4 times",
+        "executor_log.jsonl lines 12-19 show repeated Bash failures",
+        "Read tool call returned \"FileNotFoundError\" in iter-2",
+        "input_tokens averaged 42000 across 6 calls",
+        "h-main was REFUTED in iter-1, iter-2, iter-3",
+        "patches/h-main.patch did not apply cleanly",
+        "/Users/sri/inference-sim/sim.go:142 — knob `batch_size` lives here",
+        "campaign.yaml: target_system.observable_metrics is unset",
+    ])
+    def test_concrete_evidence_passes(self, text: str) -> None:
+        assert evidence_is_concrete(text), f"should pass: {text!r}"
+        assert validate_evidence(text) is None
+
+    @pytest.mark.parametrize("text", [
+        "things were slow",
+        "it didn't work",
+        "needs improvement",
+        "this could be better",
+        "not great",
+    ])
+    def test_vague_evidence_fails(self, text: str) -> None:
+        assert not evidence_is_concrete(text), f"should fail: {text!r}"
+        err = validate_evidence(text)
+        assert err is not None
+        assert "vague" in err.lower() or "short" in err.lower()
+
+    def test_empty_evidence_fails(self) -> None:
+        assert validate_evidence("") is not None
+        assert validate_evidence("a") is not None
+
+    def test_non_string_fails(self) -> None:
+        # Schema would reject before we get here, but the floor still defends.
+        assert validate_evidence(None) is not None  # type: ignore[arg-type]
+        assert validate_evidence(123) is not None  # type: ignore[arg-type]
+
+
+# ─── Emitter behavior on synthetic campaign artifacts ──────────────────────
+
+
+def _write_state(work_dir: Path, run_id: str = "test-run") -> None:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / "state.json").write_text(json.dumps({
+        "phase": "DONE", "iteration": 1, "run_id": run_id,
+        "family": "test", "timestamp": "2026-05-24T00:00:00Z",
+    }))
+
+
+def _write_ledger(work_dir: Path, iterations: list[int]) -> None:
+    rows = [
+        {"iteration": i, "status": "completed", "timestamp": "t"}
+        for i in iterations
+    ]
+    (work_dir / "ledger.json").write_text(json.dumps({"iterations": rows}))
+
+
+def _write_findings(
+    work_dir: Path, iteration: int, *,
+    h_main_status: str = "CONFIRMED", experiment_valid: bool = True,
+) -> None:
+    iter_dir = work_dir / "runs" / f"iter-{iteration}"
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    findings = {
+        "iteration": iteration,
+        "bundle_ref": f"runs/iter-{iteration}/bundle.yaml",
+        "arms": [
+            {
+                "arm_type": "h-main",
+                "predicted": ">10%",
+                "observed": "12%" if h_main_status == "CONFIRMED" else "-2%",
+                "status": h_main_status,
+                "error_type": None if h_main_status == "CONFIRMED" else "direction",
+                "diagnostic_note": None,
+            },
+        ],
+        "experiment_valid": experiment_valid,
+        "discrepancy_analysis": "stub",
+    }
+    (iter_dir / "findings.json").write_text(json.dumps(findings))
+
+
+def _append_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+class TestEmitterShape:
+    """The emitter must produce a schema-valid artifact for any campaign."""
+
+    def test_minimal_campaign_yields_schema_valid_artifact(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1)
+
+        payload = emit_meta_findings(work_dir, campaign={"target_system": {}})
+        write_meta_findings(work_dir, payload)
+
+        assert payload["schema_version"] == SCHEMA_VERSION
+        assert payload["iterations_completed"] == 1
+
+        result = validate_meta_findings(work_dir)
+        assert result["status"] == "pass", result.get("errors")
+
+    def test_artifact_lands_at_workdir_root(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1)
+
+        payload = emit_meta_findings(work_dir, campaign={"target_system": {}})
+        path = write_meta_findings(work_dir, payload)
+
+        assert path == work_dir / "meta_findings.json"
+        assert path.exists()
+        on_disk = json.loads(path.read_text())
+        assert on_disk["schema_version"] == SCHEMA_VERSION
+
+
+class TestSystemAskDetection:
+    """Target-system asks should be triggered by retry log + missing campaign fields."""
+
+    def test_unset_observable_metrics_triggers_ask(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1)
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {"name": "X"}},
+        )
+
+        asks = payload["target_system_asks"]
+        instr_asks = [a for a in asks if a["kind"] == "instrumentation"]
+        assert instr_asks, f"expected an instrumentation ask, got: {asks}"
+        # The evidence must be concrete — references campaign.yaml + observable_metrics.
+        assert validate_evidence(instr_asks[0]["evidence"]) is None
+
+    def test_set_observable_metrics_does_not_trigger(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1)
+
+        payload = emit_meta_findings(
+            work_dir,
+            campaign={"target_system": {
+                "name": "X",
+                "observable_metrics": ["latency_ms", "throughput_qps"],
+                "controllable_knobs": ["batch_size"],
+            }},
+        )
+        kinds = {a["kind"] for a in payload["target_system_asks"]}
+        assert "instrumentation" not in kinds
+        assert "documentation" not in kinds
+
+    def test_repeated_retry_failure_surfaces(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1, 2])
+        _write_findings(work_dir, 1)
+        _write_findings(work_dir, 2)
+        _append_jsonl(work_dir / "retry_log.jsonl", [
+            {"phase": "execute-analyze", "failure_type": "transient",
+             "attempt": 1, "error": "network blip"},
+            {"phase": "execute-analyze", "failure_type": "transient",
+             "attempt": 2, "error": "network blip again"},
+            {"phase": "execute-analyze", "failure_type": "transient",
+             "attempt": 3, "error": "network blip third"},
+        ])
+
+        payload = emit_meta_findings(
+            work_dir,
+            campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        repro_asks = [a for a in payload["target_system_asks"]
+                      if a["kind"] == "reproducibility"]
+        assert repro_asks
+        ask = repro_asks[0]
+        assert "transient" in ask["evidence"]
+        assert "count=3" in ask["evidence"]
+
+
+class TestNousAskDetection:
+    """Nous self-improvement asks come from llm_metrics + retry_log."""
+
+    def test_low_cache_hit_rate_surfaces(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1)
+        _append_jsonl(work_dir / "llm_metrics.jsonl", [
+            {"phase": "design", "input_tokens": 10000,
+             "cache_read_input_tokens": 100, "output_tokens": 500},
+            {"phase": "execute", "input_tokens": 8000,
+             "cache_read_input_tokens": 200, "output_tokens": 600},
+        ])
+
+        payload = emit_meta_findings(
+            work_dir,
+            campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        token_asks = [a for a in payload["nous_asks"]
+                      if a["kind"] == "token_budget"]
+        # Either a high-input ask or a low-cache ask must fire.
+        assert token_asks
+        assert any("cache" in a["evidence"] for a in token_asks)
+
+    def test_no_anomalies_yields_empty_streams(self, tmp_path: Path) -> None:
+        """Healthy campaign with full campaign.yaml + cache hits + no retries."""
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1)
+        _append_jsonl(work_dir / "llm_metrics.jsonl", [
+            {"phase": "design", "input_tokens": 1000,
+             "cache_read_input_tokens": 800, "output_tokens": 500},
+        ])
+
+        payload = emit_meta_findings(
+            work_dir,
+            campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        # No surprises → all empty + a notes string.
+        assert payload["target_system_asks"] == []
+        assert payload["nous_asks"] == []
+        assert payload["campaign_design_lessons"] == []
+        assert "notes" in payload
+
+
+class TestDesignLessonDetection:
+    """Lessons surface from refutation patterns across iterations."""
+
+    def test_invalid_experiment_surfaces_lesson(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1, experiment_valid=False)
+
+        payload = emit_meta_findings(
+            work_dir,
+            campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+        lessons = payload["campaign_design_lessons"]
+        assert lessons
+        assert any("experiment_valid=false" in l["evidence"] for l in lessons)
+
+    def test_refute_then_confirm_surfaces_lesson(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1, 2, 3])
+        _write_findings(work_dir, 1, h_main_status="REFUTED")
+        _write_findings(work_dir, 2, h_main_status="REFUTED")
+        _write_findings(work_dir, 3, h_main_status="CONFIRMED")
+
+        payload = emit_meta_findings(
+            work_dir,
+            campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        # Should mention the iter-1 refute and iter-3 confirm.
+        relevant = [
+            l for l in payload["campaign_design_lessons"]
+            if "iter-1" in l["evidence"] and "iter-3" in l["evidence"]
+        ]
+        assert relevant, payload["campaign_design_lessons"]
+
+
+# ─── Validator-floor regression ───────────────────────────────────────────
+
+
+class TestValidatorRejectsVague:
+    """Hand-crafted meta_findings.json with vague evidence is rejected."""
+
+    def test_vague_evidence_is_rejected(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        bad = {
+            "schema_version": "1",
+            "campaign_design_lessons": [
+                {"lesson": "Things should be improved overall",
+                 "evidence": "in general, slow"},
+            ],
+            "target_system_asks": [],
+            "nous_asks": [],
+        }
+        (work_dir / "meta_findings.json").write_text(json.dumps(bad))
+
+        result = validate_meta_findings(work_dir)
+        assert result["status"] == "fail"
+        joined = " | ".join(result["errors"])
+        assert "campaign_design_lessons" in joined
+        assert "vague" in joined.lower() or "short" in joined.lower()
+
+    def test_missing_file_is_reported(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        result = validate_meta_findings(work_dir)
+        assert result["status"] == "fail"
+        assert "not found" in result["errors"][0]
+
+    def test_concrete_evidence_passes(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        good = {
+            "schema_version": "1",
+            "campaign_design_lessons": [
+                {"lesson": "Tighten experiment_plan validation upstream",
+                 "evidence": "findings.json reported experiment_valid=false in iter-2"},
+            ],
+            "target_system_asks": [],
+            "nous_asks": [],
+        }
+        (work_dir / "meta_findings.json").write_text(json.dumps(good))
+
+        result = validate_meta_findings(work_dir)
+        assert result["status"] == "pass", result.get("errors")
+
+
+# ─── Markdown rendering for nous report ───────────────────────────────────
+
+
+class TestRenderMarkdown:
+    def test_renders_three_sections(self) -> None:
+        payload = {
+            "schema_version": "1",
+            "campaign_design_lessons": [
+                {"lesson": "Lesson A", "evidence": "iter-1 details"},
+            ],
+            "target_system_asks": [
+                {"ask": "Ask B", "evidence": "campaign.yaml line 12",
+                 "kind": "instrumentation"},
+            ],
+            "nous_asks": [],
+        }
+        md = render_meta_findings_markdown(payload)
+        assert "## Meta-findings" in md
+        assert "### Campaign-design lessons" in md
+        assert "### Target-system asks" in md
+        assert "### Nous asks" in md
+        assert "Lesson A" in md
+        assert "iter-1 details" in md
+        assert "_None._" in md  # nous asks empty

--- a/tests/test_repo_cache.py
+++ b/tests/test_repo_cache.py
@@ -1,0 +1,340 @@
+"""Behavioral tests for the repo-level knowledge cache (issue #156).
+
+Tests assert what's on disk after write_repo_cache + read_repo_cache,
+not which internal helpers were called. Per CLAUDE.md, no live LLM
+calls; freshness is exercised by injecting a deterministic
+``head_sha_fn`` instead of relying on real git state.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from orchestrator.repo_cache import (
+    RepoCache,
+    build_cache_from_campaign,
+    cache_dir_for,
+    is_fresh,
+    read_repo_cache,
+    render_cache_for_design_prompt,
+    write_repo_cache,
+)
+
+
+# ─── Round-trip ────────────────────────────────────────────────────────────
+
+
+class TestRoundTrip:
+    """write → read should preserve the cache content."""
+
+    def test_full_cache_round_trips(self, tmp_path: Path) -> None:
+        sha_fn = lambda _: "abc123"
+
+        write_repo_cache(
+            tmp_path,
+            exploration="# Repo tour\n\nThe `core/` package owns scheduling.\n",
+            knobs=[
+                {"name": "batch_size", "location": "src/sched.go:42",
+                 "type": "int", "default": 32, "range": [1, 128]},
+                {"name": "preempt", "type": "bool", "default": False},
+            ],
+            metrics=[
+                {"name": "latency_ms", "unit": "ms",
+                 "capture": "stdout JSON 'latency_ms'"},
+            ],
+            build={
+                "build_command": "make build",
+                "test_command": "make test",
+                "prerequisites": ["go 1.21+"],
+            },
+            head_sha_fn=sha_fn,
+        )
+
+        cache = read_repo_cache(tmp_path, head_sha_fn=sha_fn)
+        assert cache is not None
+        assert cache.fresh is True
+        assert cache.verified_sha == "abc123"
+        assert cache.head_sha == "abc123"
+        assert "core/" in cache.exploration
+        assert {k["name"] for k in cache.knobs} == {"batch_size", "preempt"}
+        assert cache.metrics[0]["capture"].startswith("stdout JSON")
+        assert cache.build["build_command"] == "make build"
+        assert "go 1.21+" in cache.build["prerequisites"]
+
+    def test_partial_cache_round_trips(self, tmp_path: Path) -> None:
+        """Writing only exploration is valid — knobs/metrics/build optional."""
+        write_repo_cache(
+            tmp_path,
+            exploration="# tour\nshort\n",
+            head_sha_fn=lambda _: "deadbeef",
+        )
+        cache = read_repo_cache(tmp_path, head_sha_fn=lambda _: "deadbeef")
+        assert cache is not None
+        assert "tour" in cache.exploration
+        assert cache.knobs == []
+        assert cache.metrics == []
+        assert cache.build == {}
+
+    def test_disk_layout_matches_documented_paths(self, tmp_path: Path) -> None:
+        write_repo_cache(
+            tmp_path,
+            exploration="x",
+            knobs=[{"name": "k1"}],
+            metrics=[{"name": "m1"}],
+            build={"build_command": "echo build"},
+            head_sha_fn=lambda _: "sha1",
+        )
+        cache_dir = cache_dir_for(tmp_path)
+        assert (cache_dir / "exploration.md").exists()
+        assert (cache_dir / "knobs.yaml").exists()
+        assert (cache_dir / "metrics.yaml").exists()
+        assert (cache_dir / "build.yaml").exists()
+        assert (cache_dir / "schema_version.txt").exists()
+        assert (cache_dir / "last_verified_at.txt").exists()
+        # Verify on-disk yaml shape too
+        knobs_content = yaml.safe_load((cache_dir / "knobs.yaml").read_text())
+        assert knobs_content["schema_version"] == "1"
+        assert knobs_content["knobs"] == [{"name": "k1"}]
+
+
+# ─── Freshness ────────────────────────────────────────────────────────────
+
+
+class TestFreshness:
+    """fresh=True only when verified_sha == HEAD."""
+
+    def test_matching_sha_is_fresh(self, tmp_path: Path) -> None:
+        write_repo_cache(tmp_path, exploration="x", head_sha_fn=lambda _: "abc")
+        assert is_fresh(tmp_path, head_sha_fn=lambda _: "abc")
+
+    def test_diverged_sha_is_stale(self, tmp_path: Path) -> None:
+        write_repo_cache(tmp_path, exploration="x", head_sha_fn=lambda _: "abc")
+        assert not is_fresh(tmp_path, head_sha_fn=lambda _: "xyz")
+
+    def test_unknown_sha_is_stale(self, tmp_path: Path) -> None:
+        """Cache written without git is conservatively never fresh."""
+        write_repo_cache(tmp_path, exploration="x", head_sha_fn=lambda _: None)
+        assert not is_fresh(tmp_path, head_sha_fn=lambda _: None)
+        # Even if we now claim a sha, the cache file says "unknown" so it
+        # cannot equal the new HEAD.
+        assert not is_fresh(tmp_path, head_sha_fn=lambda _: "abc")
+
+    def test_missing_cache_returns_none(self, tmp_path: Path) -> None:
+        assert read_repo_cache(tmp_path) is None
+        assert not is_fresh(tmp_path)
+
+
+# ─── Corruption resilience ────────────────────────────────────────────────
+
+
+class TestCorruptionResilience:
+    """A malformed file shouldn't crash the reader."""
+
+    def test_invalid_yaml_in_knobs_drops_knobs(self, tmp_path: Path) -> None:
+        write_repo_cache(
+            tmp_path, exploration="x", knobs=[{"name": "k"}],
+            head_sha_fn=lambda _: "sha",
+        )
+        (cache_dir_for(tmp_path) / "knobs.yaml").write_text("not: [valid yaml: ][")
+        cache = read_repo_cache(tmp_path, head_sha_fn=lambda _: "sha")
+        assert cache is not None
+        assert cache.knobs == []  # corrupt → empty, not crash
+        assert cache.exploration == "x"  # other files survive
+
+    def test_schema_violation_in_metrics_drops_metrics(self, tmp_path: Path) -> None:
+        write_repo_cache(
+            tmp_path, exploration="x", metrics=[{"name": "m"}],
+            head_sha_fn=lambda _: "sha",
+        )
+        # Write a metrics.yaml that violates schema (missing schema_version).
+        (cache_dir_for(tmp_path) / "metrics.yaml").write_text(
+            yaml.safe_dump({"metrics": [{"name": "still here"}]})
+        )
+        cache = read_repo_cache(tmp_path, head_sha_fn=lambda _: "sha")
+        assert cache is not None
+        assert cache.metrics == []
+
+
+# ─── Markdown rendering ───────────────────────────────────────────────────
+
+
+class TestRenderForPrompt:
+    def test_fresh_cache_renders_full_block(self, tmp_path: Path) -> None:
+        write_repo_cache(
+            tmp_path,
+            exploration="# tour\nthe sched is in core/\n",
+            knobs=[{"name": "batch_size", "location": "src/sched.go:42",
+                    "type": "int"}],
+            metrics=[{"name": "latency_ms", "unit": "ms",
+                      "capture": "stdout JSON"}],
+            build={"build_command": "make build", "test_command": "make test",
+                   "prerequisites": ["go 1.21+"]},
+            head_sha_fn=lambda _: "x",
+        )
+        cache = read_repo_cache(tmp_path, head_sha_fn=lambda _: "x")
+        assert cache is not None
+        rendered = render_cache_for_design_prompt(cache)
+        assert "## Repo cache" in rendered
+        assert "batch_size" in rendered
+        assert "src/sched.go:42" in rendered
+        assert "latency_ms" in rendered
+        assert "make build" in rendered
+
+    def test_stale_cache_renders_empty(self, tmp_path: Path) -> None:
+        write_repo_cache(tmp_path, exploration="x", head_sha_fn=lambda _: "old")
+        cache = read_repo_cache(tmp_path, head_sha_fn=lambda _: "new")
+        assert cache is not None
+        assert cache.fresh is False
+        # Even with content, stale cache renders nothing — caller should
+        # fall back to today's behavior.
+        assert render_cache_for_design_prompt(cache) == ""
+
+    def test_empty_cache_renders_empty(self) -> None:
+        assert render_cache_for_design_prompt(RepoCache(fresh=True)) == ""
+
+
+# ─── Heuristic builder from campaign artifacts ────────────────────────────
+
+
+class TestBuildFromCampaign:
+    def test_extracts_handoff_into_exploration(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        (work_dir / "handoff.md").write_text(
+            "## Handoff\n\n"
+            "### Goal\n\n"
+            "Test the mechanism\n\n"
+            "### System Interface\n\n"
+            "- **Build:** `make build`\n"
+            "- **Run baseline:** `./bin/sim --config small.yaml`\n"
+        )
+        campaign = {
+            "target_system": {
+                "observable_metrics": ["latency_ms", "qps"],
+                "controllable_knobs": ["batch_size"],
+            }
+        }
+
+        exploration, knobs, metrics, build = build_cache_from_campaign(
+            work_dir, campaign,
+        )
+
+        assert "Goal" in exploration
+        assert "System Interface" in exploration
+        assert {k["name"] for k in knobs} == {"batch_size"}
+        assert {m["name"] for m in metrics} == {"latency_ms", "qps"}
+        assert build.get("build_command") == "make build"
+        assert "./bin/sim --config small.yaml" in build.get("run_command", "")
+
+    def test_empty_campaign_yields_empty_cache(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        exploration, knobs, metrics, build = build_cache_from_campaign(
+            work_dir, {},
+        )
+        assert exploration == ""
+        assert knobs == []
+        assert metrics == []
+        assert build == {}
+
+
+# ─── End-to-end behavioral: two-campaign cache reuse ──────────────────────
+
+
+class TestTwoCampaignReuse:
+    """Simulate two campaigns on the same repo. The second sees a fresh cache."""
+
+    def test_second_campaign_sees_first_campaigns_cache(self, tmp_path: Path) -> None:
+        repo = tmp_path / "fake_repo"
+        repo.mkdir()
+        sha = "first-campaign-sha"
+
+        # ─ First campaign: produces a handoff.md + writes cache at end.
+        first_work = repo / ".nous" / "first-run"
+        first_work.mkdir(parents=True)
+        (first_work / "handoff.md").write_text(
+            "## Handoff\n\n"
+            "### Goal\n\nLearn the system.\n\n"
+            "### System Interface\n\n"
+            "- **Build:** `cargo build --release`\n"
+        )
+        campaign_yaml = {
+            "target_system": {
+                "repo_path": str(repo),
+                "observable_metrics": ["throughput"],
+                "controllable_knobs": ["workers"],
+            }
+        }
+        exploration, knobs, metrics, build = build_cache_from_campaign(
+            first_work, campaign_yaml,
+        )
+        write_repo_cache(
+            repo, exploration=exploration, knobs=knobs, metrics=metrics,
+            build=build, head_sha_fn=lambda _: sha,
+        )
+
+        # ─ Second campaign reads the cache before doing anything.
+        cache = read_repo_cache(repo, head_sha_fn=lambda _: sha)
+        assert cache is not None
+        assert cache.fresh is True
+        assert "Goal" in cache.exploration
+        assert {k["name"] for k in cache.knobs} == {"workers"}
+        assert cache.build["build_command"] == "cargo build --release"
+
+        rendered = render_cache_for_design_prompt(cache)
+        # The rendered block is what would feed the planner — verify the
+        # second campaign's design phase has cheap access to first
+        # campaign's facts.
+        assert "cargo build --release" in rendered
+        assert "workers" in rendered
+
+    def test_repo_evolves_cache_becomes_stale(self, tmp_path: Path) -> None:
+        """When HEAD diverges, the cache is marked stale; second campaign
+        must fall back to fresh exploration."""
+        repo = tmp_path / "fake_repo"
+        repo.mkdir()
+
+        write_repo_cache(
+            repo, exploration="# old tour\n",
+            head_sha_fn=lambda _: "old-sha",
+        )
+
+        # Time passes, repo evolves.
+        cache = read_repo_cache(repo, head_sha_fn=lambda _: "new-sha")
+        assert cache is not None
+        assert cache.fresh is False
+        # The renderer protects callers that forget to check fresh.
+        assert render_cache_for_design_prompt(cache) == ""
+
+
+# ─── Real-git smoke test (uses a tiny initialised repo) ───────────────────
+
+
+class TestRealGit:
+    """One light test against an actual `git init` repo to exercise the
+    default head_sha_fn path. Most tests use injected fakes."""
+
+    def test_real_git_repo_freshness(self, tmp_path: Path) -> None:
+        repo = tmp_path / "real_repo"
+        repo.mkdir()
+        try:
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+            (repo / "README.md").write_text("hi\n")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError) as e:
+            pytest.skip(f"git not available: {e}")
+
+        write_repo_cache(repo, exploration="# tour\n")
+        assert is_fresh(repo)
+
+        # New commit changes HEAD, cache becomes stale.
+        (repo / "README.md").write_text("changed\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "change"], cwd=repo, check=True)
+        assert not is_fresh(repo)

--- a/tests/test_tradeoff.py
+++ b/tests/test_tradeoff.py
@@ -1,0 +1,330 @@
+"""Behavioral tests for the H-tradeoff arm (issue #158).
+
+Tests assert what's on disk (bundle, findings) and the deterministic
+verdict classifier on synthetic numeric inputs. No live LLM calls.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.findings_classifier import classify_tradeoff
+from orchestrator.validate import validate_design
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+
+
+def _load_bundle_schema() -> dict:
+    return yaml.safe_load((SCHEMAS_DIR / "bundle.schema.yaml").read_text())
+
+
+def _load_findings_schema() -> dict:
+    return json.loads((SCHEMAS_DIR / "findings.schema.json").read_text())
+
+
+# ─── Verdict classifier truth table ────────────────────────────────────────
+
+
+class TestTradeoffVerdict:
+    def test_all_predicates_met_confirmed(self) -> None:
+        v = classify_tradeoff(
+            primary_change_observed=-30.0,
+            primary_change_predicted=-20.0,  # need <= -20, observed -30 is better
+            secondary_change_observed=5.0,
+            secondary_budget=10.0,
+            secondary_direction="increase",
+        )
+        assert v.primary_predicate_met is True
+        assert v.secondary_predicate_met is True
+        assert v.verdict == "confirmed"
+
+    def test_primary_failed(self) -> None:
+        v = classify_tradeoff(
+            primary_change_observed=-5.0,
+            primary_change_predicted=-20.0,
+            secondary_change_observed=2.0,
+            secondary_budget=10.0,
+            secondary_direction="increase",
+        )
+        assert v.primary_predicate_met is False
+        assert v.secondary_predicate_met is True
+        assert v.verdict == "primary_failed"
+
+    def test_cost_too_high(self) -> None:
+        v = classify_tradeoff(
+            primary_change_observed=-25.0,
+            primary_change_predicted=-20.0,
+            secondary_change_observed=15.0,
+            secondary_budget=10.0,
+            secondary_direction="increase",
+        )
+        assert v.primary_predicate_met is True
+        assert v.secondary_predicate_met is False
+        assert v.verdict == "cost_too_high"
+
+    def test_both_failed(self) -> None:
+        v = classify_tradeoff(
+            primary_change_observed=5.0,
+            primary_change_predicted=-20.0,
+            secondary_change_observed=20.0,
+            secondary_budget=10.0,
+            secondary_direction="increase",
+        )
+        assert v.primary_predicate_met is False
+        assert v.secondary_predicate_met is False
+        assert v.verdict == "both_failed"
+
+    def test_decrease_direction(self) -> None:
+        """secondary_direction='decrease' means worse is going down (e.g.
+        accuracy). Observed -3 with budget 5 is fine."""
+        v = classify_tradeoff(
+            primary_change_observed=-10.0,
+            primary_change_predicted=-5.0,
+            secondary_change_observed=-3.0,
+            secondary_budget=5.0,
+            secondary_direction="decrease",
+        )
+        assert v.secondary_predicate_met is True
+        assert v.verdict == "confirmed"
+
+    def test_decrease_direction_violation(self) -> None:
+        v = classify_tradeoff(
+            primary_change_observed=-10.0,
+            primary_change_predicted=-5.0,
+            secondary_change_observed=-7.0,  # more decrease than budget -5
+            secondary_budget=5.0,
+            secondary_direction="decrease",
+        )
+        assert v.secondary_predicate_met is False
+        assert v.verdict == "cost_too_high"
+
+    def test_better_than_predicted_secondary_passes(self) -> None:
+        """If secondary moves the BETTER direction (down when worse=up),
+        it must pass regardless of budget."""
+        v = classify_tradeoff(
+            primary_change_observed=-10.0,
+            primary_change_predicted=-5.0,
+            secondary_change_observed=-50.0,  # secondary went down massively
+            secondary_budget=2.0,
+            secondary_direction="increase",  # worse=up
+        )
+        assert v.secondary_predicate_met is True
+
+    def test_invalid_direction_raises(self) -> None:
+        with pytest.raises(ValueError, match="secondary_direction"):
+            classify_tradeoff(
+                primary_change_observed=0, primary_change_predicted=0,
+                secondary_change_observed=0, secondary_budget=1,
+                secondary_direction="sideways",
+            )
+
+    def test_negative_budget_raises(self) -> None:
+        with pytest.raises(ValueError, match="secondary_budget"):
+            classify_tradeoff(
+                primary_change_observed=0, primary_change_predicted=0,
+                secondary_change_observed=0, secondary_budget=-1,
+                secondary_direction="increase",
+            )
+
+
+# ─── Bundle schema accepts h-tradeoff with all required fields ────────────
+
+
+VALID_TRADEOFF_BUNDLE = {
+    "metadata": {"iteration": 1, "family": "test", "research_question": "Is it worth it?"},
+    "arms": [
+        {
+            "type": "h-main",
+            "prediction": "Caching cuts latency",
+            "mechanism": "skips redundant calls",
+            "diagnostic": "check cache hit rate",
+        },
+        {
+            "type": "h-tradeoff",
+            "prediction": "Latency drops >=20% while memory stays within +500MB",
+            "mechanism": "Cache trades memory for time",
+            "diagnostic": "If memory exceeds budget, intervention fails",
+            "metric": "latency_ms",
+            "secondary_metric": "memory_mb",
+            "secondary_budget": 500,
+            "secondary_direction": "increase",
+            "primary_change": -20.0,
+        },
+    ],
+}
+
+
+class TestBundleSchemaAcceptance:
+    def test_valid_tradeoff_bundle_passes_schema(self) -> None:
+        schema = _load_bundle_schema()
+        jsonschema.validate(VALID_TRADEOFF_BUNDLE, schema)
+
+    def test_validate_design_accepts_tradeoff(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        d.mkdir()
+        (d / "problem.md").write_text("## RQ\nIs caching worth the memory?\n")
+        (d / "bundle.yaml").write_text(yaml.safe_dump(VALID_TRADEOFF_BUNDLE))
+        (d / "handoff_snapshot.md").write_text("## Handoff\n### Goal\nx\n")
+        result = validate_design(d)
+        assert result["status"] == "pass", result.get("errors")
+
+
+# ─── Cross-field validation rejects malformed tradeoff arms ───────────────
+
+
+def _bundle_with_tradeoff_arm(**overrides) -> dict:
+    arm = {
+        "type": "h-tradeoff",
+        "prediction": "latency drops, memory grows",
+        "mechanism": "cache",
+        "diagnostic": "check usage",
+        "metric": "latency_ms",
+        "secondary_metric": "memory_mb",
+        "secondary_budget": 500,
+        "secondary_direction": "increase",
+    }
+    arm.update(overrides)
+    return {
+        "metadata": {"iteration": 1, "family": "t", "research_question": "q?"},
+        "arms": [arm],
+    }
+
+
+def _setup(d: Path, bundle: dict) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "problem.md").write_text("## RQ\nq?\n")
+    (d / "bundle.yaml").write_text(yaml.safe_dump(bundle))
+    (d / "handoff_snapshot.md").write_text("## Handoff\n### Goal\nx\n")
+
+
+class TestTradeoffCrossFieldValidation:
+    def test_rejects_same_primary_and_secondary_metric(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        bundle = _bundle_with_tradeoff_arm(secondary_metric="latency_ms")
+        _setup(d, bundle)
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        assert any("differ" in e.lower() for e in result["errors"])
+
+    def test_rejects_missing_secondary_budget(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        arm = {
+            "type": "h-tradeoff",
+            "prediction": "p", "mechanism": "m", "diagnostic": "d",
+            "metric": "latency_ms",
+            "secondary_metric": "memory_mb",
+            "secondary_direction": "increase",
+            # secondary_budget omitted
+        }
+        bundle = {
+            "metadata": {"iteration": 1, "family": "t", "research_question": "q?"},
+            "arms": [arm],
+        }
+        _setup(d, bundle)
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        assert any("secondary_budget" in e for e in result["errors"])
+
+    def test_rejects_invalid_direction(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        bundle = _bundle_with_tradeoff_arm(secondary_direction="sideways")
+        _setup(d, bundle)
+        result = validate_design(d)
+        assert result["status"] == "fail"
+
+    def test_rejects_negative_budget(self, tmp_path: Path) -> None:
+        d = tmp_path / "iter-1"
+        bundle = _bundle_with_tradeoff_arm(secondary_budget=-10)
+        _setup(d, bundle)
+        result = validate_design(d)
+        assert result["status"] == "fail"
+
+
+# ─── Findings schema accepts h-tradeoff arm result fields ─────────────────
+
+
+class TestFindingsSchemaAcceptance:
+    def test_tradeoff_findings_round_trip(self) -> None:
+        findings = {
+            "iteration": 1,
+            "bundle_ref": "runs/iter-1/bundle.yaml",
+            "arms": [
+                {
+                    "arm_type": "h-tradeoff",
+                    "predicted": "latency -20%, memory +<500MB",
+                    "observed": "latency -25%, memory +600MB",
+                    "status": "PARTIALLY_CONFIRMED",
+                    "error_type": None,
+                    "diagnostic_note": "Memory exceeded budget",
+                    "primary_change_observed": -25.0,
+                    "secondary_change_observed": 600.0,
+                    "primary_predicate_met": True,
+                    "secondary_predicate_met": False,
+                    "tradeoff_verdict": "cost_too_high",
+                },
+            ],
+            "experiment_valid": True,
+            "discrepancy_analysis": "Primary improved but secondary cost too high.",
+        }
+        schema = _load_findings_schema()
+        jsonschema.validate(findings, schema)
+
+    def test_tradeoff_verdict_enum_enforced(self) -> None:
+        findings = {
+            "iteration": 1,
+            "bundle_ref": "runs/iter-1/bundle.yaml",
+            "arms": [
+                {
+                    "arm_type": "h-tradeoff",
+                    "predicted": "p", "observed": "o",
+                    "status": "CONFIRMED",
+                    "error_type": None,
+                    "diagnostic_note": None,
+                    "tradeoff_verdict": "indeterminate",  # not in enum
+                },
+            ],
+            "experiment_valid": True,
+            "discrepancy_analysis": "x",
+        }
+        schema = _load_findings_schema()
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(findings, schema)
+
+
+# ─── End-to-end behavioral: synthetic measurements → verdict ──────────────
+
+
+class TestEndToEndTradeoff:
+    """Take a tradeoff arm + synthetic deltas, classify, produce verdict."""
+
+    def test_caching_intervention_cost_too_high(self) -> None:
+        # 'cache cut latency 20% but used 600MB more memory' against
+        # 'budget +500MB' → cost_too_high.
+        v = classify_tradeoff(
+            primary_change_observed=-22.0,
+            primary_change_predicted=-20.0,
+            secondary_change_observed=600.0,
+            secondary_budget=500.0,
+            secondary_direction="increase",
+        )
+        assert v.verdict == "cost_too_high"
+
+    def test_intervention_unlocks_new_failure_mode_visible(self) -> None:
+        """The point of the arm: a 'CONFIRMED primary, REFUTED secondary'
+        outcome is now a distinct verdict that doesn't masquerade as a
+        confirmation."""
+        v = classify_tradeoff(
+            primary_change_observed=-50.0,  # huge primary win
+            primary_change_predicted=-10.0,
+            secondary_change_observed=999.0,  # catastrophic secondary cost
+            secondary_budget=1.0,
+            secondary_direction="increase",
+        )
+        # A pre-tradeoff bundle would have called this CONFIRMED.
+        # The tradeoff arm makes the cost visible as a distinct verdict.
+        assert v.verdict == "cost_too_high"


### PR DESCRIPTION
## Summary

Resolves #160 — Self-improving Nous initiative. Five children land in
this PR:

- #155 — emit deterministic meta-findings at campaign end
- #156 — persist repo knowledge cache across campaigns with verify-before-use
- #157 — add `h-dose-response` arm
- #158 — add `h-tradeoff` arm
- #159 — graded-complexity tier discipline for bundles

Together these close the feedback loop: campaigns now write down what
they learned about *running campaigns*, repos now retain a cached
factual layer between campaigns, the bundle taxonomy gains the two
arm types most underrepresented in real use, and the methodology
gains an Occam pressure that delays sophistication until simpler
hypotheses are refuted.

## Closes

Closes #155
Closes #156
Closes #157
Closes #158
Closes #159
Closes #160

## Token-budget impact (per-PR)

| Child | Marginal token cost per campaign |
|---|---|
| #155 meta-findings | **0** — pure-Python emitter over on-disk artifacts |
| #156 repo cache    | **negative** — saves an Explore round on the second-onward campaigns; cache write is pure Python |
| #157 h-dose-response | 0 — schema + classifier; methodology change is in the cached system block |
| #158 h-tradeoff    | 0 — schema + classifier; methodology change is in the cached system block |
| #159 complexity tier | 0 — methodology lives in `CLAUDE.md` (auto-loaded, cached); gate panel is pure Python |

Net effect: zero tokens added to any per-call prompt; one cached-block
addition (~1.5KB of methodology) amortised across every call in the
session. The repo cache (#156) actively reduces input tokens on every
non-first campaign by replacing a fresh Explore pass.

## Behavioral testing — every test mocks the LLM

This PR adds **109 tests**, all behavioral:

| Test file | Tests | What it asserts |
|---|---|---|
| `tests/test_meta_findings.py` | 28 | Citation-floor classifier, schema-valid emission, heuristic detectors fire on synthetic artifacts, validator rejects vague evidence |
| `tests/test_repo_cache.py` | 17 | Round-trip on disk, freshness via injected `head_sha_fn`, corruption resilience, two-campaign reuse, real `git init` smoke test |
| `tests/test_dose_response.py` | 25 | Shape classifier on synthetic series for every shape, schema acceptance, cross-field rejection, end-to-end shape judgement |
| `tests/test_tradeoff.py` | 19 | Verdict truth table, schema acceptance, cross-field rejection (same-metric, missing budget), findings round-trip |
| `tests/test_complexity_tier.py` | 20 | Schema additive-only, prior-tier discovery, jump detection in every direction, gate panel output |

Per `CLAUDE.md` and `tests/CLAUDE.md`:
- ✓ Every assertion is on disk content, validator output, or
  deterministic classifier output.
- ✓ No `assert mock.called_with(...)` — no structural assertions.
- ✓ No live LLM calls. The autouse `block_live_llm_calls` fixture is
  the backstop; injected fakes are the contract.

`pytest -q` reports **648 passed, 1 skipped** (the skip is the
pre-existing conditional SDK-installed guard).

## Files changed

```
CLAUDE.md                                    +35  (tier system + meta-findings notes)
orchestrator/campaign.py                     +47  (emit meta-findings + write repo cache at DONE)
orchestrator/complexity_tier.py             new  (tier discipline, gate panel renderer)
orchestrator/findings_classifier.py         new  (dose-shape + tradeoff verdict classifiers)
orchestrator/gates.py                        +6   (tier_panel parameter)
orchestrator/iteration.py                    +12  (call format_tier_summary at design gate)
orchestrator/meta_findings.py               new  (citation floor + emitter + heuristics)
orchestrator/repo_cache.py                  new  (read/write/freshness + heuristic builder)
orchestrator/schemas/bundle.schema.yaml      +51  (h-dose-response, h-tradeoff, complexity_tier)
orchestrator/schemas/execute_analyze.schema.json  +18  (new arm types + verdict fields)
orchestrator/schemas/findings.schema.json    +44  (dose_points, tradeoff_verdict, etc)
orchestrator/schemas/meta_findings.schema.json    new
orchestrator/schemas/repo_cache.schema.yaml       new
orchestrator/validate.py                     +83  (typed cross-field rules + meta-findings validator)
prompts/methodology/design.md                +50  (cache instruction, new arms, tier rule)
tests/test_meta_findings.py                 new  (28)
tests/test_repo_cache.py                    new  (17)
tests/test_dose_response.py                 new  (25)
tests/test_tradeoff.py                      new  (19)
tests/test_complexity_tier.py               new  (20)
```

5 commits, one per child, in dependency-order:

```
8f71347 feat: graded-complexity tier discipline for bundles (refs #159)
57816ab feat: add H-tradeoff arm (refs #158)
6307d9e feat: add H-dose-response arm (refs #157)
b889ef4 feat: persist repo knowledge cache across campaigns (refs #156)
b5ab16d feat: emit deterministic meta-findings at campaign end (refs #155)
```

Each commit's tests pass independently, so this PR is bisectable.

## Substantively-better-outcome claims

Each PR includes its own success criteria; this PR's umbrella claim is:

1. **Future campaigns get cheaper.** A second campaign on the same repo
   pays the cost of reading 4 small cached files instead of running a
   fresh Explore pass. Measurable via `nous cost --cache-stats`.
2. **Bundle blind spots are addressed.** Tuning campaigns now have
   `h-dose-response` for shape-of-response questions, and
   `h-tradeoff` makes "improvement at unacceptable cost" a
   first-class verdict instead of a post-hoc surprise.
3. **Iteration discipline.** The complexity-tier system surfaces
   leaps in sophistication before the human says yes, so iter 1 no
   longer gets to skip past the simplest possible hypothesis.
4. **The system learns about itself.** Meta-findings turn previously-
   ephemeral chat-history lessons into a triagable JSON artifact at
   the end of every campaign — citation-anchored, schema-validated,
   never vague.

## Test plan

- [ ] `pytest` passes against `upstream/reflective` rebase
- [ ] `nous validate design --dir <iter_dir>` accepts an existing
      pre-#159 bundle (additive-only schema)
- [ ] `nous validate meta-findings --dir <work_dir>` runs cleanly on
      a campaign work-dir with a written `meta_findings.json`
- [ ] On a fresh inference-sim campaign run after merge, verify
      `.nous/repo/` is populated at completion and `meta_findings.json`
      lands at `.nous/<run_id>/`
- [ ] Re-run a campaign on the same repo with the cache present and
      capture `nous cost --cache-stats` for input_tokens delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)
