### PR TITLE
Tracking #166: Search-oriented Nous (4 children)

### DIFF
--- a/orchestrator/composite_score.py
+++ b/orchestrator/composite_score.py
@@ -1,0 +1,259 @@
+"""Composite scoring + best_found.json (issue #168).
+
+Replaces single-metric campaign success (``prediction_accuracy`` —
+the only cross-arm metric in ledger.json today) with a weighted
+composite over multiple deployability dimensions. Each campaign
+declares weights via an optional ``objective:`` block (or a named
+preset); ``best_found.json`` tracks the top-K candidates ranked by
+composite score across all iterations completed so far.
+
+Design notes
+------------
+* ``compute_score`` is pure deterministic math — `Σ w_m * value_m`.
+  Missing observations contribute zero (campaigns evolve their metric
+  vocabulary across iterations and a missing column should not crash
+  ranking).
+
+* ``ObjectiveSpec`` validates weight sum at construction time, with
+  float tolerance (so ten 0.1-weights still validate). Negative
+  weights are rejected; zero weights are allowed (lets a preset
+  reserve a slot for a metric that some campaigns won't measure).
+
+* Named presets are immutable; ``get_preset`` returns a fresh
+  ``ObjectiveSpec`` each call so callers cannot mutate the template.
+
+* ``update_best_found`` walks ``runs/iter-*/findings.json``, computes
+  a score per arm result, and writes the top-K to ``best_found.json``
+  via atomic_write. With no objective declared (legacy campaigns),
+  it falls back to a status-based ranking: CONFIRMED=1.0,
+  PARTIALLY_CONFIRMED=0.5, REFUTED=0.0. This guarantees that issue
+  #169's engine-continues-past-REFUTE flow always has a populated
+  best_found.json to point at.
+"""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from orchestrator.util import atomic_write
+
+
+_WEIGHT_SUM_TOLERANCE = 1e-6
+
+
+@dataclass
+class ObjectiveSpec:
+    """Weighted composite objective.
+
+    Attributes:
+        weights: Map of metric name → weight. Must be non-empty,
+            all weights ≥ 0, and sum to 1.0 (with float tolerance).
+        metric_extractors: Optional map of metric name → dotted path
+            into arms[].metadata. When unset, the metric name is used
+            as a flat key.
+        deploy_threshold: How much best_found composite score must
+            exceed baseline_score to trigger a 'deploy' verdict in the
+            deployment recommendation (issue #170). Default 0.1.
+    """
+    weights: dict[str, float]
+    metric_extractors: dict[str, str] = field(default_factory=dict)
+    deploy_threshold: float = 0.1
+
+    def __post_init__(self) -> None:
+        if not self.weights:
+            raise ValueError("objective weights must be non-empty")
+        for name, w in self.weights.items():
+            if w < 0:
+                raise ValueError(
+                    f"weight for {name!r} must be ≥ 0 (got {w})",
+                )
+        total = sum(self.weights.values())
+        if not math.isclose(total, 1.0, abs_tol=_WEIGHT_SUM_TOLERANCE):
+            raise ValueError(
+                f"weights must sum to 1.0 (got {total}); "
+                f"tolerance ±{_WEIGHT_SUM_TOLERANCE}",
+            )
+
+
+# ─── Named presets ────────────────────────────────────────────────────────
+#
+# Stored as factories so each call returns a fresh instance — protects
+# callers who mutate ObjectiveSpec.weights in place.
+
+PRESETS: dict[str, dict[str, Any]] = {
+    "compound-return-style": {
+        "weights": {
+            "compound_return": 0.5,
+            "walk_forward_consistency": 0.3,
+            "interpretability": 0.1,
+            "operational_simplicity": 0.1,
+        },
+        "deploy_threshold": 0.05,
+    },
+    "latency-style": {
+        "weights": {
+            "throughput": 0.4,
+            "latency_p99_inv": 0.3,
+            "stability": 0.2,
+            "operational_simplicity": 0.1,
+        },
+        "deploy_threshold": 0.10,
+    },
+}
+
+
+def get_preset(name: str) -> ObjectiveSpec:
+    """Resolve a named preset to a fresh ObjectiveSpec.
+
+    Returns a new instance each call so callers' mutations cannot leak.
+    """
+    if name not in PRESETS:
+        raise ValueError(
+            f"unknown preset {name!r}; available: {sorted(PRESETS)}",
+        )
+    template = PRESETS[name]
+    return ObjectiveSpec(
+        weights=dict(template["weights"]),
+        deploy_threshold=template.get("deploy_threshold", 0.1),
+    )
+
+
+# ─── compute_score ────────────────────────────────────────────────────────
+
+
+def compute_score(
+    observed_metrics: dict[str, Any], objective: ObjectiveSpec,
+) -> float:
+    """Weighted sum of observed metric values.
+
+    Missing metrics contribute zero — see module docstring rationale.
+    """
+    score = 0.0
+    for metric, weight in objective.weights.items():
+        value = observed_metrics.get(metric, 0.0)
+        try:
+            score += weight * float(value)
+        except (TypeError, ValueError):
+            # Non-numeric metric value: treat as zero contribution.
+            continue
+    return score
+
+
+def compute_score_components(
+    observed_metrics: dict[str, Any], objective: ObjectiveSpec,
+) -> dict[str, float]:
+    """Per-metric contribution to the score (weight × observed value)."""
+    components: dict[str, float] = {}
+    for metric, weight in objective.weights.items():
+        value = observed_metrics.get(metric, 0.0)
+        try:
+            components[metric] = weight * float(value)
+        except (TypeError, ValueError):
+            components[metric] = 0.0
+    return components
+
+
+# ─── update_best_found ────────────────────────────────────────────────────
+
+
+_LEGACY_STATUS_SCORES = {
+    "CONFIRMED": 1.0,
+    "PARTIALLY_CONFIRMED": 0.5,
+    "REFUTED": 0.0,
+}
+
+
+def _iter_findings(work_dir: Path) -> Iterable[tuple[int, dict]]:
+    runs_dir = work_dir / "runs"
+    if not runs_dir.is_dir():
+        return
+    for child in sorted(runs_dir.iterdir()):
+        if not child.is_dir() or not child.name.startswith("iter-"):
+            continue
+        try:
+            iteration = int(child.name.split("-", 1)[1])
+        except (IndexError, ValueError):
+            continue
+        path = child / "findings.json"
+        if not path.exists():
+            continue
+        try:
+            yield iteration, json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+
+def _candidate_id(iteration: int, arm: dict, idx: int) -> str:
+    """Stable identifier: prefer arms[].metadata.candidate_id, fall back to position."""
+    metadata = arm.get("metadata") or {}
+    explicit = metadata.get("candidate_id") if isinstance(metadata, dict) else None
+    if isinstance(explicit, str) and explicit:
+        return f"iter-{iteration}/{arm.get('arm_type', '?')}/{explicit}"
+    return f"iter-{iteration}/{arm.get('arm_type', '?')}/{idx}"
+
+
+def update_best_found(
+    work_dir: Path,
+    *,
+    objective: ObjectiveSpec | None,
+    top_k: int = 5,
+    now: datetime | None = None,
+) -> dict:
+    """Re-rank all candidates seen so far and write best_found.json.
+
+    Pure deterministic Python. Reads runs/iter-N/findings.json across
+    iterations, computes a score per arm, sorts descending, truncates
+    to ``top_k``, and atomically writes ``best_found.json`` at the
+    campaign root.
+
+    Args:
+        work_dir: Campaign work directory (containing ``runs/``).
+        objective: Composite-scoring objective. ``None`` falls back to
+            the legacy status-based ranking (CONFIRMED=1.0, etc.).
+        top_k: Cap on the returned list. Best candidates first.
+        now: Optional timestamp for ``updated_at``.
+
+    Returns:
+        The payload that was written. Empty ``top_k`` is valid.
+    """
+    work_dir = Path(work_dir)
+
+    candidates: list[dict] = []
+    for iteration, findings in _iter_findings(work_dir):
+        for idx, arm in enumerate(findings.get("arms", []) or []):
+            if not isinstance(arm, dict):
+                continue
+            metadata = arm.get("metadata") if isinstance(arm.get("metadata"), dict) else {}
+            assert isinstance(metadata, dict)
+
+            if objective is None:
+                score = _LEGACY_STATUS_SCORES.get(arm.get("status", ""), 0.0)
+                components = {"status": score}
+            else:
+                score = compute_score(metadata, objective)
+                components = compute_score_components(metadata, objective)
+
+            candidates.append({
+                "candidate_id": _candidate_id(iteration, arm, idx),
+                "score": float(score),
+                "components": components,
+                "iteration": iteration,
+                "arm_id": arm.get("arm_type", "?"),
+            })
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    payload = {
+        "top_k": candidates[:top_k],
+        "k": top_k,
+        "updated_at": (now or datetime.now(timezone.utc)).isoformat(),
+    }
+
+    atomic_write(
+        work_dir / "best_found.json",
+        json.dumps(payload, indent=2) + "\n",
+    )
+    return payload

--- a/orchestrator/deployment_recommendation.py
+++ b/orchestrator/deployment_recommendation.py
@@ -1,0 +1,250 @@
+"""Deployment recommendation (issue #170).
+
+Closes the search-oriented loop (#166): pre-work seeds (#167),
+composite score ranks (#168), engine continues past REFUTE (#169),
+and now every campaign emits a shippable verdict — ``deploy |
+deploy_with_caveats | fall_back_to_baseline`` — with concrete
+citations the operator can act on.
+
+Decision rule (deterministic Python, no LLM):
+
+  best_score    = best_found.json top_k[0].score (None if empty)
+  baseline      = pre_work.json baseline_metrics scored under the same
+                  objective (or 0 if pre_work absent / objective None)
+  threshold     = campaign.objective.deploy_threshold (default 0.1)
+  consistency   = top_k[0].components.get("walk_forward_consistency")
+                  (None if not in objective)
+
+  If best_score is None or best_score <= baseline:
+    ⇒ fall_back_to_baseline
+  Elif best_score > baseline + threshold AND
+       (consistency is None OR consistency > 0.7):
+    ⇒ deploy
+  Else:
+    ⇒ deploy_with_caveats
+
+Caveats are auto-generated for the middle case with concrete
+citations to iteration / arm / numeric component values, so the
+validator floor accepts them.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from orchestrator.composite_score import (
+    ObjectiveSpec,
+    compute_score,
+    get_preset,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_DEPLOY_THRESHOLD = 0.1
+_WALK_FORWARD_KEY = "walk_forward_consistency"
+_WALK_FORWARD_MIN = 0.7
+
+
+@dataclass
+class DeploymentRecommendation:
+    """Verdict + supporting citations for a campaign's terminal state."""
+    verdict: str
+    top_candidate_id: str | None = None
+    score: float | None = None
+    citations: list[dict[str, Any]] = field(default_factory=list)
+    caveats: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict,
+            "top_candidate_id": self.top_candidate_id,
+            "score": self.score,
+            "citations": list(self.citations),
+            "caveats": list(self.caveats),
+        }
+
+
+def _resolve_objective(campaign: dict) -> ObjectiveSpec | None:
+    """Pull an ObjectiveSpec from campaign config, or None if neither set."""
+    if not isinstance(campaign, dict):
+        return None
+    if (preset_name := campaign.get("objective_preset")):
+        try:
+            return get_preset(str(preset_name))
+        except ValueError:
+            return None
+    obj = campaign.get("objective")
+    if isinstance(obj, dict) and obj.get("weights"):
+        try:
+            return ObjectiveSpec(
+                weights={str(k): float(v) for k, v in obj["weights"].items()},
+                metric_extractors=dict(obj.get("metric_extractors") or {}),
+                deploy_threshold=float(
+                    obj.get("deploy_threshold", _DEFAULT_DEPLOY_THRESHOLD),
+                ),
+            )
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _read_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        loaded = json.loads(path.read_text())
+        return loaded if isinstance(loaded, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _baseline_score(work_dir: Path, objective: ObjectiveSpec | None) -> float:
+    """Score pre_work.json baseline_metrics under the same objective.
+
+    Returns 0.0 when:
+      * pre_work.json is missing or has no baseline_metrics
+      * no objective is declared (legacy fallback in best_found.json
+        already used status-as-score, which has 0..1 range — comparing
+        to baseline=0 means "anything CONFIRMED beats nothing")
+    """
+    if objective is None:
+        return 0.0
+    pre_work = _read_json(work_dir / "pre_work.json")
+    if not pre_work:
+        return 0.0
+    baseline = pre_work.get("baseline_metrics")
+    if not isinstance(baseline, dict):
+        return 0.0
+    return compute_score(baseline, objective)
+
+
+def _format_evidence(iteration: int, arm_id: str, components: dict) -> str:
+    """Concrete citation: iter-N + arm + numeric components.
+
+    Must pass meta_findings.evidence_is_concrete (regex floor — needs
+    an iter-N marker, an arm marker, and a numeric measurement).
+    """
+    parts = [f"iter-{iteration}", f"arm_id={arm_id}"]
+    for k, v in sorted(components.items()):
+        try:
+            parts.append(f"{k}={float(v):.3f}")
+        except (TypeError, ValueError):
+            continue
+    return " ".join(parts)
+
+
+def _make_caveats(
+    *,
+    iteration: int,
+    arm_id: str,
+    best_score: float,
+    baseline: float,
+    threshold: float,
+    consistency: float | None,
+) -> list[str]:
+    """Caveats are auto-generated with concrete citations."""
+    out: list[str] = []
+    margin = best_score - baseline
+    if margin <= threshold:
+        out.append(
+            f"iter-{iteration} arm {arm_id}: best_score margin over baseline "
+            f"= {margin:.3f}, below deploy_threshold of {threshold:.3f}",
+        )
+    if consistency is not None and consistency <= _WALK_FORWARD_MIN:
+        out.append(
+            f"iter-{iteration} arm {arm_id}: walk_forward_consistency "
+            f"= {consistency:.3f}, below threshold of {_WALK_FORWARD_MIN:.2f}",
+        )
+    return out
+
+
+def make_deployment_recommendation(
+    work_dir: Path,
+    *,
+    campaign: dict,
+) -> DeploymentRecommendation:
+    """Read best_found.json + pre_work.json, decide verdict.
+
+    Returns a fall_back_to_baseline verdict (with empty citations and
+    caveats) when there's nothing to recommend — never raises.
+    """
+    work_dir = Path(work_dir)
+    best_found = _read_json(work_dir / "best_found.json")
+
+    if not best_found or not best_found.get("top_k"):
+        return DeploymentRecommendation(verdict="fall_back_to_baseline")
+
+    top = best_found["top_k"][0]
+    if not isinstance(top, dict):
+        return DeploymentRecommendation(verdict="fall_back_to_baseline")
+
+    best_score = float(top.get("score", 0.0))
+    iteration = int(top.get("iteration", 0))
+    arm_id = str(top.get("arm_id", "?"))
+    candidate_id = str(top.get("candidate_id", ""))
+    components = top.get("components") or {}
+
+    objective = _resolve_objective(campaign)
+    threshold = (
+        objective.deploy_threshold if objective else _DEFAULT_DEPLOY_THRESHOLD
+    )
+    baseline = _baseline_score(work_dir, objective)
+
+    consistency: float | None = None
+    if isinstance(components, dict) and _WALK_FORWARD_KEY in components:
+        # `components` are weight-multiplied contributions; recover the raw
+        # metric value as contribution / weight when we have the weight.
+        contrib = components.get(_WALK_FORWARD_KEY)
+        weight = (
+            objective.weights.get(_WALK_FORWARD_KEY)
+            if objective else None
+        )
+        if isinstance(contrib, (int, float)) and weight:
+            consistency = float(contrib) / float(weight)
+
+    citations = [{
+        "iteration": iteration,
+        "arm_id": arm_id,
+        "evidence_snippet": _format_evidence(iteration, arm_id, components),
+    }]
+
+    if best_score <= baseline:
+        return DeploymentRecommendation(
+            verdict="fall_back_to_baseline",
+            top_candidate_id=candidate_id or None,
+            score=best_score,
+            citations=citations,
+            caveats=[
+                f"iter-{iteration} arm {arm_id}: best_score = {best_score:.3f} "
+                f"<= baseline = {baseline:.3f}",
+            ],
+        )
+
+    margin_ok = best_score > baseline + threshold
+    consistency_ok = consistency is None or consistency > _WALK_FORWARD_MIN
+
+    if margin_ok and consistency_ok:
+        verdict = "deploy"
+        caveats: list[str] = []
+    else:
+        verdict = "deploy_with_caveats"
+        caveats = _make_caveats(
+            iteration=iteration,
+            arm_id=arm_id,
+            best_score=best_score,
+            baseline=baseline,
+            threshold=threshold,
+            consistency=consistency,
+        )
+
+    return DeploymentRecommendation(
+        verdict=verdict,
+        top_candidate_id=candidate_id or None,
+        score=best_score,
+        citations=citations,
+        caveats=caveats,
+    )

--- a/orchestrator/engine.py
+++ b/orchestrator/engine.py
@@ -21,6 +21,7 @@ class Phase(str, Enum):
     """All valid orchestrator phases."""
 
     INIT = "INIT"
+    PRE_WORK = "PRE_WORK"
     DESIGN = "DESIGN"
     HUMAN_DESIGN_GATE = "HUMAN_DESIGN_GATE"
     EXECUTE_ANALYZE = "EXECUTE_ANALYZE"
@@ -29,8 +30,14 @@ class Phase(str, Enum):
 
 
 # Valid transitions: from_state -> set of valid to_states (immutable)
+#
+# PRE_WORK (issue #167) is opt-in: campaigns may go INIT → PRE_WORK → DESIGN
+# OR INIT → DESIGN. Legacy campaigns without a pre_work_script keep the
+# direct path; new campaigns that want cheap pre-iter exploration go through
+# PRE_WORK.
 TRANSITIONS: MappingProxyType[str, frozenset[str]] = MappingProxyType({
-    "INIT":                frozenset({"DESIGN"}),
+    "INIT":                frozenset({"DESIGN", "PRE_WORK"}),
+    "PRE_WORK":            frozenset({"DESIGN"}),
     "DESIGN":              frozenset({"HUMAN_DESIGN_GATE"}),
     "HUMAN_DESIGN_GATE":   frozenset({"EXECUTE_ANALYZE", "DESIGN"}),
     "EXECUTE_ANALYZE":     frozenset({"HUMAN_FINDINGS_GATE"}),

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -49,9 +49,11 @@ SCHEMAS_DIR = Path(__file__).resolve().parent / "schemas"
 DEFAULTS_PATH = Path(__file__).resolve().parent / "defaults.yaml"
 _ARM_TYPE_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-# Phase ordering for resume logic
+# Phase ordering for resume logic. PRE_WORK (issue #167) sits between
+# INIT and DESIGN — campaigns that opt into pre-work pass through it,
+# legacy campaigns skip it via the INIT → DESIGN transition.
 _PHASE_ORDER = [
-    "INIT", "DESIGN", "HUMAN_DESIGN_GATE",
+    "INIT", "PRE_WORK", "DESIGN", "HUMAN_DESIGN_GATE",
     "EXECUTE_ANALYZE", "HUMAN_FINDINGS_GATE",
     "DONE",
 ]

--- a/orchestrator/meta_findings.py
+++ b/orchestrator/meta_findings.py
@@ -92,6 +92,28 @@ def validate_evidence(text: str) -> str | None:
     return None
 
 
+def validate_caveat(text: str) -> str | None:
+    """Return None if a deployment_recommendation caveat passes the
+    citation floor, else an error. Caveats follow the same rule as
+    evidence — vague aspirations rejected regardless of source.
+
+    Issue #170: every caveat in deployment_recommendation.caveats must
+    cite a concrete marker.
+    """
+    if not isinstance(text, str):
+        return f"caveat must be a string, got {type(text).__name__}"
+    if len(text) < 8:
+        return f"caveat too short ({len(text)} chars; need >= 8)"
+    if not evidence_is_concrete(text):
+        return (
+            "caveat is vague: must cite at least one concrete marker "
+            "(iter-N, file path, tool name, quoted error, arm id, or "
+            "a numeric measurement). Got: "
+            + (text[:80] + ("…" if len(text) > 80 else ""))
+        )
+    return None
+
+
 # ─── Artifact readers ────────────────────────────────────────────────────
 
 
@@ -378,6 +400,16 @@ def emit_meta_findings(
         "target_system_asks": _detect_target_system_asks(campaign, retries),
         "nous_asks": _detect_nous_asks(metrics, retries),
     }
+
+    # Deployment recommendation (issue #170): every campaign emits a
+    # shippable verdict, even when the verdict is "fall back to baseline".
+    # Imported lazily to avoid a top-level cycle (deployment_recommendation
+    # itself imports from composite_score, not from meta_findings).
+    from orchestrator.deployment_recommendation import (
+        make_deployment_recommendation,
+    )
+    rec = make_deployment_recommendation(work_dir, campaign=campaign)
+    payload["deployment_recommendation"] = rec.to_dict()
 
     if not (
         payload["campaign_design_lessons"]

--- a/orchestrator/pre_work.py
+++ b/orchestrator/pre_work.py
@@ -1,0 +1,182 @@
+"""PRE_WORK phase — cheap deterministic exploration before iter-1 DESIGN (issue #167).
+
+User feedback (2026-05-25): "30 minutes of exploration could give the
+campaign a much better starting point than throwing it at the LLM cold
+... investing in pre-work makes the LLM iterations more targeted."
+
+Approach
+--------
+Two production runners + an injection seam for tests:
+
+  1. Default Python runner (no campaign config needed): summarizes
+     ``target_system.observable_metrics`` and ``controllable_knobs``
+     into ``data_summary``. Zero LLM tokens, zero subprocess. The
+     output is intentionally thin — the designer's prompt already
+     reads ``campaign.yaml``, so this is just structured restatement.
+
+  2. Subprocess runner (when ``campaign.pre_work_script`` is set): runs
+     the user-supplied script as a subprocess and parses its stdout as
+     JSON into a ``PreWorkResult``. This is the seam for domain-specific
+     hand-tested exploration — clustering visualizations, candidate
+     groupings, baseline computations.
+
+Failure modes are tolerant: a non-zero exit, a JSON parse error, or a
+missing script all yield an empty ``PreWorkResult`` so DESIGN proceeds
+unchanged. The PRE_WORK phase is opportunistic, not load-bearing.
+
+The ``runner=`` keyword on ``run_pre_work`` is the test injection seam —
+it bypasses both production paths so tests never invoke a real
+subprocess.
+
+Engine integration: ``Phase.PRE_WORK`` lives between ``INIT`` and
+``DESIGN`` in the transition map; both ``INIT → PRE_WORK → DESIGN`` and
+``INIT → DESIGN`` (legacy) are valid. The campaign loop chooses based
+on whether ``campaign.pre_work_script`` is set or the engine has been
+explicitly directed to run pre-work.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from orchestrator.util import atomic_write
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_S = 300
+
+
+@dataclass
+class PreWorkResult:
+    """Structured output of the PRE_WORK phase.
+
+    All fields optional. An all-None ``PreWorkResult`` is a valid
+    "nothing to report" outcome — the campaign continues into DESIGN
+    with no extra context.
+    """
+    data_summary: dict[str, Any] | None = None
+    candidate_parameter_ranges: dict[str, Any] | None = None
+    structural_groupings: list[Any] | None = None
+    baseline_metrics: dict[str, Any] | None = None
+    recommended_arms_for_iter1: list[Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Drop None fields before writing to disk — keeps the artifact tidy."""
+        d = asdict(self)
+        return {k: v for k, v in d.items() if v is not None}
+
+
+PreWorkRunner = Callable[[dict], PreWorkResult]
+"""Runner protocol: takes the campaign dict, returns a PreWorkResult."""
+
+
+def _default_python_runner(campaign: dict) -> PreWorkResult:
+    """Summary of campaign fields. Zero token cost. Deterministic.
+
+    Intentionally minimal: the designer's prompt already reads
+    campaign.yaml, so duplicating it here would just inflate context.
+    The value-add is *normalization* — the designer reads one canonical
+    structure regardless of whether the user populated optional
+    campaign fields.
+    """
+    target = campaign.get("target_system", {}) if isinstance(campaign, dict) else {}
+    if not isinstance(target, dict):
+        return PreWorkResult()
+
+    summary: dict[str, Any] = {}
+    metrics = target.get("observable_metrics")
+    if isinstance(metrics, list) and metrics:
+        summary["observable_metrics"] = list(metrics)
+    knobs = target.get("controllable_knobs")
+    if isinstance(knobs, list) and knobs:
+        summary["controllable_knobs"] = list(knobs)
+
+    if not summary:
+        return PreWorkResult()
+    return PreWorkResult(data_summary=summary)
+
+
+def _subprocess_runner(campaign: dict) -> PreWorkResult:
+    """Run the user-supplied pre_work_script and parse its stdout JSON.
+
+    Tolerant of failure: non-zero exit, JSON parse errors, and missing
+    scripts all yield an empty PreWorkResult. Pre-work is opportunistic;
+    a failed script must not break the campaign.
+    """
+    script = campaign.get("pre_work_script")
+    if not script:
+        return PreWorkResult()
+
+    try:
+        proc = subprocess.run(
+            [str(script)],
+            capture_output=True,
+            text=True,
+            timeout=_DEFAULT_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("pre_work_script %r failed to run: %s", script, exc)
+        return PreWorkResult()
+
+    if proc.returncode != 0:
+        logger.warning(
+            "pre_work_script %r exited with code %d; stderr=%r",
+            script, proc.returncode, (proc.stderr or "")[:200],
+        )
+        return PreWorkResult()
+
+    try:
+        payload = json.loads(proc.stdout)
+    except (json.JSONDecodeError, TypeError) as exc:
+        logger.warning(
+            "pre_work_script %r emitted non-JSON stdout: %s", script, exc,
+        )
+        return PreWorkResult()
+
+    if not isinstance(payload, dict):
+        return PreWorkResult()
+
+    return PreWorkResult(
+        data_summary=payload.get("data_summary"),
+        candidate_parameter_ranges=payload.get("candidate_parameter_ranges"),
+        structural_groupings=payload.get("structural_groupings"),
+        baseline_metrics=payload.get("baseline_metrics"),
+        recommended_arms_for_iter1=payload.get("recommended_arms_for_iter1"),
+    )
+
+
+def run_pre_work(
+    campaign: dict,
+    *,
+    runner: PreWorkRunner | None = None,
+) -> PreWorkResult:
+    """Execute the PRE_WORK phase.
+
+    Args:
+        campaign: Parsed campaign.yaml dict.
+        runner: Optional injected runner. When set, takes precedence
+            over both production paths — this is the test seam. When
+            unset, ``pre_work_script`` selects the subprocess path;
+            otherwise the default Python summarizer runs.
+
+    Returns:
+        PreWorkResult. May be empty (all-None) if no signal is available.
+    """
+    if runner is not None:
+        return runner(campaign)
+    if campaign.get("pre_work_script"):
+        return _subprocess_runner(campaign)
+    return _default_python_runner(campaign)
+
+
+def write_pre_work(work_dir: Path, result: PreWorkResult) -> Path:
+    """Atomically write ``pre_work.json`` to ``work_dir`` and return the path."""
+    work_dir = Path(work_dir)
+    target = work_dir / "pre_work.json"
+    atomic_write(target, json.dumps(result.to_dict(), indent=2) + "\n")
+    return target

--- a/orchestrator/refute_constraints.py
+++ b/orchestrator/refute_constraints.py
@@ -1,0 +1,187 @@
+"""Deterministic constraint-principle generation from REFUTED arms (issue #169).
+
+Audit of inference-sim ledgers (May 2026) shows campaigns like
+``mech-design-kvtime`` (acc 25%/0%), ``fp-delay-frontier`` (acc 0%),
+and ``sgsf-unification`` (REFUTED twice) walked away with no
+deployable artifact and no recorded reason for the next iteration to
+avoid the dead end. The engine itself doesn't have a REFUTE → DONE
+shortcut — that's confirmed by the test in
+``test_engine_search_continuation.py`` — but the *next* iteration's
+designer also gets no help.
+
+This module closes that gap: each REFUTED arm becomes a constraint
+principle (``category=meta``) recorded in ``principles.json``, so
+the next DESIGN reads "this mechanism was refuted in iter-N under
+regime X" and can redirect search.
+
+Pure deterministic Python — zero LLM tokens, idempotent, atomic write
+to disk. The seam matches ``meta_findings.emit_meta_findings``: scan
+on-disk artifacts, compute, write.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from orchestrator.util import atomic_write
+
+logger = logging.getLogger(__name__)
+
+
+def _constraint_id(iteration: int, arm_idx: int, arm_type: str) -> str:
+    """Stable id: encodes iteration + arm index so re-runs collide
+    with prior emissions and the existing_ids check skips duplicates."""
+    return f"C-iter{iteration}-arm{arm_idx}-{arm_type}"
+
+
+def _statement(arm: dict, family: str) -> str:
+    arm_type = arm.get("arm_type", "?")
+    predicted = (arm.get("predicted") or "").strip()
+    # Statement is human-readable but starts with "Refuted:" so the
+    # designer prompt can grep for it. Trim long predictions.
+    head = f"Refuted: family={family!r}, arm_type={arm_type!r}"
+    if predicted:
+        snippet = predicted[:120].replace("\n", " ")
+        if len(predicted) > 120:
+            snippet += "…"
+        return f"{head}. Prediction was: {snippet}"
+    return head
+
+
+def _applicability_bounds(arm: dict, family: str, iteration: int) -> str:
+    """Capture where the mechanism failed: family + iteration + observed snippet."""
+    observed = (arm.get("observed") or "").strip()
+    snippet = observed[:120].replace("\n", " ")
+    if len(observed) > 120:
+        snippet += "…"
+    if snippet:
+        return (
+            f"family={family!r}, iter-{iteration}; observed: {snippet}"
+        )
+    return f"family={family!r}, iter-{iteration}"
+
+
+def make_constraints_from_findings(
+    findings: dict,
+    *,
+    iteration: int,
+    family: str,
+    existing_ids: set[str] | None = None,
+) -> list[dict]:
+    """Return one constraint-principle dict per REFUTED arm.
+
+    Args:
+        findings: Parsed findings.json for the iteration.
+        iteration: Iteration index (used in id + applicability_bounds).
+        family: Mechanism family (used in statement + applicability_bounds).
+        existing_ids: Set of constraint ids already in principles.json;
+            constraints with these ids are skipped (idempotent re-run).
+
+    Returns:
+        List of new constraint principles, each conforming to
+        principles.schema.json. ``status="active"``, ``category="meta"``.
+    """
+    existing = existing_ids or set()
+    constraints: list[dict] = []
+
+    arms = findings.get("arms") if isinstance(findings, dict) else None
+    if not isinstance(arms, list):
+        return constraints
+
+    for idx, arm in enumerate(arms):
+        if not isinstance(arm, dict):
+            continue
+        if arm.get("status") != "REFUTED":
+            continue
+
+        arm_type = str(arm.get("arm_type") or "?")
+        cid = _constraint_id(iteration, idx, arm_type)
+        if cid in existing:
+            continue
+
+        constraints.append({
+            "id": cid,
+            "statement": _statement(arm, family),
+            "confidence": "high",
+            "regime": f"family={family!r}",
+            "evidence": [f"iter-{iteration}/findings.json arm {arm_type}"],
+            "contradicts": [],
+            "extraction_iteration": iteration,
+            "mechanism": "",
+            "applicability_bounds": _applicability_bounds(arm, family, iteration),
+            "superseded_by": None,
+            "status": "active",
+            "category": "meta",
+        })
+
+    return constraints
+
+
+def apply_refute_constraints(
+    work_dir: Path,
+    *,
+    iteration: int,
+    family: str,
+) -> list[dict]:
+    """End-to-end: read findings.json, generate constraints, merge into principles.json.
+
+    Idempotent: re-running on the same iteration produces no
+    duplicates (the existing_ids check sees the prior constraint ids
+    and skips). Atomic write — never leaves principles.json
+    half-written if interrupted.
+
+    Args:
+        work_dir: Campaign work dir (containing ``runs/iter-N/findings.json``
+            and ``principles.json``).
+        iteration: Which iteration's findings to read.
+        family: Mechanism family for statement context.
+
+    Returns:
+        The new constraints inserted (empty list if findings missing
+        or no REFUTED arms).
+    """
+    work_dir = Path(work_dir)
+
+    findings_path = work_dir / "runs" / f"iter-{iteration}" / "findings.json"
+    if not findings_path.exists():
+        return []
+    try:
+        findings = json.loads(findings_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "apply_refute_constraints: cannot read %s: %s",
+            findings_path, exc,
+        )
+        return []
+
+    principles_path = work_dir / "principles.json"
+    if principles_path.exists():
+        try:
+            store = json.loads(principles_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            store = {"principles": []}
+    else:
+        store = {"principles": []}
+
+    if not isinstance(store, dict) or not isinstance(
+        store.get("principles"), list,
+    ):
+        store = {"principles": []}
+
+    existing_ids: set[str] = {
+        p["id"] for p in store["principles"]
+        if isinstance(p, dict) and isinstance(p.get("id"), str)
+    }
+    new_constraints = make_constraints_from_findings(
+        findings,
+        iteration=iteration,
+        family=family,
+        existing_ids=existing_ids,
+    )
+    if not new_constraints:
+        return []
+
+    store["principles"] = list(store["principles"]) + new_constraints
+    atomic_write(principles_path, json.dumps(store, indent=2) + "\n")
+    return new_constraints

--- a/orchestrator/schemas/best_found.schema.json
+++ b/orchestrator/schemas/best_found.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/schemas/best_found.schema.json",
+  "title": "Best-Found Candidates",
+  "description": "Top-K candidates ranked by composite score across all iterations completed so far. Updated after each iteration's findings.json is finalized. Issue #168.",
+  "type": "object",
+  "required": ["top_k", "k", "updated_at"],
+  "additionalProperties": false,
+  "properties": {
+    "top_k": {
+      "type": "array",
+      "description": "Best candidates seen so far, ordered by score descending.",
+      "items": {
+        "type": "object",
+        "required": ["candidate_id", "score", "components", "iteration", "arm_id"],
+        "additionalProperties": false,
+        "properties": {
+          "candidate_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Stable identifier for the candidate. Combines iteration + arm + per-arm metadata.candidate_id when available."
+          },
+          "score": {
+            "type": "number",
+            "description": "Composite score; higher is better."
+          },
+          "components": {
+            "type": "object",
+            "description": "Per-metric contribution to the score (weight × observed value)."
+          },
+          "iteration": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Which iteration produced this candidate."
+          },
+          "arm_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Which arm produced this candidate (h-main, h-ablation, etc.)."
+          }
+        }
+      }
+    },
+    "k": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Top-K cap requested by the caller."
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of the most recent update."
+    }
+  }
+}

--- a/orchestrator/schemas/campaign.schema.yaml
+++ b/orchestrator/schemas/campaign.schema.yaml
@@ -85,3 +85,42 @@ properties:
       pre_work.json artifact that the designer reads as additional context.
       Pure deterministic exploration is the intent — fast, ~$0 LLM cost.
       Path is relative to campaign.yaml.
+
+  objective:
+    type: object
+    required: [weights]
+    additionalProperties: false
+    description: >
+      Optional composite-scoring objective (issue #168). Declares per-metric
+      weights for ranking candidates across iterations. Together with
+      best_found.json, drives the deployment recommendation in
+      meta_findings.json (issue #170).
+    properties:
+      weights:
+        type: object
+        description: "Map of metric name → weight. Weights must be ≥ 0 and sum to 1.0 (with float tolerance)."
+        minProperties: 1
+        additionalProperties:
+          type: number
+          minimum: 0
+      metric_extractors:
+        type: object
+        description: >
+          Optional map of metric name → dotted path into arms[].metadata
+          (e.g. "metadata.compound_return"). When omitted, the metric name
+          is used as a flat key in the observed_metrics dict.
+        additionalProperties:
+          type: string
+          minLength: 1
+      deploy_threshold:
+        type: number
+        minimum: 0
+        description: "How much best_found composite score must exceed baseline_score to trigger 'deploy' rather than 'deploy_with_caveats'. Default 0.1. Issue #170."
+
+  objective_preset:
+    type: string
+    enum: [compound-return-style, latency-style]
+    description: >
+      Opt-in named preset for the objective block (issue #168). Mutually
+      exclusive with `objective`. Adding new presets requires a schema
+      change so users can never silently inherit weights they didn't see.

--- a/orchestrator/schemas/campaign.schema.yaml
+++ b/orchestrator/schemas/campaign.schema.yaml
@@ -75,3 +75,13 @@ properties:
       domain_adapter_layer:
         type: ["string", "null"]
         description: "Path to domain-specific prompt overrides. Null if not yet generated."
+
+  pre_work_script:
+    type: string
+    minLength: 1
+    description: >
+      Optional path to a user-supplied pre-work script (issue #167). Run before
+      iter-1 DESIGN as a subprocess; the stdout JSON is parsed into a
+      pre_work.json artifact that the designer reads as additional context.
+      Pure deterministic exploration is the intent — fast, ~$0 LLM cost.
+      Path is relative to campaign.yaml.

--- a/orchestrator/schemas/meta_findings.schema.json
+++ b/orchestrator/schemas/meta_findings.schema.json
@@ -8,7 +8,8 @@
     "schema_version",
     "campaign_design_lessons",
     "target_system_asks",
-    "nous_asks"
+    "nous_asks",
+    "deployment_recommendation"
   ],
   "additionalProperties": false,
   "properties": {
@@ -27,6 +28,9 @@
     "nous_asks": {
       "type": "array",
       "items": { "$ref": "#/$defs/nous_ask" }
+    },
+    "deployment_recommendation": {
+      "$ref": "#/$defs/deployment_recommendation"
     },
     "notes": {
       "type": "string",
@@ -66,6 +70,44 @@
         "kind": {
           "type": "string",
           "enum": ["token_budget", "observability", "dispatch", "api", "gates", "schemas", "other"]
+        }
+      }
+    },
+    "deployment_recommendation": {
+      "type": "object",
+      "description": "Shippable verdict for the campaign (issue #170). Always emitted, even when the verdict is fall_back_to_baseline.",
+      "required": ["verdict", "top_candidate_id", "score", "citations", "caveats"],
+      "additionalProperties": false,
+      "properties": {
+        "verdict": {
+          "type": "string",
+          "enum": ["deploy", "deploy_with_caveats", "fall_back_to_baseline"]
+        },
+        "top_candidate_id": {
+          "type": ["string", "null"],
+          "description": "candidate_id from best_found.json. Null when nothing was found to recommend."
+        },
+        "score": {
+          "type": ["number", "null"],
+          "description": "Composite score of the top candidate. Null when no candidate."
+        },
+        "citations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["iteration", "arm_id", "evidence_snippet"],
+            "additionalProperties": false,
+            "properties": {
+              "iteration": { "type": "integer", "minimum": 0 },
+              "arm_id": { "type": "string", "minLength": 1 },
+              "evidence_snippet": { "type": "string", "minLength": 8 }
+            }
+          }
+        },
+        "caveats": {
+          "type": "array",
+          "description": "Non-empty for deploy_with_caveats verdicts. Each caveat must cite a concrete iter-N + arm marker (validator floor enforces; see meta_findings.validate_caveat).",
+          "items": { "type": "string", "minLength": 8 }
         }
       }
     }

--- a/orchestrator/schemas/pre_work.schema.json
+++ b/orchestrator/schemas/pre_work.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/schemas/pre_work.schema.json",
+  "title": "Pre-Work Result",
+  "description": "Output of the PRE_WORK phase (issue #167). Cheap deterministic exploration of the target system that informs iter-1 DESIGN. All fields are optional — empty results are valid and indicate the default runner had nothing to surface.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "data_summary": {
+      "type": "object",
+      "description": "Summary stats over the target system's data: row counts, distinct values, per-column ranges. Shape is domain-specific."
+    },
+    "candidate_parameter_ranges": {
+      "type": "object",
+      "description": "Per-knob plausible ranges discovered by the runner. Maps knob name to a [low, high] pair or a list of discrete candidates."
+    },
+    "structural_groupings": {
+      "type": "array",
+      "description": "Optional candidate groupings of the data or the system (e.g. high-momentum vs. defensive symbols, fast-path vs. slow-path requests). The designer may use these to scope arms."
+    },
+    "baseline_metrics": {
+      "type": "object",
+      "description": "Baseline values for observable metrics computed without intervention. Used by composite scoring (issue #168) and the deployment recommendation (issue #170)."
+    },
+    "recommended_arms_for_iter1": {
+      "type": "array",
+      "description": "Plain-English suggestions for what iter-1 should test, derived from the data summary. Designer treats as hints, not constraints.",
+      "items": {
+        "oneOf": [
+          { "type": "string", "minLength": 1 },
+          { "type": "object" }
+        ]
+      }
+    }
+  }
+}

--- a/orchestrator/schemas/state.schema.json
+++ b/orchestrator/schemas/state.schema.json
@@ -10,10 +10,10 @@
     "phase": {
       "type": "string",
       "enum": [
-        "INIT", "DESIGN", "HUMAN_DESIGN_GATE",
+        "INIT", "PRE_WORK", "DESIGN", "HUMAN_DESIGN_GATE",
         "EXECUTE_ANALYZE", "HUMAN_FINDINGS_GATE", "DONE"
       ],
-      "description": "Current state machine phase."
+      "description": "Current state machine phase. PRE_WORK (issue #167) is an opt-in cheap-exploration phase between INIT and DESIGN."
     },
     "iteration": {
       "type": "integer",

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -250,6 +250,30 @@ a 12-point grid but with adaptive coverage; for unimodal surfaces TPE
 typically finds the optimum in 8-10 evals. Budget=5 is generally too
 small unless the objective is decisive.
 
+## Refuted-mechanism constraints (issue #169)
+
+After every iteration with REFUTED arms, the orchestrator records a
+constraint principle with `category=meta` and a `statement` beginning
+"Refuted: family=...". These persist across iterations in
+`principles.json` — read them BEFORE proposing the next bundle.
+
+Treat each "Refuted: ..." constraint as a no-go zone:
+  * Do not re-propose the same family + arm-type combination unless
+    you have a concrete reason the regime has changed.
+  * The constraint's `applicability_bounds` carries the
+    iter-N + observed snippet that documents the failure. Cite it
+    in your problem.md when explaining why iter-{N+1} explores a
+    different mechanism.
+  * Constraints are honest signal that the *space is large* — a single
+    refutation eliminates one configuration, not the whole research
+    direction. Use the constraint to redirect search, not to give up.
+
+This pairs with the search-oriented stance (issue #166): a campaign's
+job is to find a deployable winner. A REFUTE is data that narrows
+search; the engine continues toward that goal regardless. The
+HUMAN_FINDINGS_GATE is the only path to DONE, so stopping is always
+a deliberate human decision, not a silent drop on REFUTE.
+
 ## Constraints
 
 - Do NOT violate active principles.

--- a/tests/test_composite_score.py
+++ b/tests/test_composite_score.py
@@ -1,0 +1,296 @@
+"""Behavioral tests for composite scoring + best_found.json (issue #168).
+
+Replaces single-metric campaign success with a weighted composite over
+multiple deployability dimensions. Each campaign declares weights via
+an optional `objective:` block (or a named preset); `best_found.json`
+tracks the top-K candidates ranked by score across all iterations.
+
+Test contract:
+  - compute_score is pure deterministic math: hand-computed reference matches.
+  - ObjectiveSpec rejects malformed weight sums and negative weights.
+  - Named presets resolve to known weight maps; unknown names raise.
+  - update_best_found scans runs/iter-N/findings.json deterministically
+    and writes a schema-valid best_found.json.
+  - Legacy campaigns without `objective:` fall back to ranking by
+    prediction_accuracy (the existing cross-arm metric).
+  - Schema additions are additive; legacy campaigns validate.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.composite_score import (
+    PRESETS,
+    ObjectiveSpec,
+    compute_score,
+    get_preset,
+    update_best_found,
+)
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+
+
+def _load_schema(name: str) -> dict:
+    path = SCHEMAS_DIR / name
+    if path.suffix in (".yaml", ".yml"):
+        return yaml.safe_load(path.read_text())
+    return json.loads(path.read_text())
+
+
+def _write_iter_findings(work_dir: Path, iteration: int, arms: list[dict]) -> None:
+    iter_dir = work_dir / "runs" / f"iter-{iteration}"
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    findings = {
+        "iteration": iteration,
+        "bundle_ref": f"runs/iter-{iteration}/bundle.yaml",
+        "arms": arms,
+        "experiment_valid": True,
+        "discrepancy_analysis": "",
+    }
+    (iter_dir / "findings.json").write_text(json.dumps(findings))
+
+
+def _arm(arm_type: str, status: str, metadata: dict | None = None) -> dict:
+    return {
+        "arm_type": arm_type,
+        "predicted": "p", "observed": "o",
+        "status": status, "error_type": None, "diagnostic_note": "n",
+        "metadata": metadata or {},
+    }
+
+
+# ─── compute_score: deterministic math ────────────────────────────────────
+
+
+class TestComputeScore:
+    def test_three_components_match_hand_computed_reference(self) -> None:
+        spec = ObjectiveSpec(weights={"a": 0.5, "b": 0.3, "c": 0.2})
+        score = compute_score({"a": 1.0, "b": 0.5, "c": 0.0}, spec)
+        assert score == pytest.approx(0.5 * 1.0 + 0.3 * 0.5 + 0.2 * 0.0)
+
+    def test_missing_metric_defaults_to_zero(self) -> None:
+        """A weight pointing at a metric not present in observed_metrics
+        contributes zero — campaigns evolve their metric vocabulary across
+        iterations and we don't want a missing column to crash scoring."""
+        spec = ObjectiveSpec(weights={"a": 0.5, "b": 0.5})
+        score = compute_score({"a": 1.0}, spec)  # b missing
+        assert score == pytest.approx(0.5)
+
+    def test_score_is_deterministic(self) -> None:
+        spec = ObjectiveSpec(weights={"a": 1.0})
+        m = {"a": 0.7}
+        assert compute_score(m, spec) == compute_score(m, spec)
+
+    def test_negative_metric_value_is_propagated(self) -> None:
+        """compute_score does no clamping; negative observations (e.g.
+        regression vs baseline) flow through. Direction is the caller's
+        responsibility."""
+        spec = ObjectiveSpec(weights={"a": 1.0})
+        assert compute_score({"a": -0.3}, spec) == pytest.approx(-0.3)
+
+
+# ─── ObjectiveSpec validation ─────────────────────────────────────────────
+
+
+class TestObjectiveSpecValidation:
+    def test_weights_must_sum_to_one(self) -> None:
+        with pytest.raises(ValueError, match="weights"):
+            ObjectiveSpec(weights={"a": 0.5, "b": 0.3})  # 0.8
+
+    def test_negative_weight_rejected(self) -> None:
+        with pytest.raises(ValueError, match="weight"):
+            ObjectiveSpec(weights={"a": 1.5, "b": -0.5})  # sums to 1 but b<0
+
+    def test_empty_weights_rejected(self) -> None:
+        with pytest.raises(ValueError, match="weights"):
+            ObjectiveSpec(weights={})
+
+    def test_floating_point_tolerance(self) -> None:
+        """0.1 * 10 isn't exactly 1.0 in float; allow small tolerance."""
+        weights = {f"m{i}": 0.1 for i in range(10)}
+        spec = ObjectiveSpec(weights=weights)
+        assert sum(spec.weights.values()) == pytest.approx(1.0)
+
+
+# ─── Named presets ────────────────────────────────────────────────────────
+
+
+class TestPresets:
+    def test_compound_return_preset_resolves(self) -> None:
+        spec = get_preset("compound-return-style")
+        assert "compound_return" in spec.weights
+        assert sum(spec.weights.values()) == pytest.approx(1.0)
+
+    def test_latency_preset_resolves(self) -> None:
+        spec = get_preset("latency-style")
+        assert sum(spec.weights.values()) == pytest.approx(1.0)
+
+    def test_unknown_preset_rejected(self) -> None:
+        with pytest.raises(ValueError, match="preset"):
+            get_preset("nonsense")
+
+    def test_presets_dict_is_immutable(self) -> None:
+        """A caller who mutates PRESETS shouldn't break other callers."""
+        spec = get_preset("compound-return-style")
+        spec.weights["compound_return"] = 999  # local mutation
+        spec2 = get_preset("compound-return-style")
+        assert spec2.weights["compound_return"] != 999
+
+
+# ─── update_best_found: scans iters, writes best_found.json ───────────────
+
+
+class TestUpdateBestFound:
+    def test_ranks_arms_by_composite_score(self, tmp_path: Path) -> None:
+        objective = ObjectiveSpec(weights={"compound_return": 1.0})
+        # Two arms in iter-1 with different metadata.compound_return values.
+        _write_iter_findings(tmp_path, 1, [
+            _arm("h-main", "CONFIRMED", {"compound_return": 0.5,
+                                          "candidate_id": "A"}),
+            _arm("h-main", "CONFIRMED", {"compound_return": 0.9,
+                                          "candidate_id": "B"}),
+        ])
+        result = update_best_found(tmp_path, objective=objective, top_k=5)
+        assert result["k"] == 5
+        # Best-first ordering
+        assert result["top_k"][0]["score"] == pytest.approx(0.9)
+        assert result["top_k"][1]["score"] == pytest.approx(0.5)
+
+    def test_merges_across_iterations(self, tmp_path: Path) -> None:
+        objective = ObjectiveSpec(weights={"compound_return": 1.0})
+        _write_iter_findings(tmp_path, 1, [
+            _arm("h-main", "CONFIRMED", {"compound_return": 0.4,
+                                          "candidate_id": "A"}),
+        ])
+        _write_iter_findings(tmp_path, 2, [
+            _arm("h-main", "CONFIRMED", {"compound_return": 0.8,
+                                          "candidate_id": "B"}),
+        ])
+        result = update_best_found(tmp_path, objective=objective, top_k=5)
+        # Iter-2's arm scored higher
+        assert result["top_k"][0]["iteration"] == 2
+        assert len(result["top_k"]) == 2
+        # Both candidates surface in candidate_id (which embeds metadata.candidate_id)
+        candidate_ids = [t["candidate_id"] for t in result["top_k"]]
+        assert any("/A" in cid for cid in candidate_ids)
+        assert any("/B" in cid for cid in candidate_ids)
+
+    def test_top_k_truncates(self, tmp_path: Path) -> None:
+        objective = ObjectiveSpec(weights={"x": 1.0})
+        for i in range(1, 6):  # 5 iterations × 1 arm each = 5 candidates
+            _write_iter_findings(tmp_path, i, [
+                _arm("h-main", "CONFIRMED", {"x": float(i),
+                                              "candidate_id": f"C{i}"}),
+            ])
+        result = update_best_found(tmp_path, objective=objective, top_k=3)
+        assert result["k"] == 3
+        assert len(result["top_k"]) == 3
+        # Ordered descending by score
+        scores = [t["score"] for t in result["top_k"]]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_writes_atomic_best_found_json(self, tmp_path: Path) -> None:
+        objective = ObjectiveSpec(weights={"x": 1.0})
+        _write_iter_findings(tmp_path, 1, [
+            _arm("h-main", "CONFIRMED", {"x": 1.0, "candidate_id": "A"}),
+        ])
+        update_best_found(tmp_path, objective=objective, top_k=5)
+        path = tmp_path / "best_found.json"
+        assert path.exists()
+        loaded = json.loads(path.read_text())
+        jsonschema.validate(loaded, _load_schema("best_found.schema.json"))
+
+    def test_legacy_no_objective_falls_back_to_prediction_accuracy(
+        self, tmp_path: Path,
+    ) -> None:
+        """Without an objective, ranks by 1.0 if CONFIRMED, 0.5 if PARTIALLY,
+        0.0 if REFUTED. Provides a sensible fallback so #169's engine-
+        continues-past-REFUTE still gets a populated best_found.json."""
+        _write_iter_findings(tmp_path, 1, [
+            _arm("h-main", "CONFIRMED"),
+            _arm("h-main", "PARTIALLY_CONFIRMED"),
+            _arm("h-main", "REFUTED"),
+        ])
+        result = update_best_found(tmp_path, objective=None, top_k=5)
+        scores = [t["score"] for t in result["top_k"]]
+        assert scores == sorted(scores, reverse=True)
+        assert scores[0] == 1.0    # CONFIRMED
+        assert scores[1] == 0.5    # PARTIALLY_CONFIRMED
+        assert scores[2] == 0.0    # REFUTED
+
+    def test_no_findings_produces_empty_top_k(self, tmp_path: Path) -> None:
+        result = update_best_found(tmp_path, objective=None, top_k=5)
+        assert result["top_k"] == []
+        assert result["k"] == 5
+
+
+# ─── Schema additions ─────────────────────────────────────────────────────
+
+
+class TestCampaignSchemaAcceptsObjective:
+    def _base_campaign(self) -> dict:
+        return {
+            "research_question": "q?",
+            "run_id": "demo",
+            "max_iterations": 1,
+            "target_system": {"name": "x", "description": "d"},
+            "prompts": {"methodology_layer": "p"},
+        }
+
+    def test_objective_block_validates(self) -> None:
+        c = self._base_campaign()
+        c["objective"] = {
+            "weights": {"a": 0.5, "b": 0.5},
+            "metric_extractors": {"a": "metadata.a"},
+            "deploy_threshold": 0.15,
+        }
+        jsonschema.validate(c, _load_schema("campaign.schema.yaml"))
+
+    def test_objective_preset_validates(self) -> None:
+        c = self._base_campaign()
+        c["objective_preset"] = "compound-return-style"
+        jsonschema.validate(c, _load_schema("campaign.schema.yaml"))
+
+    def test_legacy_no_objective_validates(self) -> None:
+        jsonschema.validate(self._base_campaign(),
+                            _load_schema("campaign.schema.yaml"))
+
+    def test_unknown_preset_name_rejected_by_schema(self) -> None:
+        c = self._base_campaign()
+        c["objective_preset"] = "unknown-preset"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(c, _load_schema("campaign.schema.yaml"))
+
+
+class TestBestFoundSchema:
+    def test_empty_best_found_validates(self) -> None:
+        payload = {"top_k": [], "k": 5, "updated_at": "2026-05-25T00:00:00Z"}
+        jsonschema.validate(payload, _load_schema("best_found.schema.json"))
+
+    def test_full_best_found_validates(self) -> None:
+        payload = {
+            "top_k": [
+                {
+                    "candidate_id": "iter-1/h-main/A",
+                    "score": 0.85,
+                    "components": {"compound_return": 0.85},
+                    "iteration": 1,
+                    "arm_id": "h-main",
+                },
+            ],
+            "k": 5,
+            "updated_at": "2026-05-25T00:00:00Z",
+        }
+        jsonschema.validate(payload, _load_schema("best_found.schema.json"))
+
+    def test_unknown_top_level_field_rejected(self) -> None:
+        payload = {"top_k": [], "k": 5, "updated_at": "2026-05-25T00:00:00Z",
+                   "surprise": "no"}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(payload, _load_schema("best_found.schema.json"))

--- a/tests/test_deployment_recommendation.py
+++ b/tests/test_deployment_recommendation.py
@@ -1,0 +1,405 @@
+"""Behavioral tests for deployment recommendation in meta_findings (issue #170).
+
+Closes the search-oriented loop (#166): pre-work seeds (#167), composite
+score ranks (#168), engine continues past REFUTE (#169), and now every
+campaign emits a shippable verdict — `deploy | deploy_with_caveats |
+fall_back_to_baseline` — with concrete citations.
+
+Decision rule:
+  * deploy  if best_score > baseline + deploy_threshold AND
+            walk_forward_consistency component > 0.7 (when present)
+  * fall_back_to_baseline  if best_score <= baseline OR best_found empty
+  * deploy_with_caveats    otherwise
+
+Test contract:
+  - All three verdicts produced on the right inputs.
+  - Citations resolve to real iteration/arm pairs in the on-disk fixture.
+  - Validator floor rejects vague caveats; caveats must cite a concrete
+    iter-N or arm marker.
+  - Schema additive: meta_findings.json with deployment_recommendation
+    validates; legacy without it is rejected (it's required-on-emit).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from orchestrator.composite_score import ObjectiveSpec, update_best_found
+from orchestrator.deployment_recommendation import (
+    DeploymentRecommendation,
+    make_deployment_recommendation,
+)
+from orchestrator.meta_findings import (
+    emit_meta_findings,
+    validate_caveat,
+    validate_evidence,
+)
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+
+
+def _load_schema(name: str) -> dict:
+    return json.loads((SCHEMAS_DIR / name).read_text())
+
+
+def _arm(arm_type: str, status: str, metadata: dict | None = None) -> dict:
+    return {
+        "arm_type": arm_type,
+        "predicted": "p", "observed": "o",
+        "status": status, "error_type": None, "diagnostic_note": "n",
+        "metadata": metadata or {},
+    }
+
+
+def _seed_workdir(
+    work_dir: Path,
+    *,
+    arms: list[dict],
+    objective: ObjectiveSpec | None,
+    pre_work_baseline: dict | None = None,
+) -> None:
+    """Set up runs/iter-1/findings.json + best_found.json + pre_work.json."""
+    iter_dir = work_dir / "runs" / "iter-1"
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    findings = {
+        "iteration": 1,
+        "bundle_ref": "runs/iter-1/bundle.yaml",
+        "arms": arms,
+        "experiment_valid": True,
+        "discrepancy_analysis": "",
+    }
+    (iter_dir / "findings.json").write_text(json.dumps(findings))
+
+    update_best_found(work_dir, objective=objective, top_k=5)
+
+    if pre_work_baseline is not None:
+        (work_dir / "pre_work.json").write_text(
+            json.dumps({"baseline_metrics": pre_work_baseline}),
+        )
+
+
+def _campaign(
+    *,
+    objective: dict | None = None,
+    objective_preset: str | None = None,
+) -> dict:
+    c: dict = {
+        "research_question": "q?",
+        "run_id": "demo",
+        "max_iterations": 1,
+        "target_system": {"name": "x", "description": "d"},
+        "prompts": {"methodology_layer": "p"},
+    }
+    if objective is not None:
+        c["objective"] = objective
+    if objective_preset is not None:
+        c["objective_preset"] = objective_preset
+    return c
+
+
+# ─── Verdict logic ────────────────────────────────────────────────────────
+
+
+class TestVerdictDeploy:
+    def test_high_score_with_high_consistency_yields_deploy(
+        self, tmp_path: Path,
+    ) -> None:
+        objective = ObjectiveSpec(weights={
+            "compound_return": 0.7, "walk_forward_consistency": 0.3,
+        })
+        _seed_workdir(
+            tmp_path,
+            arms=[_arm("h-main", "CONFIRMED", {
+                "compound_return": 0.9,
+                "walk_forward_consistency": 0.85,
+                "candidate_id": "winner",
+            })],
+            objective=objective,
+            pre_work_baseline={
+                "compound_return": 0.5,
+                "walk_forward_consistency": 0.5,
+            },
+        )
+
+        rec = make_deployment_recommendation(
+            tmp_path,
+            campaign=_campaign(objective={
+                "weights": {
+                    "compound_return": 0.7,
+                    "walk_forward_consistency": 0.3,
+                },
+                "deploy_threshold": 0.1,
+            }),
+        )
+        assert rec.verdict == "deploy"
+        assert rec.top_candidate_id is not None
+        assert "winner" in rec.top_candidate_id
+
+
+class TestVerdictFallback:
+    def test_score_below_baseline_yields_fall_back(self, tmp_path: Path) -> None:
+        objective = ObjectiveSpec(weights={"compound_return": 1.0})
+        _seed_workdir(
+            tmp_path,
+            arms=[_arm("h-main", "CONFIRMED", {
+                "compound_return": 0.3, "candidate_id": "loser",
+            })],
+            objective=objective,
+            pre_work_baseline={"compound_return": 0.5},
+        )
+
+        rec = make_deployment_recommendation(
+            tmp_path,
+            campaign=_campaign(objective={
+                "weights": {"compound_return": 1.0},
+                "deploy_threshold": 0.1,
+            }),
+        )
+        assert rec.verdict == "fall_back_to_baseline"
+
+    def test_empty_best_found_yields_fall_back(self, tmp_path: Path) -> None:
+        """No iterations completed yet → no candidate, fall back."""
+        # Don't seed anything; update_best_found writes empty top_k.
+        update_best_found(tmp_path, objective=None, top_k=5)
+        rec = make_deployment_recommendation(
+            tmp_path, campaign=_campaign(),
+        )
+        assert rec.verdict == "fall_back_to_baseline"
+
+
+class TestVerdictWithCaveats:
+    def test_high_score_low_consistency_yields_caveats(
+        self, tmp_path: Path,
+    ) -> None:
+        """Score beats baseline + threshold but consistency component
+        is below the 0.7 walk-forward bar — needs caveats."""
+        objective = ObjectiveSpec(weights={
+            "compound_return": 0.7, "walk_forward_consistency": 0.3,
+        })
+        _seed_workdir(
+            tmp_path,
+            arms=[_arm("h-main", "CONFIRMED", {
+                "compound_return": 0.9,
+                "walk_forward_consistency": 0.4,  # below 0.7 threshold
+                "candidate_id": "shaky",
+            })],
+            objective=objective,
+            pre_work_baseline={
+                "compound_return": 0.5,
+                "walk_forward_consistency": 0.5,
+            },
+        )
+        rec = make_deployment_recommendation(
+            tmp_path,
+            campaign=_campaign(objective={
+                "weights": {
+                    "compound_return": 0.7,
+                    "walk_forward_consistency": 0.3,
+                },
+                "deploy_threshold": 0.1,
+            }),
+        )
+        assert rec.verdict == "deploy_with_caveats"
+        assert rec.caveats, "verdict_with_caveats must produce at least one caveat"
+        # All caveats must cite a concrete marker (validator floor).
+        for caveat in rec.caveats:
+            assert validate_caveat(caveat) is None, (
+                f"caveat failed validator floor: {caveat!r}"
+            )
+
+    def test_marginal_score_above_baseline_yields_caveats(
+        self, tmp_path: Path,
+    ) -> None:
+        """Score beats baseline but only by less than deploy_threshold."""
+        objective = ObjectiveSpec(weights={"compound_return": 1.0})
+        _seed_workdir(
+            tmp_path,
+            arms=[_arm("h-main", "CONFIRMED", {
+                "compound_return": 0.55,  # baseline 0.5 + 0.05 < threshold 0.1
+                "candidate_id": "marginal",
+            })],
+            objective=objective,
+            pre_work_baseline={"compound_return": 0.5},
+        )
+        rec = make_deployment_recommendation(
+            tmp_path,
+            campaign=_campaign(objective={
+                "weights": {"compound_return": 1.0},
+                "deploy_threshold": 0.1,
+            }),
+        )
+        assert rec.verdict == "deploy_with_caveats"
+
+
+# ─── Citations point at real iteration/arm pairs ──────────────────────────
+
+
+class TestCitations:
+    def test_top_candidate_resolves_to_real_arm(self, tmp_path: Path) -> None:
+        objective = ObjectiveSpec(weights={"compound_return": 1.0})
+        _seed_workdir(
+            tmp_path,
+            arms=[_arm("h-main", "CONFIRMED", {
+                "compound_return": 0.9, "candidate_id": "winner",
+            })],
+            objective=objective,
+            pre_work_baseline={"compound_return": 0.0},
+        )
+        rec = make_deployment_recommendation(
+            tmp_path,
+            campaign=_campaign(objective={
+                "weights": {"compound_return": 1.0}, "deploy_threshold": 0.1,
+            }),
+        )
+        assert rec.citations
+        for c in rec.citations:
+            assert c["iteration"] == 1
+            assert c["arm_id"] == "h-main"
+            assert validate_evidence(c["evidence_snippet"]) is None
+
+
+# ─── Validator floor on caveats ───────────────────────────────────────────
+
+
+class TestValidatorFloor:
+    def test_vague_caveat_rejected(self) -> None:
+        err = validate_caveat("things looked promising")
+        assert err is not None
+        assert "vague" in err.lower() or "concrete" in err.lower()
+
+    def test_concrete_caveat_passes(self) -> None:
+        text = "iter-2 arm h-main: walk_forward_consistency = 0.4 (< 0.7)"
+        assert validate_caveat(text) is None
+
+    def test_short_caveat_rejected(self) -> None:
+        err = validate_caveat("ok")
+        assert err is not None
+
+
+# ─── meta_findings.emit emits deployment_recommendation ───────────────────
+
+
+class TestMetaFindingsIntegration:
+    def test_emit_includes_deployment_recommendation(
+        self, tmp_path: Path,
+    ) -> None:
+        objective = ObjectiveSpec(weights={"compound_return": 1.0})
+        _seed_workdir(
+            tmp_path,
+            arms=[_arm("h-main", "CONFIRMED", {
+                "compound_return": 0.9, "candidate_id": "winner",
+            })],
+            objective=objective,
+            pre_work_baseline={"compound_return": 0.0},
+        )
+        # Set up minimal state.json
+        (tmp_path / "state.json").write_text(json.dumps({
+            "phase": "DONE", "iteration": 1, "run_id": "demo",
+            "family": None, "timestamp": "2026-05-25T00:00:00Z",
+        }))
+
+        payload = emit_meta_findings(
+            tmp_path,
+            campaign=_campaign(objective={
+                "weights": {"compound_return": 1.0}, "deploy_threshold": 0.1,
+            }),
+        )
+        assert "deployment_recommendation" in payload
+        assert payload["deployment_recommendation"]["verdict"] == "deploy"
+
+        # Schema accepts the new required field.
+        jsonschema.validate(payload, _load_schema("meta_findings.schema.json"))
+
+    def test_legacy_payload_without_deployment_recommendation_rejected(
+        self,
+    ) -> None:
+        """The field is required-on-emit. Schema enforces it."""
+        legacy = {
+            "schema_version": "1",
+            "campaign_design_lessons": [],
+            "target_system_asks": [],
+            "nous_asks": [],
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(legacy, _load_schema("meta_findings.schema.json"))
+
+
+# ─── Schema acceptance ────────────────────────────────────────────────────
+
+
+class TestDeploymentRecommendationSchema:
+    def test_full_recommendation_validates(self) -> None:
+        payload = {
+            "schema_version": "1",
+            "campaign_design_lessons": [],
+            "target_system_asks": [],
+            "nous_asks": [],
+            "deployment_recommendation": {
+                "verdict": "deploy",
+                "top_candidate_id": "iter-1/h-main/winner",
+                "score": 0.9,
+                "citations": [
+                    {
+                        "iteration": 1,
+                        "arm_id": "h-main",
+                        "evidence_snippet": "iter-1 arm h-main score=0.9",
+                    },
+                ],
+                "caveats": [],
+            },
+        }
+        jsonschema.validate(payload, _load_schema("meta_findings.schema.json"))
+
+    def test_invalid_verdict_rejected(self) -> None:
+        payload = {
+            "schema_version": "1",
+            "campaign_design_lessons": [],
+            "target_system_asks": [],
+            "nous_asks": [],
+            "deployment_recommendation": {
+                "verdict": "ship_it_yolo",
+                "top_candidate_id": None,
+                "score": None,
+                "citations": [],
+                "caveats": [],
+            },
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(payload, _load_schema("meta_findings.schema.json"))
+
+    def test_fall_back_with_null_candidate_validates(self) -> None:
+        payload = {
+            "schema_version": "1",
+            "campaign_design_lessons": [],
+            "target_system_asks": [],
+            "nous_asks": [],
+            "deployment_recommendation": {
+                "verdict": "fall_back_to_baseline",
+                "top_candidate_id": None,
+                "score": None,
+                "citations": [],
+                "caveats": [],
+            },
+        }
+        jsonschema.validate(payload, _load_schema("meta_findings.schema.json"))
+
+
+# ─── DeploymentRecommendation result shape ────────────────────────────────
+
+
+class TestResultShape:
+    def test_result_carries_typed_fields(self, tmp_path: Path) -> None:
+        update_best_found(tmp_path, objective=None, top_k=5)
+        rec = make_deployment_recommendation(
+            tmp_path, campaign=_campaign(),
+        )
+        assert isinstance(rec, DeploymentRecommendation)
+        assert rec.verdict in {
+            "deploy", "deploy_with_caveats", "fall_back_to_baseline",
+        }
+        assert isinstance(rec.citations, list)
+        assert isinstance(rec.caveats, list)

--- a/tests/test_engine_search_continuation.py
+++ b/tests/test_engine_search_continuation.py
@@ -1,0 +1,266 @@
+"""Behavioral tests for engine search-continuation past REFUTE (issue #169).
+
+Auditing the inference-sim ledgers (May 2026): mech-design-kvtime,
+fp-delay-frontier, sgsf-unification all REFUTED at iter-1 and walked
+away producing nothing deployable. The engine itself doesn't have a
+REFUTE → DONE shortcut, but the conventional flow today emits no
+constraint principles either, so the next iteration's designer
+gets no help avoiding the dead end.
+
+This commit closes both halves:
+  * Regression: assert the state machine has no REFUTE-driven path
+    to DONE (only HUMAN_FINDINGS_GATE → DONE via human approval).
+  * Generation: deterministic Python that turns each REFUTED arm
+    into a category=meta constraint principle, recorded in
+    principles.json so the next DESIGN reads it.
+
+Test contract:
+  - Engine transition map continues to allow HUMAN_FINDINGS_GATE →
+    EXECUTE_ANALYZE (the redesign loop), NOT a direct DONE for REFUTE.
+  - make_constraints_from_findings produces one constraint per REFUTED
+    arm, zero for CONFIRMED/PARTIALLY_CONFIRMED.
+  - apply_refute_constraints reads runs/iter-N/findings.json and
+    writes constraints into principles.json atomically. Idempotent
+    when re-run on the same findings.
+  - All emitted principles carry category=meta and a clear
+    "Refuted: ..." statement plus an applicability_bounds capturing
+    where it failed.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestrator.engine import TRANSITIONS
+from orchestrator.refute_constraints import (
+    apply_refute_constraints,
+    make_constraints_from_findings,
+)
+
+
+def _arm(arm_type: str, status: str, **extra) -> dict:
+    return {
+        "arm_type": arm_type,
+        "predicted": extra.get("predicted", "p"),
+        "observed": extra.get("observed", "o"),
+        "status": status,
+        "error_type": None,
+        "diagnostic_note": "n",
+        "metadata": extra.get("metadata", {}),
+    }
+
+
+def _findings(arms: list[dict], iteration: int = 1) -> dict:
+    return {
+        "iteration": iteration,
+        "bundle_ref": f"runs/iter-{iteration}/bundle.yaml",
+        "arms": arms,
+        "experiment_valid": True,
+        "discrepancy_analysis": "",
+    }
+
+
+def _write_iter(work_dir: Path, iteration: int, findings: dict) -> None:
+    iter_dir = work_dir / "runs" / f"iter-{iteration}"
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    (iter_dir / "findings.json").write_text(json.dumps(findings))
+
+
+def _write_principles(work_dir: Path, principles: list) -> None:
+    (work_dir / "principles.json").write_text(
+        json.dumps({"principles": principles}),
+    )
+
+
+# ─── Engine state-machine regression ──────────────────────────────────────
+
+
+class TestEngineDoesNotAutoTerminateOnRefute:
+    def test_human_findings_gate_can_loop_back_to_execute_analyze(self) -> None:
+        """The redesign loop is intact — REFUTE flows back through this path."""
+        assert "EXECUTE_ANALYZE" in TRANSITIONS["HUMAN_FINDINGS_GATE"]
+
+    def test_human_findings_gate_can_reach_done(self) -> None:
+        """DONE remains reachable from HUMAN_FINDINGS_GATE — the human
+        gate exists precisely so a human can end the campaign. The
+        important property is that REFUTE doesn't bypass that gate."""
+        assert "DONE" in TRANSITIONS["HUMAN_FINDINGS_GATE"]
+
+    def test_no_state_offers_a_direct_path_to_done_other_than_findings_gate(
+        self,
+    ) -> None:
+        """Audit: the only state allowed to transition to DONE is
+        HUMAN_FINDINGS_GATE. No automatic short-circuit."""
+        states_with_done = {
+            from_state for from_state, dests in TRANSITIONS.items()
+            if "DONE" in dests
+        }
+        assert states_with_done == {"HUMAN_FINDINGS_GATE"}
+
+
+# ─── make_constraints_from_findings: pure function ────────────────────────
+
+
+class TestMakeConstraints:
+    def test_refuted_arm_produces_one_constraint(self) -> None:
+        findings = _findings([_arm("h-main", "REFUTED")])
+        constraints = make_constraints_from_findings(
+            findings, iteration=1, family="burst-aware-noise-floor",
+        )
+        assert len(constraints) == 1
+        c = constraints[0]
+        assert c["category"] == "meta"
+        assert c["status"] == "active"
+        assert "Refuted" in c["statement"] or "refuted" in c["statement"]
+        assert c["extraction_iteration"] == 1
+        # Family is captured in the regime / applicability_bounds
+        assert "burst-aware-noise-floor" in (c["regime"] + c["applicability_bounds"])
+
+    def test_confirmed_arm_produces_no_constraint(self) -> None:
+        findings = _findings([_arm("h-main", "CONFIRMED")])
+        constraints = make_constraints_from_findings(
+            findings, iteration=1, family="x",
+        )
+        assert constraints == []
+
+    def test_partially_confirmed_arm_produces_no_constraint(self) -> None:
+        """Partial = redirect, not eliminate. Constraints come only from
+        full refutations."""
+        findings = _findings([_arm("h-main", "PARTIALLY_CONFIRMED")])
+        constraints = make_constraints_from_findings(
+            findings, iteration=1, family="x",
+        )
+        assert constraints == []
+
+    def test_multiple_refuted_arms_produce_multiple_constraints(self) -> None:
+        findings = _findings([
+            _arm("h-main", "REFUTED"),
+            _arm("h-ablation", "REFUTED"),
+            _arm("h-control-negative", "CONFIRMED"),
+        ])
+        constraints = make_constraints_from_findings(
+            findings, iteration=2, family="x",
+        )
+        assert len(constraints) == 2
+        types = sorted(c["statement"] for c in constraints)
+        # Different arms produce distinguishable statements
+        assert types[0] != types[1]
+
+    def test_existing_ids_prevent_duplicates(self) -> None:
+        """Idempotent: if a constraint with the same id was already
+        recorded in a previous run, don't emit it again."""
+        findings = _findings([_arm("h-main", "REFUTED")])
+        first = make_constraints_from_findings(
+            findings, iteration=1, family="x",
+        )
+        existing = {c["id"] for c in first}
+        second = make_constraints_from_findings(
+            findings, iteration=1, family="x", existing_ids=existing,
+        )
+        assert second == []
+
+    def test_all_emitted_constraints_have_category_meta(self) -> None:
+        findings = _findings([
+            _arm("h-main", "REFUTED"),
+            _arm("h-robustness", "REFUTED"),
+        ])
+        constraints = make_constraints_from_findings(
+            findings, iteration=1, family="x",
+        )
+        for c in constraints:
+            assert c["category"] == "meta"
+
+
+# ─── apply_refute_constraints: end-to-end on disk ─────────────────────────
+
+
+class TestApplyRefuteConstraints:
+    def test_replay_inserts_constraints_into_principles_json(
+        self, tmp_path: Path,
+    ) -> None:
+        """Mirrors a mech-design-kvtime-shaped iter-1: all REFUTED, no
+        prior principles. After apply, principles.json has constraint
+        rows with category=meta."""
+        _write_iter(tmp_path, 1, _findings([
+            _arm("h-main", "REFUTED"),
+            _arm("h-ablation", "REFUTED"),
+        ]))
+        _write_principles(tmp_path, [])
+
+        applied = apply_refute_constraints(
+            tmp_path, iteration=1, family="kvtime-discrimination",
+        )
+
+        on_disk = json.loads((tmp_path / "principles.json").read_text())
+        assert len(on_disk["principles"]) == len(applied) == 2
+        assert all(p["category"] == "meta" for p in on_disk["principles"])
+        assert all("kvtime" in p["regime"] + p["applicability_bounds"]
+                   for p in on_disk["principles"])
+
+    def test_replay_preserves_existing_principles(
+        self, tmp_path: Path,
+    ) -> None:
+        """Existing domain principles aren't disturbed by new constraint
+        emissions."""
+        prior = {
+            "id": "RP-1", "statement": "existing", "confidence": "medium",
+            "regime": "", "evidence": [], "contradicts": [],
+            "extraction_iteration": 0, "mechanism": "",
+            "applicability_bounds": "", "superseded_by": None,
+            "status": "active", "category": "domain",
+        }
+        _write_iter(tmp_path, 1, _findings([_arm("h-main", "REFUTED")]))
+        _write_principles(tmp_path, [prior])
+
+        apply_refute_constraints(tmp_path, iteration=1, family="x")
+
+        on_disk = json.loads((tmp_path / "principles.json").read_text())
+        ids = [p["id"] for p in on_disk["principles"]]
+        assert "RP-1" in ids
+        assert len(on_disk["principles"]) == 2  # RP-1 + new constraint
+
+    def test_idempotent_replay_does_not_duplicate(
+        self, tmp_path: Path,
+    ) -> None:
+        """Running the same iteration twice produces the same
+        principles file — recovery / re-execution must not duplicate."""
+        _write_iter(tmp_path, 1, _findings([_arm("h-main", "REFUTED")]))
+        _write_principles(tmp_path, [])
+
+        apply_refute_constraints(tmp_path, iteration=1, family="x")
+        first = json.loads((tmp_path / "principles.json").read_text())
+
+        apply_refute_constraints(tmp_path, iteration=1, family="x")
+        second = json.loads((tmp_path / "principles.json").read_text())
+
+        assert first == second
+
+    def test_no_refuted_arms_no_change_to_principles(
+        self, tmp_path: Path,
+    ) -> None:
+        _write_iter(tmp_path, 1, _findings([_arm("h-main", "CONFIRMED")]))
+        _write_principles(tmp_path, [])
+
+        apply_refute_constraints(tmp_path, iteration=1, family="x")
+
+        on_disk = json.loads((tmp_path / "principles.json").read_text())
+        assert on_disk["principles"] == []
+
+    def test_missing_findings_is_no_op(self, tmp_path: Path) -> None:
+        """No findings.json → don't crash, don't write."""
+        _write_principles(tmp_path, [])
+        result = apply_refute_constraints(tmp_path, iteration=1, family="x")
+        assert result == []
+
+    def test_methodology_prompt_describes_constraint_reading(self) -> None:
+        """design.md tells the LLM what to do with category=meta principles
+        whose statement starts with 'Refuted'."""
+        prompt = (Path(__file__).resolve().parent.parent
+                  / "prompts" / "methodology" / "design.md")
+        text = prompt.read_text()
+        # Either the explicit blurb or some structured guidance about
+        # refuted-mechanism constraints must be present.
+        assert "Refuted" in text or "refuted" in text
+        assert "category=meta" in text or "constraint" in text.lower()

--- a/tests/test_meta_findings.py
+++ b/tests/test_meta_findings.py
@@ -328,6 +328,11 @@ class TestValidatorRejectsVague:
             ],
             "target_system_asks": [],
             "nous_asks": [],
+            "deployment_recommendation": {
+                "verdict": "fall_back_to_baseline",
+                "top_candidate_id": None, "score": None,
+                "citations": [], "caveats": [],
+            },
         }
         (work_dir / "meta_findings.json").write_text(json.dumps(bad))
 
@@ -355,6 +360,11 @@ class TestValidatorRejectsVague:
             ],
             "target_system_asks": [],
             "nous_asks": [],
+            "deployment_recommendation": {
+                "verdict": "fall_back_to_baseline",
+                "top_candidate_id": None, "score": None,
+                "citations": [], "caveats": [],
+            },
         }
         (work_dir / "meta_findings.json").write_text(json.dumps(good))
 

--- a/tests/test_pre_work.py
+++ b/tests/test_pre_work.py
@@ -1,0 +1,338 @@
+"""Behavioral tests for the PRE_WORK phase (issue #167).
+
+PRE_WORK runs before iter-1 DESIGN, performing cheap deterministic
+exploration of the target system to inform the campaign's iteration
+structure. The artifact is `pre_work.json` at the campaign root.
+
+Test contract:
+  - Module-level `run_pre_work(campaign, runner=)` honors injected runners
+    and chooses the right default behavior given campaign config.
+  - Schema additions are additive: legacy state.json + campaign.yaml validate.
+  - PRE_WORK is a recognized phase in engine.Phase + transition map.
+  - subprocess hook for `pre_work_script` is mockable; no live subprocess
+    in tests.
+  - pre_work.json validates against pre_work.schema.json; all fields optional.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.engine import Phase, TRANSITIONS
+from orchestrator.pre_work import (
+    PreWorkResult,
+    run_pre_work,
+    write_pre_work,
+)
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+
+
+def _load_schema(name: str) -> dict:
+    path = SCHEMAS_DIR / name
+    if path.suffix in (".yaml", ".yml"):
+        return yaml.safe_load(path.read_text())
+    return json.loads(path.read_text())
+
+
+# ─── Default runner: Python summary of campaign + repo_cache ──────────────
+
+
+class TestDefaultRunner:
+    def test_default_runner_returns_pre_work_result(self) -> None:
+        """With no pre_work_script and no repo_cache, default still returns a result."""
+        campaign = {
+            "run_id": "test",
+            "target_system": {"name": "demo", "description": "d"},
+        }
+        result = run_pre_work(campaign)
+        assert isinstance(result, PreWorkResult)
+
+    def test_default_runner_summarizes_target_system(self) -> None:
+        """data_summary captures observable_metrics + controllable_knobs from campaign.yaml."""
+        campaign = {
+            "run_id": "demo",
+            "target_system": {
+                "name": "demo",
+                "description": "d",
+                "observable_metrics": ["latency_p50", "throughput"],
+                "controllable_knobs": ["batch_size", "concurrency"],
+            },
+        }
+        result = run_pre_work(campaign)
+        assert result.data_summary is not None
+        assert "observable_metrics" in result.data_summary
+        assert "latency_p50" in result.data_summary["observable_metrics"]
+        assert "controllable_knobs" in result.data_summary
+        assert "batch_size" in result.data_summary["controllable_knobs"]
+
+    def test_default_runner_is_deterministic(self) -> None:
+        """Calling twice on the same campaign returns equal results — no randomness."""
+        campaign = {
+            "run_id": "demo",
+            "target_system": {
+                "name": "x",
+                "observable_metrics": ["m1"],
+                "controllable_knobs": ["k1"],
+            },
+        }
+        a = run_pre_work(campaign)
+        b = run_pre_work(campaign)
+        assert a.data_summary == b.data_summary
+
+
+# ─── Subprocess runner: pre_work_script declared in campaign.yaml ─────────
+
+
+class TestSubprocessRunner:
+    def test_pre_work_script_subprocess_is_called(
+        self, monkeypatch, tmp_path: Path,
+    ) -> None:
+        """When pre_work_script is set, the default path subprocesses it."""
+        script = tmp_path / "explore.py"
+        script.write_text("# fake")
+        campaign = {
+            "run_id": "demo",
+            "target_system": {"name": "x"},
+            "pre_work_script": str(script),
+        }
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append(list(cmd))
+            stdout = json.dumps({
+                "data_summary": {"rows": 1000},
+                "candidate_parameter_ranges": {"rate": [0.1, 10.0]},
+            })
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr("orchestrator.pre_work.subprocess.run", fake_run)
+
+        result = run_pre_work(campaign)
+        assert result.data_summary == {"rows": 1000}
+        assert result.candidate_parameter_ranges == {"rate": [0.1, 10.0]}
+        assert len(captured) == 1
+        assert str(script) in captured[0]
+
+    def test_subprocess_runner_handles_nonzero_exit(
+        self, monkeypatch, tmp_path: Path,
+    ) -> None:
+        """A failing pre_work_script yields an empty PreWorkResult; campaign continues."""
+        script = tmp_path / "explore.py"
+        script.write_text("# fake")
+        campaign = {
+            "run_id": "demo",
+            "target_system": {"name": "x"},
+            "pre_work_script": str(script),
+        }
+
+        def failing_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom")
+
+        monkeypatch.setattr("orchestrator.pre_work.subprocess.run", failing_run)
+
+        result = run_pre_work(campaign)
+        # No crash. PreWorkResult has all-None fields — DESIGN proceeds normally.
+        assert isinstance(result, PreWorkResult)
+        assert result.data_summary is None
+
+    def test_subprocess_runner_handles_invalid_json(
+        self, monkeypatch, tmp_path: Path,
+    ) -> None:
+        """Invalid JSON output yields empty PreWorkResult, not a crash."""
+        script = tmp_path / "explore.py"
+        script.write_text("# fake")
+        campaign = {
+            "run_id": "demo",
+            "target_system": {"name": "x"},
+            "pre_work_script": str(script),
+        }
+
+        def bad_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout="not json", stderr="")
+
+        monkeypatch.setattr("orchestrator.pre_work.subprocess.run", bad_run)
+        result = run_pre_work(campaign)
+        assert isinstance(result, PreWorkResult)
+        assert result.data_summary is None
+
+
+# ─── Injection seam: runner= replaces both default behaviors ──────────────
+
+
+class TestRunnerInjection:
+    def test_injected_runner_replaces_default(self) -> None:
+        invocations: list[dict] = []
+
+        def fake_runner(campaign):
+            invocations.append(campaign)
+            return PreWorkResult(
+                data_summary={"injected": True},
+                candidate_parameter_ranges=None,
+                structural_groupings=["A", "B"],
+                baseline_metrics=None,
+                recommended_arms_for_iter1=None,
+            )
+
+        result = run_pre_work({"run_id": "x"}, runner=fake_runner)
+        assert result.data_summary == {"injected": True}
+        assert result.structural_groupings == ["A", "B"]
+        assert len(invocations) == 1
+
+    def test_injected_runner_overrides_pre_work_script(
+        self, monkeypatch,
+    ) -> None:
+        """Even when pre_work_script is set, runner= takes precedence (test discipline)."""
+        called = {"subprocess": 0, "injected": 0}
+
+        def fake_subprocess_run(*args, **kwargs):
+            called["subprocess"] += 1
+            return subprocess.CompletedProcess([], 0, stdout="{}", stderr="")
+
+        def injected(campaign):
+            called["injected"] += 1
+            return PreWorkResult()
+
+        monkeypatch.setattr("orchestrator.pre_work.subprocess.run", fake_subprocess_run)
+        run_pre_work(
+            {"run_id": "x", "pre_work_script": "/fake/path.py"},
+            runner=injected,
+        )
+        assert called["injected"] == 1
+        assert called["subprocess"] == 0
+
+
+# ─── Atomic write to pre_work.json ────────────────────────────────────────
+
+
+class TestWritePreWork:
+    def test_write_round_trips_through_schema(self, tmp_path: Path) -> None:
+        result = PreWorkResult(
+            data_summary={"rows": 42},
+            candidate_parameter_ranges={"rate": [0.0, 10.0]},
+            structural_groupings=[{"name": "g1", "members": ["m1", "m2"]}],
+            baseline_metrics={"throughput": 100.0},
+            recommended_arms_for_iter1=["focus on rate above 5"],
+        )
+        path = write_pre_work(tmp_path, result)
+        assert path == tmp_path / "pre_work.json"
+
+        on_disk = json.loads(path.read_text())
+        jsonschema.validate(on_disk, _load_schema("pre_work.schema.json"))
+
+        # Round-trips
+        assert on_disk["data_summary"] == {"rows": 42}
+        assert on_disk["recommended_arms_for_iter1"] == ["focus on rate above 5"]
+
+    def test_write_empty_result_validates(self, tmp_path: Path) -> None:
+        """All-None fields produce a minimal-but-valid pre_work.json."""
+        path = write_pre_work(tmp_path, PreWorkResult())
+        on_disk = json.loads(path.read_text())
+        jsonschema.validate(on_disk, _load_schema("pre_work.schema.json"))
+
+
+# ─── Engine: PRE_WORK is a recognized phase ───────────────────────────────
+
+
+class TestPhaseRegistration:
+    def test_pre_work_is_in_phase_enum(self) -> None:
+        assert Phase.PRE_WORK.value == "PRE_WORK"
+
+    def test_init_can_transition_to_pre_work(self) -> None:
+        assert "PRE_WORK" in TRANSITIONS["INIT"]
+
+    def test_pre_work_can_transition_to_design(self) -> None:
+        assert "DESIGN" in TRANSITIONS["PRE_WORK"]
+
+    def test_init_to_design_still_allowed(self) -> None:
+        """Backward-compat: legacy campaigns can still skip PRE_WORK."""
+        assert "DESIGN" in TRANSITIONS["INIT"]
+
+
+# ─── Schema additions ─────────────────────────────────────────────────────
+
+
+class TestSchemaAcceptsPreWorkPhase:
+    def test_state_with_pre_work_phase_validates(self) -> None:
+        state = {
+            "phase": "PRE_WORK",
+            "iteration": 0,
+            "run_id": "demo",
+            "family": None,
+            "timestamp": "2026-05-25T00:00:00Z",
+        }
+        jsonschema.validate(state, _load_schema("state.schema.json"))
+
+    def test_legacy_state_without_pre_work_validates(self) -> None:
+        state = {
+            "phase": "DESIGN",
+            "iteration": 1,
+            "run_id": "demo",
+            "family": None,
+            "timestamp": "2026-05-25T00:00:00Z",
+        }
+        jsonschema.validate(state, _load_schema("state.schema.json"))
+
+
+class TestSchemaAcceptsPreWorkScript:
+    def test_campaign_with_pre_work_script_validates(self) -> None:
+        campaign = {
+            "research_question": "q?",
+            "run_id": "demo",
+            "max_iterations": 1,
+            "target_system": {"name": "x", "description": "d"},
+            "prompts": {"methodology_layer": "p"},
+            "pre_work_script": "scripts/explore.py",
+        }
+        jsonschema.validate(campaign, _load_schema("campaign.schema.yaml"))
+
+    def test_legacy_campaign_without_pre_work_script_validates(self) -> None:
+        campaign = {
+            "research_question": "q?",
+            "run_id": "demo",
+            "max_iterations": 1,
+            "target_system": {"name": "x", "description": "d"},
+            "prompts": {"methodology_layer": "p"},
+        }
+        jsonschema.validate(campaign, _load_schema("campaign.schema.yaml"))
+
+    def test_examples_campaign_yaml_still_validates(self) -> None:
+        """Real-world examples/campaign.yaml passes the updated schema."""
+        examples = (Path(__file__).resolve().parent.parent
+                    / "examples" / "campaign.yaml")
+        if not examples.exists():
+            pytest.skip("examples/campaign.yaml not present")
+        loaded = yaml.safe_load(examples.read_text())
+        jsonschema.validate(loaded, _load_schema("campaign.schema.yaml"))
+
+
+# ─── pre_work.schema.json shape ───────────────────────────────────────────
+
+
+class TestPreWorkSchema:
+    def test_empty_object_validates(self) -> None:
+        jsonschema.validate({}, _load_schema("pre_work.schema.json"))
+
+    def test_full_object_validates(self) -> None:
+        payload = {
+            "data_summary": {"rows": 100},
+            "candidate_parameter_ranges": {"rate": [0.0, 10.0]},
+            "structural_groupings": [{"name": "g1"}],
+            "baseline_metrics": {"throughput": 100.0},
+            "recommended_arms_for_iter1": ["arm description"],
+        }
+        jsonschema.validate(payload, _load_schema("pre_work.schema.json"))
+
+    def test_unknown_top_level_field_rejected(self) -> None:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(
+                {"surprise": "value"},
+                _load_schema("pre_work.schema.json"),
+            )


### PR DESCRIPTION
Reframes Nous campaigns from hypothesis-test (stop on refute) to outcome-search (always emit a deployable winner). Pre-work seeds → composite score ranks → engine continues past REFUTE → deployment recommendation says ship/don't-ship. Each piece is **opt-in / schema-additive**, adds **zero LLM tokens** at the engine seam (per `CLAUDE.md` test policy), and ships behind a constructor injection point so tests run without live calls.

## Why

From the 29-campaign audit (`inference-sim/.nous`, May 2026):
- `mech-design-kvtime`, `fp-delay-frontier`, `sgsf-unification` REFUTED at iter-1 and walked away producing nothing — even though the simulator runs contained signal about which configs were *closer* to deployable.
- `composite-sensitivity-boundary` ran 5 iters × ~65 sim units with prediction accuracy stuck at 50% — a deterministic CC_RD distribution plot in pre-work would have right-sized N and likely cut a full iteration.
- User feedback (2026-05-25, trading-strategy campaign): "the objective here is not merely confirming and refuting hypothesis for the sake of it. The objective here is, actually find a really good structure that we can profit from."

## What lands (in order, A → B → C → D)

### feat: PRE_WORK phase (eafe920) — Closes #167
- New `Phase.PRE_WORK` between `INIT` and `DESIGN`. Transition map allows BOTH `INIT → PRE_WORK → DESIGN` (opt-in) and `INIT → DESIGN` (legacy).
- `orchestrator/pre_work.py` with `run_pre_work(campaign, runner=None) -> PreWorkResult`. Three runner modes via one seam: injected fake (test), `pre_work_script` subprocess (user-supplied exploration), or default Python summary of campaign fields. All three failure modes (missing script, non-zero exit, invalid JSON) yield an empty result so DESIGN proceeds unchanged.
- Schemas: `state.schema.json` accepts `PRE_WORK`; `campaign.schema.yaml` accepts optional `pre_work_script`; new `pre_work.schema.json` with all-optional fields. `iteration._PHASE_ORDER` updated for resume parity.
- 22 behavioral tests; no live subprocess.

### feat: composite scoring + best_found.json (42ac6de) — Closes #168
- `orchestrator/composite_score.py` with `compute_score`, `ObjectiveSpec` (weight-sum validation with float tolerance, ≥0 weights), `get_preset` (immutable per-call return), and `update_best_found` (walks `runs/iter-N/findings.json`, ranks, atomic-writes `best_found.json`).
- Two named presets: `compound-return-style` (50/30/10/10) and `latency-style` (40/30/20/10). Adding new presets requires a schema change so users can never silently inherit weights they didn't see.
- Schemas: `campaign.schema.yaml` accepts optional `objective` block AND `objective_preset` (closed enum); new `best_found.schema.json` with strict shape.
- Legacy fallback: no objective ⇒ rank by status (CONFIRMED=1.0, PARTIALLY_CONFIRMED=0.5, REFUTED=0.0). Guarantees that #169's engine-continues-past-REFUTE flow always has a populated `best_found.json` to point at.
- 25 behavioral tests; pure deterministic Python.

### feat: engine search continuation past REFUTE (fb4c9af) — Closes #169
- The engine state machine doesn't have a `REFUTE → DONE` shortcut today — that's confirmed by a regression test asserting `HUMAN_FINDINGS_GATE` is the *only* state with a `DONE` transition. The actual change is **deterministic constraint-principle generation**.
- `orchestrator/refute_constraints.py` with `make_constraints_from_findings` (one constraint per REFUTED arm, idempotent via `existing_ids`) and `apply_refute_constraints` (read findings.json, merge into principles.json atomically). Tolerant of missing/corrupt files.
- Every emitted constraint carries `category=meta`, `confidence=high`, statement starting `Refuted: family=...`, and `applicability_bounds = family + iter-N + observed snippet`.
- Methodology prompt (`prompts/methodology/design.md`, cached system block) gains a Refuted-mechanism-constraints section: read before next bundle, treat as no-go zones, cite when redirecting search.
- 15 behavioral tests covering engine state-machine regression + constraint generation + end-to-end apply.

### feat: deployment recommendation (4419f37) — Closes #170
- `orchestrator/deployment_recommendation.py` with `make_deployment_recommendation(work_dir, campaign=)` reading `best_found.json` + `pre_work.json` baseline_metrics. Decision rule:
  - `deploy` if `best_score > baseline + threshold` AND `walk_forward_consistency > 0.7` (when present)
  - `fall_back_to_baseline` if `best_score <= baseline` OR no candidate
  - `deploy_with_caveats` otherwise
- `meta_findings.emit_meta_findings` now includes `deployment_recommendation` in the payload — every campaign emits a shippable verdict. New `validate_caveat` function applies the same citation floor as `validate_evidence`: caveats must cite an `iter-N` + arm + numeric marker.
- Schema: `meta_findings.schema.json` adds `deployment_recommendation` as a **required-on-emit** field with closed verdict enum, citation shape, and min-length caveat strings. Two pre-existing test fixtures updated as schema-migration consequence.
- 15 behavioral tests covering all three verdicts, citation shape, validator floor, end-to-end emit, schema acceptance.

## Test discipline (CLAUDE.md)

**No live LLM, MCMC, Optuna trial, or subprocess calls in tests.** Every new module ships with a constructor injection seam (`runner=`, `objective=None`, etc.). All four sub-PRs follow the seam-and-fixture pattern from #171 (the just-merged statistical-rigor PR).

## Test counts

```
tests/test_pre_work.py                         22 passed
tests/test_composite_score.py                  25 passed
tests/test_engine_search_continuation.py       15 passed
tests/test_deployment_recommendation.py        15 passed
full suite                                    739 passed,  2 skipped, exit 0
```
(2 pre-existing failures in `test_llm_dispatch.py::TestNoApiKey` are SOCKS-proxy / `httpx[socks]` env issues unrelated to this work.)

## Token-budget impact

Zero. All new modules are pure deterministic Python. The cached methodology blurb in `design.md` adds ~250 tokens to the system block, paid once per session.

## Relationship to #162

#162 (just merged) made the existing methodology rigorous (power, posteriors, sweeps); #166 makes it outcome-oriented (search instead of hypothesis-test). No file overlap, no schema collisions. Branched off the post-merge `upstream/reflective` so the test-discipline patterns established in #171 (PyMC + Optuna conftest blockers, deterministic-injection-seam pattern) are reused throughout.

Closes #167.
Closes #168.
Closes #169.
Closes #170.
Refs #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
