### PR TITLE
Tracking #176: sort_bench-surfaced integration gaps (3 children)

### DIFF
--- a/orchestrator/deployment_recommendation.py
+++ b/orchestrator/deployment_recommendation.py
@@ -173,14 +173,48 @@ def make_deployment_recommendation(
     caveats) when there's nothing to recommend — never raises.
     """
     work_dir = Path(work_dir)
-    best_found = _read_json(work_dir / "best_found.json")
+    best_found_path = work_dir / "best_found.json"
+    best_found = _read_json(best_found_path)
 
-    if not best_found or not best_found.get("top_k"):
-        return DeploymentRecommendation(verdict="fall_back_to_baseline")
+    # Issue #178: distinguish "no candidate beat baseline" (genuine
+    # fall-back) from "best_found.json is missing" (upstream wiring
+    # gap — see #177). Both keep the conservative fall_back_to_baseline
+    # verdict, but the caveats now tell the operator what actually
+    # happened. Each caveat passes meta_findings.validate_caveat
+    # (cites a concrete artifact name + numeric / issue reference).
+    if best_found is None:
+        return DeploymentRecommendation(
+            verdict="fall_back_to_baseline",
+            caveats=[
+                f"best_found.json not present at {best_found_path}; "
+                f"cannot rank candidates. The iteration finalize step "
+                f"either did not run or did not call update_best_found. "
+                f"See issue #177 in orchestrator/iteration.py."
+            ],
+        )
+
+    if not best_found.get("top_k"):
+        return DeploymentRecommendation(
+            verdict="fall_back_to_baseline",
+            caveats=[
+                f"best_found.json present at {best_found_path} but "
+                f"top_k is empty (k={best_found.get('k', 0)}); no "
+                f"candidate scored above baseline across the iterations "
+                f"recorded in runs/iter-N/findings.json."
+            ],
+        )
 
     top = best_found["top_k"][0]
     if not isinstance(top, dict):
-        return DeploymentRecommendation(verdict="fall_back_to_baseline")
+        return DeploymentRecommendation(
+            verdict="fall_back_to_baseline",
+            caveats=[
+                f"best_found.json top_k[0] has unexpected type "
+                f"{type(top).__name__!r} at {best_found_path}; "
+                f"expected dict. Investigate whether update_best_found "
+                f"wrote a corrupt entry — see issue #177."
+            ],
+        )
 
     best_score = float(top.get("score", 0.0))
     iteration = int(top.get("iteration", 0))

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -162,6 +162,79 @@ def _enter_phase(engine, phase):
     return True
 
 
+def _resolve_objective(campaign: dict):
+    """Resolve campaign.yaml's objective block to an ObjectiveSpec, or None.
+
+    Issue #177: the iteration finalize step calls update_best_found with
+    this objective. Legacy campaigns without `objective` or `objective_preset`
+    fall through to the legacy status-based ranking inside update_best_found.
+    """
+    if not isinstance(campaign, dict):
+        return None
+    from orchestrator.composite_score import ObjectiveSpec, get_preset
+
+    if (preset := campaign.get("objective_preset")):
+        try:
+            return get_preset(str(preset))
+        except ValueError:
+            return None
+
+    obj = campaign.get("objective")
+    if isinstance(obj, dict) and obj.get("weights"):
+        try:
+            return ObjectiveSpec(
+                weights={str(k): float(v) for k, v in obj["weights"].items()},
+                metric_extractors=dict(obj.get("metric_extractors") or {}),
+                deploy_threshold=float(obj.get("deploy_threshold", 0.1)),
+            )
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def finalize_iteration(
+    *,
+    work_dir: Path,
+    iter_dir: Path,
+    iteration: int,
+    campaign: dict,
+) -> None:
+    """Run the deterministic post-gate finalize steps for an iteration.
+
+    Public seam (issue #177) so integration tests can drive the same
+    code path that ``run_iteration`` calls after HUMAN_FINDINGS_GATE
+    approves. The sort_bench dry-run on 2026-05-25 surfaced the gap:
+    ``update_best_found`` shipped in PR #172 with passing unit tests
+    but no caller — this function is the caller.
+
+    Steps (deterministic Python, no LLM):
+      1. Merge ``principle_updates.json`` into ``principles.json``.
+      2. Re-rank candidates and atomically rewrite ``best_found.json``
+         (issue #168 / #177).
+      3. Regenerate per-campaign ``CLAUDE.md`` so the next iteration's
+         session sees the updated principles + handoff (issue #131).
+
+    Tolerant of partial fixtures: missing principle_updates.json,
+    missing findings.json, and CLAUDE.md regeneration failures all
+    soft-fail — the iteration's terminal artifacts (``best_found.json``,
+    ``principles.json``) are still written.
+    """
+    from orchestrator.composite_score import update_best_found
+
+    _merge_principles(work_dir, iter_dir)
+
+    objective = _resolve_objective(campaign)
+    update_best_found(work_dir, objective=objective, top_k=5)
+
+    # CLAUDE.md regenerate is best-effort; failure here doesn't roll back
+    # the merged principles or the best_found ranking.
+    try:
+        from orchestrator.claude_md import regenerate_from_disk
+        regenerate_from_disk(work_dir, campaign, iteration=iteration)
+    except (OSError, RuntimeError) as exc:
+        logger.warning("Failed to regenerate CLAUDE.md: %s", exc)
+
+
 def _merge_principles(work_dir: Path, iter_dir: Path) -> None:
     """Merge principle_updates.json into the shared principles.json store."""
     updates_path = iter_dir / "principle_updates.json"
@@ -534,19 +607,16 @@ def run_iteration(
             print("Aborted.")
             return IterationOutcome.ABORTED
 
-    # ─── PRINCIPLE MERGE (Python, no LLM) ─────────────────────────────────
-    _merge_principles(work_dir, iter_dir)
+    # ─── FINALIZE: merge principles + write best_found.json + CLAUDE.md ───
+    # Issue #177: the sort_bench dry-run on 2026-05-25 surfaced that
+    # update_best_found (#168) had no caller in the production path.
+    # finalize_iteration is the caller. Tests drive it directly.
+    finalize_iteration(
+        work_dir=work_dir, iter_dir=iter_dir,
+        iteration=iteration, campaign=campaign,
+    )
     print(f"  -> Principles merged into {work_dir / 'principles.json'}")
-
-    # ─── CLAUDE.md REGENERATE (Python, no LLM) — issue #131 ───────────────
-    # Refresh per-campaign CLAUDE.md so the next iteration's session loads
-    # the updated principles + handoff via Claude Code's auto-context loading.
-    try:
-        from orchestrator.claude_md import regenerate_from_disk
-        regenerate_from_disk(work_dir, campaign, iteration=iteration)
-    except (OSError, RuntimeError) as exc:
-        # Best-effort: a CLAUDE.md write failure shouldn't abort the iteration.
-        logger.warning("Failed to regenerate CLAUDE.md: %s", exc)
+    print(f"  -> best_found.json updated at {work_dir / 'best_found.json'}")
 
     if final:
         engine.transition("DONE")

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -208,10 +208,14 @@ def finalize_iteration(
     but no caller — this function is the caller.
 
     Steps (deterministic Python, no LLM):
-      1. Merge ``principle_updates.json`` into ``principles.json``.
-      2. Re-rank candidates and atomically rewrite ``best_found.json``
+      1. Classify principle_updates.json in place — fill empirical_content
+         / derivation_type from text heuristics (issue #179).
+      2. Merge ``principle_updates.json`` into ``principles.json``.
+      3. Re-rank candidates and atomically rewrite ``best_found.json``
          (issue #168 / #177).
-      3. Regenerate per-campaign ``CLAUDE.md`` so the next iteration's
+      4. Surface validator warnings for any residual unclassified
+         domain principles (issue #179, #86).
+      5. Regenerate per-campaign ``CLAUDE.md`` so the next iteration's
          session sees the updated principles + handoff (issue #131).
 
     Tolerant of partial fixtures: missing principle_updates.json,
@@ -220,11 +224,30 @@ def finalize_iteration(
     ``principles.json``) are still written.
     """
     from orchestrator.composite_score import update_best_found
+    from orchestrator.principles_classifier import classify_principle_updates_in_place
+    from orchestrator.validate import validate_principles_have_empirical_content
+
+    # Classify BEFORE merge so principles.json reflects the tags on its
+    # very first write (issue #179).
+    classify_principle_updates_in_place(iter_dir)
 
     _merge_principles(work_dir, iter_dir)
 
     objective = _resolve_objective(campaign)
     update_best_found(work_dir, objective=objective, top_k=5)
+
+    # Surface validator warnings for residual unclassified domain
+    # principles. Advisory only — doesn't roll back the merge.
+    principles_path = work_dir / "principles.json"
+    if principles_path.exists():
+        try:
+            store = json.loads(principles_path.read_text())
+            for warning in validate_principles_have_empirical_content(
+                store.get("principles", []),
+            ):
+                logger.warning("%s", warning)
+        except (OSError, json.JSONDecodeError):
+            pass
 
     # CLAUDE.md regenerate is best-effort; failure here doesn't roll back
     # the merged principles or the best_found ranking.

--- a/orchestrator/principles_classifier.py
+++ b/orchestrator/principles_classifier.py
@@ -1,0 +1,183 @@
+"""Deterministic post-extraction classifier for principle empiricism (issue #179).
+
+The sort_bench dry-run on 2026-05-25 surfaced that extracted principles
+ship with `empirical_content` and `derivation_type` (issue #86) unset
+because the methodology prompt is advisory and the schema treats them
+as optional. RP-2 in that run was a clear empirical observation
+(*"timsort uses 460 comparisons on nearly-sorted input"*) but was
+silently filed without tags.
+
+This module provides a deterministic Python heuristic that runs on
+``principle_updates.json`` before merge into ``principles.json``,
+filling the fields when the statement is classifiable. Residual
+unclassifiable principles are caught by the validator warning in
+``orchestrator.validate.validate_principles_have_empirical_content``.
+
+Approach: composable A+B from issue #179.
+  * A: This module — deterministic auto-classifier.
+  * B: ``validate.py`` — soft validator emitting WARN on residual misses.
+
+Heuristic priority:
+  1. Existing explicit tags are preserved (explicit > heuristic).
+  2. Algebraic markers (`iff`, `algebraic`, `identity`, `theorem`) → algebraic.
+  3. Definitional markers (`is defined as`, `by definition`) → definitional.
+  4. Empirical markers (`iter-N`, numeric measurements with units,
+     `observed`, `measured`, `experiments`) → empirical.
+  5. Otherwise leave None — the validator warning surfaces to the human.
+
+No LLM, no live calls. Tests assert on the heuristic's verdicts for
+known statement shapes.
+"""
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from pathlib import Path
+
+from orchestrator.util import atomic_write
+
+
+_ALGEBRAIC_MARKERS = (
+    re.compile(r"\biff\b", re.IGNORECASE),
+    re.compile(r"\bif\s+and\s+only\s+if\b", re.IGNORECASE),
+    re.compile(r"\balgebraic(?:ally)?\b", re.IGNORECASE),
+    re.compile(r"\bidentity\b", re.IGNORECASE),
+    re.compile(r"\bequivalent(?:ly)?\s+to\b", re.IGNORECASE),
+    re.compile(r"\bfollows\s+from\b", re.IGNORECASE),
+    re.compile(r"\btheorem\b", re.IGNORECASE),
+    re.compile(r"\baxiom\b", re.IGNORECASE),
+    re.compile(r"\bproof\b", re.IGNORECASE),
+)
+
+_DEFINITIONAL_MARKERS = (
+    re.compile(r"\bis\s+defined\s+as\b", re.IGNORECASE),
+    re.compile(r"\bby\s+definition\b", re.IGNORECASE),
+    re.compile(r"\bdefinitional(?:ly)?\b", re.IGNORECASE),
+)
+
+_EMPIRICAL_MARKERS = (
+    # Iteration / arm citations
+    re.compile(r"\biter[-_ ]?\d+\b", re.IGNORECASE),
+    re.compile(r"\barm[-_]?\w+\b", re.IGNORECASE),
+    # Empirical-process verbs
+    re.compile(r"\bobserved\b", re.IGNORECASE),
+    re.compile(r"\bmeasured\b", re.IGNORECASE),
+    re.compile(r"\bfound\s+that\b", re.IGNORECASE),
+    re.compile(r"\bexperiments?\b", re.IGNORECASE),
+    re.compile(r"\bdiscover(?:ed|y)?\b", re.IGNORECASE),
+    re.compile(r"\bempirical(?:ly)?\b", re.IGNORECASE),
+    # Numeric measurements with units (high signal)
+    re.compile(
+        r"\b\d+(?:\.\d+)?\s*"
+        r"(?:%|ms|us|s|MB|GB|comparisons?|tokens?|seeds?|x)\b",
+        re.IGNORECASE,
+    ),
+    # Concrete equations / values: "= 460", "approximately 0.85"
+    re.compile(r"=\s*\d{2,}"),
+    re.compile(r"\bratio\s*=?\s*\d", re.IGNORECASE),
+)
+
+
+def classify_principle(p: dict) -> dict:
+    """Return a copy of ``p`` with ``empirical_content`` / ``derivation_type``
+    filled in if the heuristic fires and the field is currently unset.
+
+    Pure: does not mutate the input. Existing values are preserved
+    (explicit > heuristic). When neither side fires strongly, returns
+    a copy with the fields still ``None`` — the validator warning
+    surfaces the residual to the human.
+    """
+    if not isinstance(p, dict):
+        return p  # malformed; let downstream validators catch it
+    out = deepcopy(p)
+
+    # If both fields are already set, no change.
+    has_empirical = out.get("empirical_content") is not None
+    has_derivation = out.get("derivation_type") is not None
+    if has_empirical and has_derivation:
+        return out
+
+    statement = str(out.get("statement") or "")
+    algebraic_hits = sum(1 for r in _ALGEBRAIC_MARKERS if r.search(statement))
+    definitional_hits = sum(1 for r in _DEFINITIONAL_MARKERS if r.search(statement))
+    empirical_hits = sum(1 for r in _EMPIRICAL_MARKERS if r.search(statement))
+
+    # Case 1: ``empirical_content`` was explicitly set; derivation_type
+    # follows. True ⇒ empirical; False ⇒ algebraic or definitional
+    # depending on which marker family dominates.
+    if has_empirical and not has_derivation:
+        if out.get("empirical_content") is True:
+            out["derivation_type"] = "empirical"
+        else:
+            if definitional_hits >= 1 and definitional_hits >= algebraic_hits:
+                out["derivation_type"] = "definitional"
+            else:
+                out["derivation_type"] = "algebraic"
+        return out
+
+    # Case 2: ``derivation_type`` was explicitly set; empirical_content
+    # follows by definition (only "empirical" → True; the others → False).
+    if has_derivation and not has_empirical:
+        out["empirical_content"] = (out.get("derivation_type") == "empirical")
+        return out
+
+    # Case 3: neither set. Apply the heuristic with priority:
+    # definitional > algebraic > empirical.
+
+    # Definitional markers are most specific — "is defined as" /
+    # "by definition" override algebraic markers that may co-occur.
+    if definitional_hits >= 1:
+        out["empirical_content"] = False
+        out["derivation_type"] = "definitional"
+        return out
+
+    # Algebraic markers — at least one of {iff, theorem, identity, …}
+    # AND no stronger empirical signal.
+    if algebraic_hits >= 1 and algebraic_hits >= empirical_hits:
+        out["empirical_content"] = False
+        out["derivation_type"] = "algebraic"
+        return out
+
+    # Empirical markers — require at least 2 (single iter-N alone is too
+    # weak; we want corroborating evidence like a numeric measurement
+    # or a process verb).
+    if empirical_hits >= 2 and empirical_hits > algebraic_hits:
+        out["empirical_content"] = True
+        out["derivation_type"] = "empirical"
+        return out
+
+    # Neither side fired strongly. Leave fields as-is (likely None) —
+    # validator will warn for category=domain principles.
+    return out
+
+
+def classify_principles(principles: list[dict]) -> list[dict]:
+    """Classify a list of principle dicts; returns a new list."""
+    if not isinstance(principles, list):
+        return principles
+    return [classify_principle(p) for p in principles]
+
+
+def classify_principle_updates_in_place(iter_dir: Path) -> None:
+    """Read ``runs/iter-N/principle_updates.json``, classify, and write back atomically.
+
+    No-op if the file is missing or malformed. Idempotent: re-running on
+    an already-classified file produces byte-equal output.
+
+    This is the seam ``finalize_iteration`` calls before
+    ``_merge_principles``, so the merged ``principles.json`` reflects
+    the tags on its very first write.
+    """
+    updates_path = Path(iter_dir) / "principle_updates.json"
+    if not updates_path.exists():
+        return
+    try:
+        updates = json.loads(updates_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(updates, list):
+        return
+
+    classified = classify_principles(updates)
+    atomic_write(updates_path, json.dumps(classified, indent=2) + "\n")

--- a/orchestrator/validate.py
+++ b/orchestrator/validate.py
@@ -104,6 +104,49 @@ def _validate_ground_truth_independence(bundle: dict) -> list[str]:
     return errors
 
 
+def validate_principles_have_empirical_content(
+    principles: list[dict],
+) -> list[str]:
+    """Return WARN strings for category=domain principles missing #86 fields.
+
+    Issue #179: even after the deterministic classifier
+    (``orchestrator.principles_classifier``) runs, some principles
+    will have a statement too neutral for the heuristic to classify.
+    This validator surfaces those residuals so the human can act on
+    them at the design gate or in the report.
+
+    Meta-category principles (constraint principles emitted by
+    ``orchestrator.refute_constraints`` per #169) are exempt — they're
+    orchestrator-emitted facts, not LLM-extracted observations, and
+    the empirical/algebraic distinction doesn't apply to them.
+
+    Returned strings are advisory (``WARN:`` prefix); they don't fail
+    validation. Callers may surface them via the design-gate summary
+    or via a campaign-end report.
+    """
+    if not isinstance(principles, list):
+        return []
+    warnings: list[str] = []
+    for i, p in enumerate(principles):
+        if not isinstance(p, dict):
+            continue
+        if p.get("category") == "meta":
+            continue
+        if p.get("empirical_content") is None or p.get("derivation_type") is None:
+            pid = p.get("id", f"principles[{i}]")
+            warnings.append(
+                f"WARN: principle {pid} has unset empirical_content / "
+                f"derivation_type (issue #86). The classifier (#179) "
+                f"could not infer the fields from the statement. Add "
+                f"explicit empirical_content + derivation_type to the "
+                f"principle, or refine the statement so it cites either "
+                f"a concrete measurement (empirical) or an algebraic / "
+                f"definitional marker (e.g. 'iff', 'theorem', "
+                f"'by definition')."
+            )
+    return warnings
+
+
 def _validate_typed_arm_fields(bundle: dict) -> list[str]:
     """Cross-field rules per arm type that JSON Schema can't easily express.
 

--- a/tests/test_deployment_recommendation.py
+++ b/tests/test_deployment_recommendation.py
@@ -171,6 +171,70 @@ class TestVerdictFallback:
         assert rec.verdict == "fall_back_to_baseline"
 
 
+# ─── #178: missing vs empty best_found.json must be distinguishable ───────
+
+
+class TestFallbackDistinguishesMissingVsEmpty:
+    """Regression for the sort_bench dry-run failure: a 100%-CONFIRMED
+    campaign reported `fall_back_to_baseline` with empty caveats because
+    best_found.json was missing (cascade from #177). Even when #177 is
+    fixed, the deployment recommender should distinguish "missing" from
+    "empty" with concrete caveats so the operator knows what happened."""
+
+    def test_missing_best_found_caveat_cites_filename_and_issue(
+        self, tmp_path: Path,
+    ) -> None:
+        # No best_found.json on disk — the case from the sort_bench run.
+        rec = make_deployment_recommendation(tmp_path, campaign=_campaign())
+        assert rec.verdict == "fall_back_to_baseline"
+        assert rec.caveats, (
+            "missing best_found must produce at least one caveat — "
+            "silent fall_back is the bug from #178"
+        )
+        c0 = rec.caveats[0]
+        assert "best_found.json" in c0
+        assert "#177" in c0 or "update_best_found" in c0, (
+            "caveat must point at the upstream wiring root cause"
+        )
+
+    def test_missing_best_found_caveat_passes_validator_floor(
+        self, tmp_path: Path,
+    ) -> None:
+        """The caveat must pass meta_findings.validate_caveat (#170 floor).
+        Validator floor rejects vague aspirations regardless of source."""
+        from orchestrator.meta_findings import validate_caveat
+
+        rec = make_deployment_recommendation(tmp_path, campaign=_campaign())
+        for caveat in rec.caveats:
+            assert validate_caveat(caveat) is None, (
+                f"auto-generated caveat fails validator floor: {caveat!r}"
+            )
+
+    def test_empty_top_k_caveat_distinguishable_from_missing(
+        self, tmp_path: Path,
+    ) -> None:
+        """File present but top_k=[] is a different condition: search
+        ran, no candidate beat baseline. Caveat text must reflect that."""
+        update_best_found(tmp_path, objective=None, top_k=5)  # writes empty
+        rec = make_deployment_recommendation(tmp_path, campaign=_campaign())
+        assert rec.verdict == "fall_back_to_baseline"
+        assert rec.caveats
+        # Empty case mentions empty / k= rather than the missing path
+        c0 = rec.caveats[0]
+        assert ("empty" in c0 or "no candidate" in c0.lower()
+                or "top_k" in c0)
+
+    def test_empty_top_k_caveat_passes_validator_floor(
+        self, tmp_path: Path,
+    ) -> None:
+        from orchestrator.meta_findings import validate_caveat
+
+        update_best_found(tmp_path, objective=None, top_k=5)
+        rec = make_deployment_recommendation(tmp_path, campaign=_campaign())
+        for caveat in rec.caveats:
+            assert validate_caveat(caveat) is None
+
+
 class TestVerdictWithCaveats:
     def test_high_score_low_consistency_yields_caveats(
         self, tmp_path: Path,

--- a/tests/test_iteration_finalize.py
+++ b/tests/test_iteration_finalize.py
@@ -1,0 +1,215 @@
+"""Integration tests for the iteration-finalize seam (issue #177, #179).
+
+The sort_bench dry-run on 2026-05-25 surfaced a Phase-A-without-Phase-B
+gap: `update_best_found` shipped in PR #172 with passing unit tests, but
+no production code path called it after `findings.json` was finalized,
+so `best_found.json` was never written during a real `nous run`.
+
+`principles_classifier.classify_principles` (issue #179) has the same
+shape: shipping the function alone wouldn't help unless the iteration
+loop calls it before merging principle_updates into principles.json.
+
+Test contract:
+  - `finalize_iteration(work_dir, iter_dir, iteration, campaign)` is the
+    public seam. After it runs:
+      * `best_found.json` exists at work_dir root with non-empty `top_k`
+      * `principles.json` reflects merged principles
+      * (#179) merged principles have `empirical_content` /
+        `derivation_type` set when the statement is classifiable
+  - Driving with fixture findings (no LLM, no live calls) catches the
+    same gap that ~205 unit tests missed.
+  - Backward-compat: a campaign without an `objective:` block still
+    produces `best_found.json` via the legacy status-based ranking.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestrator.iteration import finalize_iteration
+
+
+def _write_state(work_dir: Path, *, phase: str = "HUMAN_FINDINGS_GATE") -> None:
+    (work_dir / "state.json").write_text(json.dumps({
+        "phase": phase, "iteration": 1, "run_id": "demo",
+        "family": "test", "timestamp": "2026-05-25T00:00:00Z",
+    }))
+
+
+def _write_principles_template(work_dir: Path, principles: list | None = None) -> None:
+    (work_dir / "principles.json").write_text(json.dumps({
+        "principles": principles or [],
+    }))
+
+
+def _arm_result(arm_type: str, status: str, metadata: dict | None = None) -> dict:
+    return {
+        "arm_type": arm_type,
+        "predicted": "p", "observed": "o",
+        "status": status, "error_type": None, "diagnostic_note": "n",
+        "metadata": metadata or {},
+    }
+
+
+def _write_findings(iter_dir: Path, *, arms: list[dict]) -> None:
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    (iter_dir / "findings.json").write_text(json.dumps({
+        "iteration": 1,
+        "bundle_ref": "runs/iter-1/bundle.yaml",
+        "arms": arms,
+        "experiment_valid": True,
+        "discrepancy_analysis": "",
+    }))
+
+
+def _write_principle_updates(iter_dir: Path, updates: list[dict]) -> None:
+    (iter_dir / "principle_updates.json").write_text(json.dumps(updates))
+
+
+def _principle(*, pid: str, statement: str, **extra) -> dict:
+    p = {
+        "id": pid, "statement": statement, "confidence": "medium",
+        "regime": "", "evidence": [], "contradicts": [],
+        "extraction_iteration": 1, "mechanism": "",
+        "applicability_bounds": "", "superseded_by": None,
+        "status": "active", "category": "domain",
+    }
+    p.update(extra)
+    return p
+
+
+def _campaign(objective: dict | None = None) -> dict:
+    c: dict = {
+        "research_question": "q?",
+        "run_id": "demo",
+        "max_iterations": 1,
+        "target_system": {"name": "x", "description": "d"},
+        "prompts": {"methodology_layer": "p"},
+    }
+    if objective is not None:
+        c["objective"] = objective
+    return c
+
+
+# ─── #177: best_found.json is written during finalize ─────────────────────
+
+
+class TestFinalizeWritesBestFound:
+    def test_finalize_writes_best_found_json(self, tmp_path: Path) -> None:
+        """The bug from the sort_bench run: this file was missing after
+        a real iteration. After fix, it exists with non-empty top_k."""
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        iter_dir = work_dir / "runs" / "iter-1"
+        _write_state(work_dir)
+        _write_principles_template(work_dir)
+        _write_findings(iter_dir, arms=[
+            _arm_result("h-main", "CONFIRMED",
+                        {"compound_return": 0.85, "candidate_id": "winner"}),
+            _arm_result("h-control-negative", "CONFIRMED"),
+        ])
+        _write_principle_updates(iter_dir, [])
+
+        finalize_iteration(
+            work_dir=work_dir, iter_dir=iter_dir, iteration=1,
+            campaign=_campaign(objective={
+                "weights": {"compound_return": 1.0},
+                "deploy_threshold": 0.05,
+            }),
+        )
+
+        bf_path = work_dir / "best_found.json"
+        assert bf_path.exists(), (
+            "best_found.json must exist after finalize (regression for #177)"
+        )
+        payload = json.loads(bf_path.read_text())
+        assert payload["top_k"], "top_k must be non-empty for a CONFIRMED iteration"
+        assert payload["top_k"][0]["score"] > 0
+
+    def test_finalize_uses_legacy_fallback_when_no_objective(
+        self, tmp_path: Path,
+    ) -> None:
+        """A campaign without `objective:` still gets best_found.json via
+        the legacy status-based ranking (CONFIRMED=1.0, etc.). This
+        means the sort_bench-style campaign — which didn't declare an
+        objective — would have had a populated best_found.json on day
+        one if the wire-up had been there."""
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        iter_dir = work_dir / "runs" / "iter-1"
+        _write_state(work_dir)
+        _write_principles_template(work_dir)
+        _write_findings(iter_dir, arms=[
+            _arm_result("h-main", "CONFIRMED"),
+            _arm_result("h-main", "REFUTED"),
+        ])
+        _write_principle_updates(iter_dir, [])
+
+        finalize_iteration(
+            work_dir=work_dir, iter_dir=iter_dir, iteration=1,
+            campaign=_campaign(),  # no objective
+        )
+
+        payload = json.loads((work_dir / "best_found.json").read_text())
+        assert payload["top_k"], "legacy fallback must still populate top_k"
+        # Scores: CONFIRMED=1.0, REFUTED=0.0, ordered descending
+        assert payload["top_k"][0]["score"] == 1.0
+        assert payload["top_k"][-1]["score"] == 0.0
+
+    def test_finalize_uses_objective_preset(self, tmp_path: Path) -> None:
+        """Campaigns can declare a preset instead of an explicit objective."""
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        iter_dir = work_dir / "runs" / "iter-1"
+        _write_state(work_dir)
+        _write_principles_template(work_dir)
+        _write_findings(iter_dir, arms=[
+            _arm_result("h-main", "CONFIRMED", {
+                "compound_return": 0.9,
+                "walk_forward_consistency": 0.8,
+                "interpretability": 0.7,
+                "operational_simplicity": 0.6,
+                "candidate_id": "preset-winner",
+            }),
+        ])
+        _write_principle_updates(iter_dir, [])
+
+        c = _campaign()
+        c["objective_preset"] = "compound-return-style"
+        finalize_iteration(
+            work_dir=work_dir, iter_dir=iter_dir, iteration=1, campaign=c,
+        )
+
+        payload = json.loads((work_dir / "best_found.json").read_text())
+        assert payload["top_k"][0]["candidate_id"].endswith("preset-winner")
+        # compound-return-style weights: 0.5*0.9 + 0.3*0.8 + 0.1*0.7 + 0.1*0.6
+        assert payload["top_k"][0]["score"] == pytest.approx(0.82)
+
+
+# ─── Tolerance for missing/empty fixtures ────────────────────────────────
+
+
+class TestFinalizeToleratesPartialFixtures:
+    def test_finalize_no_findings_no_crash(self, tmp_path: Path) -> None:
+        """Defensive: if findings.json doesn't exist (caller error),
+        finalize should not crash. update_best_found returns empty
+        top_k in that case."""
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        iter_dir = work_dir / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        _write_state(work_dir)
+        _write_principles_template(work_dir)
+
+        # No findings.json, no principle_updates.json — finalize still runs.
+        finalize_iteration(
+            work_dir=work_dir, iter_dir=iter_dir, iteration=1,
+            campaign=_campaign(),
+        )
+        # best_found.json IS still written (with empty top_k); that's what
+        # the deployment recommendation (#178) reads to decide its caveat.
+        assert (work_dir / "best_found.json").exists()
+        payload = json.loads((work_dir / "best_found.json").read_text())
+        assert payload["top_k"] == []

--- a/tests/test_principles_classifier.py
+++ b/tests/test_principles_classifier.py
@@ -1,0 +1,277 @@
+"""Behavioral tests for the principles classifier (issue #179).
+
+The sort_bench dry-run on 2026-05-25 surfaced that extracted principles
+ship with `empirical_content` and `derivation_type` unset because the
+methodology prompt is advisory and the schema treats them as optional.
+This module fills the gap with a deterministic post-extraction
+classifier (no LLM) plus a validator that warns when residual unset
+principles slip through.
+
+Test contract:
+  - `classify_principle({statement: ...})` tags `empirical_content` /
+    `derivation_type` based on text heuristics.
+  - Obvious-empirical statements (iter-N reference + numeric
+    measurement) → empirical_content=True, derivation_type='empirical'.
+  - Obvious-algebraic statements (`iff`, `identity`, `theorem`,
+    `algebraic`) → empirical_content=False, derivation_type='algebraic'.
+  - Pre-tagged principles preserved (explicit > heuristic).
+  - Neutral statements left None → validator WARN catches them.
+  - `validate_principles_have_empirical_content` returns WARN strings
+    for category=domain principles with unset fields; meta-category
+    principles (constraint principles from #169) are exempt.
+  - `classify_principle_updates_in_place(iter_dir)` mutates
+    principle_updates.json atomically and is idempotent.
+  - End-to-end: `finalize_iteration` calls the classifier before
+    `_merge_principles`, so principles.json reflects the tags.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestrator.iteration import finalize_iteration
+from orchestrator.principles_classifier import (
+    classify_principle,
+    classify_principle_updates_in_place,
+    classify_principles,
+)
+from orchestrator.validate import validate_principles_have_empirical_content
+
+
+def _principle(*, pid: str, statement: str, category: str = "domain", **extra) -> dict:
+    p = {
+        "id": pid, "statement": statement, "confidence": "medium",
+        "regime": "", "evidence": [], "contradicts": [],
+        "extraction_iteration": 1, "mechanism": "",
+        "applicability_bounds": "", "superseded_by": None,
+        "status": "active", "category": category,
+    }
+    p.update(extra)
+    return p
+
+
+def _campaign() -> dict:
+    return {
+        "research_question": "q?",
+        "run_id": "demo",
+        "max_iterations": 1,
+        "target_system": {"name": "x", "description": "d"},
+        "prompts": {"methodology_layer": "p"},
+    }
+
+
+# ─── Classifier — single-principle heuristics ─────────────────────────────
+
+
+class TestClassifyPrinciple:
+    def test_obvious_empirical_statement_is_tagged(self) -> None:
+        """The exact case from sort_bench RP-2: numeric measurements +
+        iter-N reference. This must be tagged empirical."""
+        p = _principle(
+            pid="RP-1",
+            statement=(
+                "On nearly_sorted (n=200, k=5), timsort uses 460 "
+                "comparisons (iter-1)."
+            ),
+        )
+        out = classify_principle(p)
+        assert out["empirical_content"] is True
+        assert out["derivation_type"] == "empirical"
+
+    def test_obvious_algebraic_statement_is_tagged(self) -> None:
+        """The composite-sensitivity-boundary RP-9 case from #84/#86."""
+        p = _principle(
+            pid="RP-2",
+            statement=(
+                "CC_RD > 1.0 iff completion_fraction < 1 - 1/sqrt(N) — "
+                "algebraic identity."
+            ),
+        )
+        out = classify_principle(p)
+        assert out["empirical_content"] is False
+        assert out["derivation_type"] == "algebraic"
+
+    def test_definitional_statement_is_tagged(self) -> None:
+        p = _principle(
+            pid="RP-3",
+            statement=(
+                "RD is defined as 1 minus the completion fraction — "
+                "by definition."
+            ),
+        )
+        out = classify_principle(p)
+        assert out["empirical_content"] is False
+        assert out["derivation_type"] == "definitional"
+
+    def test_existing_explicit_tags_are_preserved(self) -> None:
+        """Heuristic must NOT overwrite a fielded value. Explicit > heuristic
+        — even when the heuristic would have classified differently."""
+        p = _principle(
+            pid="RP-4",
+            statement=(
+                "Numbers like 460 and iter-1 appear (would normally "
+                "classify empirical) but I have already declared this as "
+                "definitional."
+            ),
+            empirical_content=False,
+            derivation_type="definitional",
+        )
+        out = classify_principle(p)
+        assert out["empirical_content"] is False
+        assert out["derivation_type"] == "definitional"
+
+    def test_partial_existing_tag_fills_only_unset_field(self) -> None:
+        """If empirical_content is set but derivation_type is None,
+        only the missing field gets filled in."""
+        p = _principle(
+            pid="RP-5",
+            statement="iter-3 measurement: 0.85 ratio",
+            empirical_content=True,
+            derivation_type=None,
+        )
+        out = classify_principle(p)
+        assert out["empirical_content"] is True
+        assert out["derivation_type"] == "empirical"
+
+    def test_neutral_statement_left_unclassified(self) -> None:
+        """When neither side fires strongly, leave fields None — the
+        validator warning will surface to the human."""
+        p = _principle(
+            pid="RP-6",
+            statement="The system seems to work well in many cases.",
+        )
+        out = classify_principle(p)
+        # Either both None, or at most one classified weakly. The strict
+        # contract: empirical_content must NOT be silently True without
+        # numeric / iter evidence.
+        assert out.get("empirical_content") is None or out.get("empirical_content") is False
+
+    def test_classifier_is_pure(self) -> None:
+        """Input dict must not be mutated — caller may rely on it."""
+        p = _principle(pid="RP-7", statement="iter-1 obs 42")
+        snapshot = json.dumps(p, sort_keys=True)
+        classify_principle(p)
+        assert json.dumps(p, sort_keys=True) == snapshot
+
+
+class TestClassifyPrinciplesBatch:
+    def test_batch_classifies_each_independently(self) -> None:
+        ps = [
+            _principle(pid="A", statement="iter-1 measured 460 comparisons"),
+            _principle(pid="B", statement="iff CC_RD > 1.0 — algebraic identity"),
+        ]
+        out = classify_principles(ps)
+        assert out[0]["empirical_content"] is True
+        assert out[1]["empirical_content"] is False
+
+
+# ─── In-place file mutation ───────────────────────────────────────────────
+
+
+class TestClassifyPrincipleUpdatesInPlace:
+    def test_rewrites_principle_updates_json_atomically(self, tmp_path: Path) -> None:
+        iter_dir = tmp_path / "iter-1"
+        iter_dir.mkdir()
+        updates_path = iter_dir / "principle_updates.json"
+        updates_path.write_text(json.dumps([
+            _principle(pid="X", statement="iter-1: observed 460 comparisons"),
+        ]))
+
+        classify_principle_updates_in_place(iter_dir)
+
+        on_disk = json.loads(updates_path.read_text())
+        assert on_disk[0]["empirical_content"] is True
+
+    def test_idempotent_on_already_classified(self, tmp_path: Path) -> None:
+        iter_dir = tmp_path / "iter-1"
+        iter_dir.mkdir()
+        updates_path = iter_dir / "principle_updates.json"
+        updates_path.write_text(json.dumps([
+            _principle(
+                pid="X", statement="iter-1: measured 460",
+                empirical_content=True, derivation_type="empirical",
+            ),
+        ]))
+
+        classify_principle_updates_in_place(iter_dir)
+        once = updates_path.read_text()
+        classify_principle_updates_in_place(iter_dir)
+        twice = updates_path.read_text()
+        assert once == twice
+
+    def test_missing_file_no_op(self, tmp_path: Path) -> None:
+        """No principle_updates.json — finalize must not crash."""
+        iter_dir = tmp_path / "iter-1"
+        iter_dir.mkdir()
+        # No file. Should not raise.
+        classify_principle_updates_in_place(iter_dir)
+
+
+# ─── Validator: WARN on residual unset domain principles ──────────────────
+
+
+class TestValidatePrinciplesHaveEmpiricalContent:
+    def test_warns_on_unset_domain_principle(self) -> None:
+        ps = [_principle(pid="X", statement="something neutral")]
+        warnings = validate_principles_have_empirical_content(ps)
+        assert warnings
+        assert any("empirical_content" in w for w in warnings)
+        assert any(w.startswith("WARN:") for w in warnings)
+
+    def test_no_warning_when_classified(self) -> None:
+        ps = [_principle(
+            pid="X", statement="iter-1 measured X",
+            empirical_content=True, derivation_type="empirical",
+        )]
+        warnings = validate_principles_have_empirical_content(ps)
+        assert warnings == []
+
+    def test_meta_principles_exempt(self) -> None:
+        """Constraint principles from #169 are category=meta and don't
+        need empirical_content tagging — they're orchestrator-emitted,
+        not LLM-extracted."""
+        ps = [_principle(pid="C-1", statement="Refuted: ...", category="meta")]
+        warnings = validate_principles_have_empirical_content(ps)
+        assert warnings == []
+
+
+# ─── End-to-end: finalize_iteration runs the classifier ──────────────────
+
+
+class TestFinalizeIntegrationWithClassifier:
+    def test_finalize_classifies_before_merge(self, tmp_path: Path) -> None:
+        """The end-to-end regression for #179 — same shape as #177's
+        integration test. After finalize_iteration runs, principles.json
+        has empirical_content set on the obviously-empirical statement."""
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        iter_dir = work_dir / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+
+        (work_dir / "state.json").write_text(json.dumps({
+            "phase": "HUMAN_FINDINGS_GATE", "iteration": 1, "run_id": "demo",
+            "family": None, "timestamp": "2026-05-25T00:00:00Z",
+        }))
+        (work_dir / "principles.json").write_text(json.dumps({"principles": []}))
+        (iter_dir / "findings.json").write_text(json.dumps({
+            "iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml",
+            "arms": [], "experiment_valid": True, "discrepancy_analysis": "",
+        }))
+        (iter_dir / "principle_updates.json").write_text(json.dumps([
+            _principle(
+                pid="RP-1",
+                statement="iter-1: timsort uses 460 comparisons on n=200 k=5",
+            ),
+        ]))
+
+        finalize_iteration(
+            work_dir=work_dir, iter_dir=iter_dir,
+            iteration=1, campaign=_campaign(),
+        )
+
+        merged = json.loads((work_dir / "principles.json").read_text())
+        rp1 = next(p for p in merged["principles"] if p["id"] == "RP-1")
+        assert rp1["empirical_content"] is True
+        assert rp1["derivation_type"] == "empirical"


### PR DESCRIPTION
Closes the three integration gaps surfaced by the first real campaign run (the `sort_bench` timsort-vs-quicksort dry-run on 2026-05-25) that exercised the trackers from #162 / #166 / #173. Three PRs and ~205 unit tests passed; the live `nous run` hit all three gaps immediately. Classic Phase-A-shipped-but-Phase-B-not-wired pattern.

## Why

From the sort_bench run:
- `best_found.json` was missing at the work_dir root despite a 100%-CONFIRMED campaign (h-main: 85.3× ratio, h-control-negative: 2.16× ratio).
- `meta_findings.json::deployment_recommendation` reported `fall_back_to_baseline` with empty caveats — silent misrepresentation of a successful campaign.
- Both extracted principles (RP-1, RP-2) shipped with `empirical_content` and `derivation_type` unset; RP-2 was a clear empirical observation that should have been tagged.

## What lands (in order — three commits)

### fix: wire update_best_found into iteration finalize (`a481a9e`) — Closes #177

- New `finalize_iteration(work_dir, iter_dir, iteration, campaign)` public seam in `orchestrator.iteration`. Encapsulates the deterministic post-gate Python steps.
- `_resolve_objective(campaign)` reads `objective` or `objective_preset` from `campaign.yaml`; tolerant of malformed declarations (returns None, falls through to legacy status-based ranking already implemented in `update_best_found`).
- `run_iteration()` now calls `finalize_iteration` instead of inlining steps — production path and test path are the same path.
- 4 behavioral tests covering best_found.json existence, legacy fallback, objective_preset honoring, and missing-findings tolerance.

### fix: deployment_recommendation distinguishes missing vs empty best_found.json (`15ea5f0`) — Closes #178

- `make_deployment_recommendation` now distinguishes three failure modes (file missing, empty top_k, corrupt top_k[0]) with concrete caveats. The verdict stays `fall_back_to_baseline` (conservative-correct) but the caveats list now tells the operator what actually happened.
- All auto-generated caveats pass `meta_findings.validate_caveat` (#170 floor): each cites a concrete artifact path, numeric indicator, or issue/code reference.
- 4 new behavioral tests including validator-floor compliance regressions for both missing and empty cases.

### fix: principles classifier + validator warning for empirical_content (`5c2dca2`) — Closes #179, Closes #176

- New `orchestrator/principles_classifier.py` with `classify_principle(p)` — pure function returning a copy with `empirical_content` / `derivation_type` filled in based on text heuristics. Existing explicit values are preserved.
- Heuristic priority: **definitional** (`by definition`, `is defined as`) > **algebraic** (`iff`, `identity`, `theorem`, `algebraic`) > **empirical** (iter-N + numeric measurement + process verbs). Empirical requires ≥ 2 markers; a lone iter-N is too weak.
- `classify_principle_updates_in_place(iter_dir)` rewrites `runs/iter-N/principle_updates.json` atomically, idempotent.
- `orchestrator.validate.validate_principles_have_empirical_content` returns WARN strings for `category=domain` principles with unset fields after classification. Meta-category principles (constraint principles from #169) are exempt.
- `finalize_iteration` calls the classifier BEFORE `_merge_principles`, so `principles.json` reflects the tags on its first write. After merge, validator scans and logs warnings — visible in the run log without rolling back the merge.
- 15 behavioral tests covering the obvious-empirical case (RP-2 from sort_bench), obvious-algebraic case (RP-9 from #84/#86), definitional case, explicit-tag preservation, partial-tag fill-in, neutral-statement-left-unclassified, batch, in-place + idempotence, validator on unset / classified / meta principles, and end-to-end finalize → classifier → merge.

## The methodological lesson

All three commits share the same root cause: **unit tests passed in isolation; the integration path was untested.** The fix here is not just the wiring, it's the **integration test pattern**:

  * Set up `runs/iter-N/findings.json` + `principle_updates.json` as fixtures (no LLM).
  * Drive `finalize_iteration` directly — the same code path `nous run` exercises.
  * Assert on the work_dir's terminal artifacts (best_found.json, principles.json, deployment_recommendation in meta_findings.json).

Every future Phase-A delivery in this repo should ship at least one integration test that drives the production code path, not just the new function in isolation. Worth referencing this PR from CLAUDE.md once it merges.

## Test discipline (CLAUDE.md)

No live LLM, MCMC, Optuna trial, or subprocess in tests. Every new fixture is fully scripted. The conftest live-call guards from prior trackers (PyMC, Optuna) carry through unchanged.

## Test counts

```
tests/test_iteration_finalize.py            4 passed   (#177)
tests/test_deployment_recommendation.py     4 new      (#178)
tests/test_principles_classifier.py         15 passed  (#179)
full suite                                  834 passed,  2 skipped, exit 0
```
(2 pre-existing failures in `test_llm_dispatch.py::TestNoApiKey` are SOCKS-proxy / `httpx[socks]` env issues unrelated to this work.)

## Token-budget impact

Zero. All three modules are pure deterministic Python at the iteration finalize seam. No new dependencies (stdlib only: `re`, `copy`, `json`, `pathlib`).

Closes #176.
Closes #177.
Closes #178.
Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
