### PR TITLE
fix(cli): give honest error for path-shaped status targets (#181)

### DIFF
--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -45,6 +45,10 @@ def resolve_work_dir(target):
     if p.is_dir() and (p / "state.json").exists():
         return p
 
+    if p.is_absolute() or "/" in target:
+        print(f"Work directory not found: {p}", file=sys.stderr)
+        sys.exit(1)
+
     run_id = target
     root = _find_repo_root()
     work_dir = root / ".nous" / run_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,47 @@ class TestResolveWorkDir:
         with pytest.raises(SystemExit):
             resolve_work_dir("/no/such/campaign.yaml")
 
+    def test_absolute_path_to_nonexistent_dir_reports_missing_workdir(
+        self, tmp_path, capsys
+    ):
+        """An absolute path that doesn't exist must not be silently
+        reinterpreted as a bare run-id — the user clearly intended a path,
+        so the error should name that path, not 'no .nous/ in any parent'.
+        Regression for #181."""
+        missing = tmp_path / "inference-sim" / ".nous" / "paper-burst"
+        with pytest.raises(SystemExit):
+            resolve_work_dir(str(missing))
+        err = capsys.readouterr().err
+        assert "Work directory not found" in err
+        assert str(missing) in err
+        assert ".nous/ directory in any parent" not in err
+
+    def test_absolute_path_to_dir_without_state_json_reports_missing_workdir(
+        self, tmp_path, capsys
+    ):
+        """A directory that exists but lacks state.json (e.g. mid-bootstrap
+        or wrong path) must produce the same path-shaped error, not the
+        run-id walk-up error. Regression for #181."""
+        half = tmp_path / ".nous" / "half-bootstrapped"
+        half.mkdir(parents=True)
+        with pytest.raises(SystemExit):
+            resolve_work_dir(str(half))
+        err = capsys.readouterr().err
+        assert "Work directory not found" in err
+        assert ".nous/ directory in any parent" not in err
+
+    def test_relative_path_with_separator_treated_as_path(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A relative target containing a path separator is path-shaped —
+        don't fall through to run-id resolution."""
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(SystemExit):
+            resolve_work_dir("subdir/missing-run")
+        err = capsys.readouterr().err
+        assert "Work directory not found" in err
+        assert ".nous/ directory in any parent" not in err
+
 
 class TestCmdRun:
     def test_run_errors_if_state_beyond_init(self, tmp_path):


### PR DESCRIPTION
## Summary

- `resolve_work_dir()` no longer silently reinterprets absolute or path-shaped targets as bare run-ids. When a path-shaped target doesn't resolve to a valid work-dir, the error names the path: `Work directory not found: <p>`.
- The existing bare-run-id ergonomic (`nous status my-campaign` from inside a Nous repo) is preserved unchanged.

## Repro (before)

```
$ cd ~/Documents/Projects/
$ nous status --line ~/Documents/Projects/inference-sim/.nous/paper-burst
Could not find .nous/ directory in any parent
```

The user passed a fully-qualified path; the error talks about parent-directory walking from `cwd`, which is irrelevant.

## After

```
$ nous status --line ~/Documents/Projects/inference-sim/.nous/paper-burst
Work directory not found: /Users/sri/Documents/Projects/inference-sim/.nous/paper-burst
```

## Why the heuristic was wrong

`resolve_work_dir()` had three branches: campaign yaml → work-dir path → bare run-id. The work-dir-path branch only matched when both `is_dir()` and `state.json` existed. Any other input — non-existent path, dir mid-bootstrap, dir without state.json — fell through to run-id resolution and walked up from `cwd` looking for `.nous/`, producing a `.nous/`-flavored error for inputs the user clearly meant as paths.

The fix splits path-shaped inputs (`p.is_absolute() or "/" in target`) off from the run-id case before the fallthrough.

## Test plan

- [x] `pytest tests/test_cli.py::TestResolveWorkDir` — 8 passed (5 existing + 3 new regression tests for #181):
  - absolute path to nonexistent dir → `Work directory not found` exit, no `.nous/` walk-up message
  - absolute path to dir without `state.json` → same
  - relative path with `/` separator → same
- [x] Existing tests preserved: campaign yaml, bare run-id from cwd, full path with state.json, missing yaml.
- [x] Smoke test of original bug repro: now prints the correct error.
- [x] Full suite: 873 passed, 2 pre-existing httpx/SOCKS environment failures in `tests/test_llm_dispatch.py::TestNoApiKey` unrelated to this change.

No live LLM calls; pure path-resolution behavior tested at the dispatcher-free seam per `tests/CLAUDE.md`.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)