### PR TITLE
paper-burst friction-test cleanup (#203)

### DIFF
--- a/orchestrator/campaign.py
+++ b/orchestrator/campaign.py
@@ -179,8 +179,15 @@ def _generate_report(
 def _persist_max_iterations(work_dir: Path, max_iterations: int) -> None:
     """Write effective max_iterations into state.json (#197).
 
-    Best-effort: on any read/parse/write failure we log and move on; the
-    feature is operational sugar, not load-bearing for correctness.
+    Best-effort. Three early-return paths are silent benign no-ops:
+      * state.json doesn't exist (run hasn't called setup_work_dir yet)
+      * state.json content isn't a dict (corrupt; load_state will catch it)
+      * value is unchanged (idempotent skip)
+
+    OS / parse / write *errors* are logged at WARNING level with the
+    fallback chain noted, since the feature is operational sugar
+    (carries the original cap across resume) and not load-bearing for
+    correctness.
     """
     state_path = Path(work_dir) / "state.json"
     if not state_path.exists():

--- a/orchestrator/campaign.py
+++ b/orchestrator/campaign.py
@@ -38,6 +38,7 @@ import yaml
 from orchestrator.engine import Engine
 from orchestrator.gates import HumanGate
 from orchestrator.inline_dispatch import InlineDispatcher
+from orchestrator.util import atomic_write
 from orchestrator.ledger import append_failed_row, append_ledger_row
 from orchestrator.llm_dispatch import LLMDispatcher
 from orchestrator.metrics import summarize_metrics
@@ -175,6 +176,53 @@ def _generate_report(
         print(f"  Report generation skipped: {exc}")
 
 
+def _persist_max_iterations(work_dir: Path, max_iterations: int) -> None:
+    """Write effective max_iterations into state.json (#197).
+
+    Best-effort: on any read/parse/write failure we log and move on; the
+    feature is operational sugar, not load-bearing for correctness.
+    """
+    state_path = Path(work_dir) / "state.json"
+    if not state_path.exists():
+        return
+    try:
+        state = json.loads(state_path.read_text())
+        if not isinstance(state, dict):
+            return
+        if state.get("max_iterations") == max_iterations:
+            return
+        state["max_iterations"] = int(max_iterations)
+        atomic_write(state_path, json.dumps(state, indent=2) + "\n")
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Could not persist max_iterations=%d to state.json (%s): "
+            "resume will fall back to CLI flag / campaign.yaml / default.",
+            max_iterations, exc,
+        )
+
+
+def read_persisted_max_iterations(work_dir: Path) -> int | None:
+    """Read max_iterations from state.json if present (#197).
+
+    Returns None when state.json doesn't exist, can't be parsed, or
+    doesn't carry a max_iterations field. Callers should fall back to
+    their normal resolution chain (CLI flag → campaign.yaml → default).
+    """
+    state_path = Path(work_dir) / "state.json"
+    if not state_path.exists():
+        return None
+    try:
+        state = json.loads(state_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(state, dict):
+        return None
+    val = state.get("max_iterations")
+    if not isinstance(val, int) or val < 1:
+        return None
+    return val
+
+
 def _resume_completed_campaign(work_dir: Path, max_iterations: int) -> int:
     """Decide where to resume a campaign and, if DONE, advance it.
 
@@ -194,8 +242,16 @@ def _resume_completed_campaign(work_dir: Path, max_iterations: int) -> int:
     if engine.phase not in ("INIT", "DONE"):
         start = engine.iteration
         if start < 1:
-            logger.warning(
-                "state.json has iteration=%d (< 1); starting fresh.", start,
+            # #202: pre-#194, the engine kept state.iteration=0 throughout
+            # iter-1 (incrementing only on DONE→DESIGN). The earlier WARNING
+            # "starting fresh" wording read like data loss; in practice
+            # existing iter-1 artifacts are preserved and the resume
+            # continues at state.phase. Phrase it informationally.
+            logger.info(
+                "state.json has iteration=%d (no completed iterations yet); "
+                "treating as iter-1. Existing artifacts under runs/iter-1/ "
+                "are preserved; resuming at phase=%s.",
+                start, engine.phase,
             )
             return 1
         if start > max_iterations:
@@ -308,6 +364,12 @@ def run_campaign(
             max_retries=max_cli_retries,
         )
         preflight_dispatcher.preflight_check()
+
+    # #197: persist effective max_iterations into state.json so a later
+    # `nous resume` (without --max-iterations) honors the original cap
+    # instead of silently defaulting to 10. The state file is the single
+    # source of truth across run/resume invocations.
+    _persist_max_iterations(work_dir, max_iterations)
 
     start_iter = _resume_completed_campaign(work_dir, max_iterations)
 

--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -156,10 +156,12 @@ def _cmd_resume(args):
         sys.exit(1)
 
     # #197: max_iterations resolution chain on resume:
-    #   1. CLI --max-iterations (explicit override wins)
-    #   2. state.json (preserves the cap from the original `nous run`)
-    #   3. campaign.yaml.max_iterations (fallback for legacy state)
-    #   4. hardcoded default (10)
+    #   1. CLI --max-iterations (explicit override wins).
+    #   2. state.json (preserves the cap from the original `nous run`).
+    #   3. campaign.yaml.max_iterations, or the hardcoded default 10 if
+    #      campaign.yaml doesn't pin it. (Both flow through the same
+    #      `campaign.get("max_iterations", 10)` call — legacy state files
+    #      pre-dating #197 land here.)
     if args.max_iterations is not None:
         max_iterations = args.max_iterations
         print(f"Resuming with max_iterations={max_iterations} (CLI override).")

--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -114,6 +114,11 @@ def _cmd_run(args):
             file=sys.stderr,
         )
         sys.exit(1)
+    # #193: --sandbox CLI flag overrides campaign.sandbox if both present;
+    # leaving it unset preserves whatever the campaign.yaml declares (or
+    # the SDKDispatcher default of "bypass").
+    if getattr(args, "sandbox", None) is not None:
+        campaign["sandbox"] = args.sandbox
     run_campaign(
         campaign,
         work_dir,
@@ -132,7 +137,7 @@ def _cmd_run(args):
 def _cmd_resume(args):
     import logging
 
-    from orchestrator.campaign import run_campaign
+    from orchestrator.campaign import run_campaign, read_persisted_max_iterations
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
@@ -150,7 +155,29 @@ def _cmd_resume(args):
         print("resume requires campaign.yaml", file=sys.stderr)
         sys.exit(1)
 
-    max_iterations = args.max_iterations if args.max_iterations is not None else campaign.get("max_iterations", 10)
+    # #197: max_iterations resolution chain on resume:
+    #   1. CLI --max-iterations (explicit override wins)
+    #   2. state.json (preserves the cap from the original `nous run`)
+    #   3. campaign.yaml.max_iterations (fallback for legacy state)
+    #   4. hardcoded default (10)
+    if args.max_iterations is not None:
+        max_iterations = args.max_iterations
+        print(f"Resuming with max_iterations={max_iterations} (CLI override).")
+    else:
+        persisted = read_persisted_max_iterations(work_dir)
+        if persisted is not None:
+            max_iterations = persisted
+            print(
+                f"Resuming with max_iterations={max_iterations} "
+                f"(persisted from original `nous run`)."
+            )
+        else:
+            max_iterations = campaign.get("max_iterations", 10)
+            print(
+                f"Resuming with max_iterations={max_iterations} "
+                f"(from campaign.yaml / default — state.json had no "
+                f"persisted value)."
+            )
     run_campaign(
         campaign,
         work_dir,
@@ -608,6 +635,13 @@ def main():
              "SDK for code phases; 'inline' emits prompts to stdout for "
              "an enclosing agent framework. The legacy 'api' backend "
              "was removed in #183.",
+    )
+    p_run.add_argument(
+        "--sandbox", choices=["bypass", "default"], default=None,
+        help="SDK filesystem sandbox mode (#193). Default 'bypass' (set "
+             "via campaign.sandbox). Pass 'default' to use the SDK's "
+             "default permission gating — only sensible when the "
+             "campaign's writes all land under the launched cwd.",
     )
     p_run.add_argument(
         "--bundle", type=Path, default=None,

--- a/orchestrator/cli_dispatch.py
+++ b/orchestrator/cli_dispatch.py
@@ -186,7 +186,14 @@ class CLIDispatcher(LLMDispatcher):
             else:
                 atomic_write(output_path, json.dumps(data, indent=2) + "\n")
 
-        logger.info("CLIDispatcher: role=%s phase=%s -> %s", role, phase, output_path)
+        logger.info(
+            # #196: report the runtime class name, not the parent's. SDKDispatcher
+            # inherits from CLIDispatcher and runs through this path, but the
+            # log line should say "SDKDispatcher" so operators don't think the
+            # legacy claude -p subprocess (removed in #183) is in use.
+            "%s: role=%s phase=%s -> %s",
+            type(self).__name__, role, phase, output_path,
+        )
 
     def _retry_cli_parse(self, original_prompt: str, error: Exception, fmt: str) -> dict:
         feedback = (

--- a/orchestrator/engine.py
+++ b/orchestrator/engine.py
@@ -121,9 +121,16 @@ class Engine:
                 f"Invalid transition: {current} -> {to_state}. "
                 f"Valid: {TRANSITIONS[current]}"
             )
-        # Build candidate state before writing to disk
+        # Build candidate state before writing to disk.
+        # #194: increment iteration whenever we leave INIT (iter-1 begins,
+        # whether via PRE_WORK or directly to DESIGN) and whenever DONE
+        # transitions to DESIGN (iter-N+1 begins). Pre-#194, the counter
+        # only ticked on DONE→DESIGN, so state.iteration stayed at 0
+        # throughout iter-1 even though artifacts lived at runs/iter-1/.
         new_state = dict(self._state)
-        if current == "DONE" and to_state == "DESIGN":
+        if current == "INIT":
+            new_state["iteration"] += 1
+        elif current == "DONE" and to_state == "DESIGN":
             new_state["iteration"] += 1
         new_state["phase"] = to_state
         new_state["timestamp"] = datetime.now(timezone.utc).isoformat()

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -180,6 +180,82 @@ def _missing_design_artifacts(iter_dir: Path) -> list[str]:
     ]
 
 
+# #200: which files MUST exist after EXECUTE_ANALYZE completes for the
+# iteration to advance to the findings gate. Drives the structured
+# "execute_incomplete" diagnostic — sister to #187 for DESIGN.
+_REQUIRED_EXECUTE_ARTIFACTS = (
+    "experiment_plan.yaml",
+    "findings.json",
+    "principle_updates.json",
+)
+
+
+class ExecuteAnalyzeIncompleteError(RuntimeError):
+    """EXECUTE_ANALYZE exited without producing the required artifacts (#200).
+
+    Distinct from a validator failure (where the artifacts exist but
+    are malformed). Fires when one or more of experiment_plan.yaml /
+    findings.json / principle_updates.json is missing on disk after the
+    dispatcher returned — typically because:
+
+      * max_turns budget exhausted before the agent finished aggregating
+        per-arm results.
+      * A subprocess (BLIS, build, test) hung and the agent never
+        recovered to author the analysis files.
+      * The agent got stuck in a polling loop waiting on a never-arriving
+        signal (e.g. a hung child process the orchestrator can't see).
+      * API stall / transport failure mid-turn.
+
+    The orchestrator catches this and writes a structured retry_log
+    entry with ``failure_type: "execute_incomplete"`` so post-mortem
+    tooling (#170 meta-findings, ad-hoc grep) can name the failure mode.
+    """
+
+    def __init__(self, missing: list[str], iter_dir: Path, max_turns: int):
+        self.missing = list(missing)
+        self.iter_dir = Path(iter_dir)
+        self.max_turns = max_turns
+        super().__init__(self._build_message())
+
+    def _build_message(self) -> str:
+        missing_lines = "\n".join(f"  - {m}" for m in self.missing)
+        log_path = self.iter_dir / "inputs" / "executor_log.jsonl"
+        legacy_log_path = self.iter_dir / "executor_log.jsonl"
+        return (
+            f"EXECUTE_ANALYZE incomplete for {self.iter_dir.name}. Missing "
+            f"required artifacts:\n"
+            f"{missing_lines}\n\n"
+            f"The agent did not commit a complete analysis. Likely causes:\n"
+            f"  1. max_turns exhaustion (current limit: {self.max_turns}). "
+            f"Compare against the actual turn count in llm_metrics.jsonl. "
+            f"Raise the cap via per-campaign max_turns (#186) if turns ran "
+            f"out before the agent could aggregate results.\n"
+            f"  2. Subprocess hang. The agent's tool calls block the SDK "
+            f"turn; check `ps` for orphaned BLIS / build / test processes "
+            f"that never returned.\n"
+            f"  3. Polling loop without progress. Look for repeated "
+            f"`sleep N && ls …` patterns in the streaming log; those "
+            f"signal the agent waiting on something that never arrived.\n"
+            f"  4. API stall / transport failure. The SDK streaming log\n"
+            f"     is at {log_path}\n"
+            f"     (or, on legacy campaigns predating #190, at\n"
+            f"     {legacy_log_path}).\n"
+            f"\n"
+            f"For full context, look at "
+            f"{self.iter_dir / 'executor_log.md'} (the agent's working "
+            f"notes this turn) and any partial outputs under "
+            f"{self.iter_dir / 'results'}/."
+        )
+
+
+def _missing_execute_artifacts(iter_dir: Path) -> list[str]:
+    """Return the list of required EXECUTE_ANALYZE artifacts that don't exist (#200)."""
+    return [
+        name for name in _REQUIRED_EXECUTE_ARTIFACTS
+        if not (iter_dir / name).exists()
+    ]
+
+
 def _apply_pre_authored_bundle(
     iter_dir: Path,
     *,
@@ -378,13 +454,24 @@ def _split_design_output(raw: str, iter_dir: Path) -> None:
         atomic_write(iter_dir.parent.parent / "handoff.md", handoff_md + "\n")
 
 
-def _enter_phase(engine, phase):
-    """Transition to phase if needed. Returns True if phase work should run."""
+def _enter_phase(engine, phase, work_dir: Path | None = None):
+    """Transition to phase if needed. Returns True if phase work should run.
+
+    #198: when ``work_dir`` is supplied and we're about to begin (not
+    skip-past) a phase, honour any STOP sentinel before doing the
+    transition. This makes ``nous stop`` granular at phase boundaries
+    (DESIGN / HUMAN_DESIGN_GATE / EXECUTE_ANALYZE / HUMAN_FINDINGS_GATE)
+    instead of only iteration boundaries — important when a long
+    EXECUTE_ANALYZE phase is running and the operator wants to halt
+    without waiting for the next iteration.
+    """
     current_idx = _PHASE_INDEX[engine.phase]
     target_idx = _PHASE_INDEX[phase]
     if current_idx > target_idx:
         return False
     if engine.phase != phase:
+        if work_dir is not None:
+            _raise_if_stopped(work_dir, where=f"before {phase}")
         engine.transition(phase)
     return True
 
@@ -711,7 +798,7 @@ def run_iteration(
         print(f"\n  Resuming from {engine.phase}\n")
 
     # ─── DESIGN ───────────────────────────────────────────────────────────
-    if _enter_phase(engine, "DESIGN"):
+    if _enter_phase(engine, "DESIGN", work_dir):
         print(f"\n{'='*60}")
         if pre_authored_bundle is not None:
             # #188: experiment is fully pre-specified — skip the agent
@@ -735,7 +822,7 @@ def run_iteration(
             print(f"  -> {iter_dir / 'bundle_manifest.json'}")
             # Fall through to validation; required artifacts now exist.
             from orchestrator.validate import validate_design
-            result = validate_design(iter_dir)
+            result = validate_design(iter_dir, campaign=campaign)
             if result["status"] == "fail":
                 raise RuntimeError(
                     f"Pre-authored design artifacts failed validation:\n"
@@ -791,7 +878,7 @@ def run_iteration(
             )
         # Validate design artifacts regardless of dispatch path
         from orchestrator.validate import validate_design
-        result = validate_design(iter_dir)
+        result = validate_design(iter_dir, campaign=campaign)
         if result["status"] == "fail":
             raise RuntimeError(
                 f"Design artifacts failed validation:\n"
@@ -801,7 +888,7 @@ def run_iteration(
         print(f"  -> {iter_dir / 'bundle.yaml'}")
 
     # ─── HUMAN DESIGN GATE ────────────────────────────────────────────────
-    if _enter_phase(engine, "HUMAN_DESIGN_GATE"):
+    if _enter_phase(engine, "HUMAN_DESIGN_GATE", work_dir):
         print(f"\n{'='*60}")
         print(f"  HUMAN DESIGN GATE")
         print(f"{'='*60}")
@@ -835,7 +922,7 @@ def run_iteration(
 
     # ─── EXECUTE + ANALYZE ────────────────────────────────────────────────
     experiment_dir = experiment_id = None
-    if _enter_phase(engine, "EXECUTE_ANALYZE"):
+    if _enter_phase(engine, "EXECUTE_ANALYZE", work_dir):
         print(f"\n{'='*60}")
         print(f"  EXECUTE + ANALYZE — building, running, and analyzing")
         print(f"{'='*60}")
@@ -888,9 +975,32 @@ def run_iteration(
                     iter_dir / "principle_updates.json",
                     json.dumps(combined["principle_updates"], indent=2) + "\n",
                 )
+        # #200: surface the structured "execute_incomplete" diagnostic
+        # BEFORE running schema validation. When required EXECUTE artifacts
+        # are missing, the operator needs hints (max_turns exhaustion,
+        # subprocess hang, polling loop, API stall) — not just a raw
+        # "X not found" from validate_execution.
+        missing = _missing_execute_artifacts(iter_dir)
+        if missing:
+            from orchestrator.metrics import log_retry_event
+            log_retry_event(work_dir / "llm_metrics.jsonl", {
+                "iteration": iteration,
+                "phase": "execute-analyze",
+                "failure_type": "execute_incomplete",
+                "missing_artifacts": missing,
+                "max_turns": _max_turns_for("execute_analyze"),
+            })
+            # Clean up the experiment worktree so a re-run isn't blocked.
+            if repo_path and experiment_id:
+                remove_experiment_worktree(Path(repo_path), experiment_id)
+            raise ExecuteAnalyzeIncompleteError(
+                missing=missing,
+                iter_dir=iter_dir,
+                max_turns=_max_turns_for("execute_analyze"),
+            )
         # Validate artifacts — trust the agent, log warning on failure
         from orchestrator.validate import validate_execution
-        result = validate_execution(iter_dir)
+        result = validate_execution(iter_dir, campaign=campaign)
         if result["status"] == "fail":
             logger.warning(
                 "Executor artifacts failed post-check validation: %s",
@@ -914,7 +1024,7 @@ def run_iteration(
         ) from exc
 
     # ─── HUMAN FINDINGS GATE ──────────────────────────────────────────────
-    if _enter_phase(engine, "HUMAN_FINDINGS_GATE"):
+    if _enter_phase(engine, "HUMAN_FINDINGS_GATE", work_dir):
         print(f"\n{'='*60}")
         print(f"  HUMAN FINDINGS GATE")
         print(f"{'='*60}")

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -212,6 +212,25 @@ class ExecuteAnalyzeIncompleteError(RuntimeError):
     """
 
     def __init__(self, missing: list[str], iter_dir: Path, max_turns: int):
+        # Defensive validation. ``missing`` must be non-empty (otherwise
+        # this exception class doesn't make sense) and every entry must
+        # be a known required artifact (catches typos at the raise site).
+        if not missing:
+            raise ValueError(
+                "ExecuteAnalyzeIncompleteError.missing must be non-empty"
+            )
+        unknown = [m for m in missing if m not in _REQUIRED_EXECUTE_ARTIFACTS]
+        if unknown:
+            raise ValueError(
+                f"ExecuteAnalyzeIncompleteError.missing contains unknown "
+                f"artifact name(s) {unknown!r}; allowed: "
+                f"{list(_REQUIRED_EXECUTE_ARTIFACTS)!r}"
+            )
+        if max_turns < 1:
+            raise ValueError(
+                f"ExecuteAnalyzeIncompleteError.max_turns must be >= 1, "
+                f"got {max_turns}"
+            )
         self.missing = list(missing)
         self.iter_dir = Path(iter_dir)
         self.max_turns = max_turns
@@ -243,8 +262,11 @@ class ExecuteAnalyzeIncompleteError(RuntimeError):
             f"\n"
             f"For full context, look at "
             f"{self.iter_dir / 'executor_log.md'} (the agent's working "
-            f"notes this turn) and any partial outputs under "
-            f"{self.iter_dir / 'results'}/."
+            f"notes this turn). Per-arm BLIS outputs (when present) "
+            f"live under {self.iter_dir / 'results'}/; the missing "
+            f"top-level analysis files (experiment_plan.yaml / "
+            f"findings.json / principle_updates.json) belong at the "
+            f"iter root."
         )
 
 
@@ -454,24 +476,27 @@ def _split_design_output(raw: str, iter_dir: Path) -> None:
         atomic_write(iter_dir.parent.parent / "handoff.md", handoff_md + "\n")
 
 
-def _enter_phase(engine, phase, work_dir: Path | None = None):
+def _enter_phase(engine, phase, work_dir: Path):
     """Transition to phase if needed. Returns True if phase work should run.
 
-    #198: when ``work_dir`` is supplied and we're about to begin (not
-    skip-past) a phase, honour any STOP sentinel before doing the
-    transition. This makes ``nous stop`` granular at phase boundaries
-    (DESIGN / HUMAN_DESIGN_GATE / EXECUTE_ANALYZE / HUMAN_FINDINGS_GATE)
-    instead of only iteration boundaries — important when a long
-    EXECUTE_ANALYZE phase is running and the operator wants to halt
-    without waiting for the next iteration.
+    #198: when we're about to begin (not skip-past) a phase, honour any
+    STOP sentinel before doing the transition. This makes ``nous stop``
+    granular at phase boundaries (DESIGN / HUMAN_DESIGN_GATE /
+    EXECUTE_ANALYZE / HUMAN_FINDINGS_GATE) instead of only iteration
+    boundaries — important when a long EXECUTE_ANALYZE phase is running
+    and the operator wants to halt without waiting for the next
+    iteration.
+
+    ``work_dir`` was made required after PR #204 review: a default of
+    ``None`` would silently skip the stop-sentinel check for any caller
+    that forgot to pass it, and all in-repo callers pass it anyway.
     """
     current_idx = _PHASE_INDEX[engine.phase]
     target_idx = _PHASE_INDEX[phase]
     if current_idx > target_idx:
         return False
     if engine.phase != phase:
-        if work_dir is not None:
-            _raise_if_stopped(work_dir, where=f"before {phase}")
+        _raise_if_stopped(work_dir, where=f"before {phase}")
         engine.transition(phase)
     return True
 

--- a/orchestrator/schemas/campaign.schema.yaml
+++ b/orchestrator/schemas/campaign.schema.yaml
@@ -63,6 +63,60 @@ properties:
       execute_analyze: { type: string, description: "Model for EXECUTE_ANALYZE phase (claude -p). Default: claude-sonnet-4-6." }
       report: { type: string, description: "Model for report generation (LLM API). Default: claude-sonnet-4-6." }
 
+  sdk_timeouts:
+    type: object
+    additionalProperties: false
+    description: >
+      SDK turn timing controls (#201). Per-campaign tunables for the
+      silence detector that surfaces excessive event gaps to
+      retry_log.jsonl after each turn. Observation-only today —
+      operators can scan retry_log for ``failure_type: sdk_silence`` to
+      catch hung subprocesses, polling-loop stalls, and API stalls
+      without watching the run live.
+    properties:
+      silence_threshold_seconds:
+        type: number
+        minimum: 0
+        description: >
+          Minimum gap between SDK streaming events that should trigger a
+          silence warning in retry_log.jsonl. Default 600 (10 minutes).
+          Set to 0 to disable the diagnostic entirely.
+
+  sandbox:
+    type: string
+    enum: [bypass, default]
+    description: >
+      Claude Agent SDK filesystem sandbox mode (#193). Default: ``bypass``.
+      Nous campaigns routinely write outside the launched cwd (the
+      orchestrator runs the agent with cwd=experiment-worktree, but
+      build/test/BLIS subprocesses write to the main repo's
+      .nous/<run>/runs/iter-N/results/). The default sandbox blocks
+      these writes; ``bypass`` removes the restriction. Set to
+      ``default`` only if the campaign genuinely lives entirely under
+      the launched cwd (rare).
+
+  validation:
+    type: object
+    additionalProperties: false
+    description: >
+      Per-campaign overrides to nous's validators (#199). Most campaigns
+      don't need this block; paper-* and other campaigns with custom
+      iter-root artifacts (analysis_summary.json, manifest.json,
+      probe_report.md, …) declare them here so validate_design /
+      validate_execution don't reject them as "unexpected file at iter
+      root."
+    properties:
+      iter_root_extensions:
+        type: array
+        items:
+          type: string
+          minLength: 1
+        uniqueItems: true
+        description: >
+          Additional filenames allowed at the iter root (in addition to
+          the global whitelist in orchestrator/validate.py). Names only,
+          not paths — files in subdirectories are always allowed.
+
   max_turns:
     type: object
     additionalProperties: false

--- a/orchestrator/sdk_dispatch.py
+++ b/orchestrator/sdk_dispatch.py
@@ -70,6 +70,47 @@ def _load_methodology_preamble(methodology_dir: Path) -> str | None:
     return "\n\n---\n\n".join(blocks)
 
 
+def summarize_silence_gaps(event_log_path: Path) -> dict:
+    """Walk an executor_log.jsonl and report the longest silence gap (#201).
+
+    Returns ``{"max_gap_seconds": float, "event_count": int}`` — both 0
+    when the log doesn't exist, has fewer than 2 events, or can't be
+    parsed. The max-gap is the largest delta between consecutive event
+    timestamps, in seconds. Useful for post-turn diagnostics: a multi-
+    minute gap between events typically signals a hung tool call (BLIS
+    subprocess, long-running build, polling-loop on a stuck signal).
+    """
+    if not event_log_path.exists():
+        return {"max_gap_seconds": 0.0, "event_count": 0}
+    try:
+        lines = event_log_path.read_text().splitlines()
+    except OSError:
+        return {"max_gap_seconds": 0.0, "event_count": 0}
+    import json as _json
+    timestamps: list[float] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            rec = _json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        ts = rec.get("ts")
+        if isinstance(ts, (int, float)):
+            timestamps.append(float(ts))
+    if len(timestamps) < 2:
+        return {"max_gap_seconds": 0.0, "event_count": len(timestamps)}
+    max_gap = 0.0
+    for prev, cur in zip(timestamps, timestamps[1:]):
+        gap = cur - prev
+        if gap > max_gap:
+            max_gap = gap
+    return {
+        "max_gap_seconds": max_gap,
+        "event_count": len(timestamps),
+    }
+
+
 def _tee_event(event_log_path: Path | None, message: object, cls_name: str) -> None:
     """Append one SDK event to executor_log.jsonl (#127 Phase B).
 
@@ -94,6 +135,22 @@ def _tee_event(event_log_path: Path | None, message: object, cls_name: str) -> N
                 record[field_name] = val
             except (TypeError, ValueError):
                 record[field_name] = repr(val)[:200]
+    # #195: AssistantMessage.tool_name is empty; the actual tool name lives
+    # on ToolUseBlock instances inside `content` (a list of TextBlock /
+    # ThinkingBlock / ToolUseBlock objects). Walk the list and surface the
+    # last tool name so `nous status` can render `last=Bash` etc.
+    if "tool_name" not in record:
+        content = getattr(message, "content", None)
+        if isinstance(content, (list, tuple)):
+            for block in reversed(content):
+                name = getattr(block, "name", None)
+                if name and not callable(name):
+                    try:
+                        _json.dumps(name)
+                        record["tool_name"] = name
+                        break
+                    except (TypeError, ValueError):
+                        pass
     try:
         with open(event_log_path, "a") as f:
             f.write(_json.dumps(record) + "\n")
@@ -143,6 +200,7 @@ class SDKRunner(Protocol):
         system_prompt: str | None = None,
         settings_path: Path | None = None,
         event_log_path: Path | None = None,
+        permission_mode: str | None = None,
     ) -> SDKResult:
         ...
 
@@ -163,6 +221,7 @@ def _default_sdk_runner_factory() -> SDKRunner:
         system_prompt: str | None = None,
         settings_path: Path | None = None,
         event_log_path: Path | None = None,
+        permission_mode: str | None = "bypassPermissions",
     ) -> SDKResult:
         try:
             import anyio
@@ -178,13 +237,32 @@ def _default_sdk_runner_factory() -> SDKRunner:
             ) from exc
 
         async def _run() -> SDKResult:
-            options = ClaudeAgentOptions(
-                model=model,
-                cwd=str(cwd) if cwd else None,
-                max_turns=max_turns,
-                system_prompt=system_prompt,
-                settings=str(settings_path) if settings_path else None,
-            )
+            # #193: ``permission_mode`` controls the Claude Code SDK
+            # filesystem sandbox. Default is "bypassPermissions" because
+            # nous campaigns routinely need writes outside cwd (the
+            # orchestrator launches with cwd=worktree but BLIS / build /
+            # test subprocess outputs land at <main-repo>/.nous/<run>/
+            # runs/iter-N/results/, which the default sandbox rejects).
+            # Operators can opt out via campaign.sandbox="default" or
+            # `nous run --sandbox default` if they want the SDK's default
+            # permission gating.
+            if permission_mode:
+                options = ClaudeAgentOptions(
+                    model=model,
+                    cwd=str(cwd) if cwd else None,
+                    max_turns=max_turns,
+                    system_prompt=system_prompt,
+                    settings=str(settings_path) if settings_path else None,
+                    permission_mode=permission_mode,  # type: ignore[arg-type]
+                )
+            else:
+                options = ClaudeAgentOptions(
+                    model=model,
+                    cwd=str(cwd) if cwd else None,
+                    max_turns=max_turns,
+                    system_prompt=system_prompt,
+                    settings=str(settings_path) if settings_path else None,
+                )
             text_chunks: list[str] = []
             usage: dict = {}
             cost_usd = 0.0
@@ -279,6 +357,7 @@ class SDKDispatcher(CLIDispatcher):
         sdk_runner: Callable | None = None,
         system_prompt: str | None = None,
         settings_path: Path | None = None,
+        sandbox: str | None = None,
     ) -> None:
         super().__init__(
             work_dir=work_dir,
@@ -294,6 +373,24 @@ class SDKDispatcher(CLIDispatcher):
             prompts_dir or Path(__file__).parent.parent / "prompts" / "methodology",
         )
         self._settings_path = settings_path
+        # #193: resolve sandbox mode. Order: explicit kwarg > campaign.sandbox
+        # > "bypass" default (which maps to permission_mode="bypassPermissions").
+        # Pass "default" to keep the SDK's default permission gating.
+        resolved = sandbox if sandbox is not None else campaign.get("sandbox", "bypass")
+        if resolved not in ("bypass", "default"):
+            raise ValueError(
+                f"campaign.sandbox must be 'bypass' or 'default', got {resolved!r}"
+            )
+        self._permission_mode = (
+            "bypassPermissions" if resolved == "bypass" else None
+        )
+        # #201: silence threshold (seconds) for post-turn diagnostics.
+        # Default 600s; opt out by setting to 0. Configured per-campaign
+        # via campaign.sdk_timeouts.silence_threshold_seconds.
+        timeouts = campaign.get("sdk_timeouts") or {}
+        self._silence_threshold = float(
+            timeouts.get("silence_threshold_seconds", 600)
+        )
         # #127 Phase B: event log path is recomputed per-dispatch (it depends
         # on the iteration), so we don't store it on the dispatcher.
         self._event_log_path: Path | None = None
@@ -301,6 +398,30 @@ class SDKDispatcher(CLIDispatcher):
     # ------------------------------------------------------------------
     # Per-iteration event log (#127 Phase B)
     # ------------------------------------------------------------------
+
+    def _maybe_log_silence(self, iteration: int, phase: str) -> None:
+        """#201: post-turn diagnostic — if the streaming log shows a gap
+        between events larger than the configured threshold, append a
+        ``failure_type: "sdk_silence"`` entry to retry_log.jsonl. Purely
+        observational; doesn't interrupt or fail the turn.
+        """
+        if self._silence_threshold <= 0 or self._event_log_path is None:
+            return
+        summary = summarize_silence_gaps(self._event_log_path)
+        if summary["max_gap_seconds"] > self._silence_threshold:
+            log_retry_event(self._metrics_path, {
+                "iteration": iteration,
+                "phase": phase,
+                "failure_type": "sdk_silence",
+                "max_gap_seconds": round(summary["max_gap_seconds"], 1),
+                "threshold_seconds": self._silence_threshold,
+                "event_count": summary["event_count"],
+            })
+            logger.warning(
+                "SDK turn observed a %.1fs silence gap (threshold=%.0fs); "
+                "see retry_log.jsonl for details.",
+                summary["max_gap_seconds"], self._silence_threshold,
+            )
 
     def dispatch(  # type: ignore[override]
         self, role: str, phase: str, *, output_path, iteration: int,
@@ -322,6 +443,13 @@ class SDKDispatcher(CLIDispatcher):
                 perspective=perspective, h_main_result=h_main_result,
             )
         finally:
+            # #201: post-turn silence diagnostic. Read the streaming log
+            # we just produced and surface excessive event gaps to
+            # retry_log.jsonl. Best-effort — never raise from the finally.
+            try:
+                self._maybe_log_silence(iteration=iteration, phase=phase)
+            except Exception as exc:  # noqa: BLE001 — never break the turn
+                logger.debug("silence diagnostic skipped: %s", exc)
             self._event_log_path = None
 
     # ------------------------------------------------------------------
@@ -375,6 +503,7 @@ class SDKDispatcher(CLIDispatcher):
                     system_prompt=self._system_prompt,
                     settings_path=self._settings_path,
                     event_log_path=self._event_log_path,
+                    permission_mode=self._permission_mode,
                 )
             except SDKTransientError as exc:
                 failure_count += 1

--- a/orchestrator/sdk_dispatch.py
+++ b/orchestrator/sdk_dispatch.py
@@ -29,7 +29,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Protocol, runtime_checkable
+from typing import Callable, Literal, Protocol, runtime_checkable
 
 from orchestrator.cli_dispatch import CLIDispatcher, _backoff_for
 from orchestrator.metrics import log_metrics, log_retry_event
@@ -200,8 +200,16 @@ class SDKRunner(Protocol):
         system_prompt: str | None = None,
         settings_path: Path | None = None,
         event_log_path: Path | None = None,
-        permission_mode: str | None = None,
+        permission_mode: Literal["bypassPermissions"] | None = None,
     ) -> SDKResult:
+        """One SDK turn.
+
+        ``permission_mode``: ``"bypassPermissions"`` disables the Claude
+        Code SDK's filesystem sandbox (the default for nous campaigns;
+        see #193). ``None`` means: don't pass the flag — let the SDK
+        apply its own default permission gating. The dispatcher
+        translates ``campaign.sandbox`` to one of these two values.
+        """
         ...
 
 
@@ -221,7 +229,7 @@ def _default_sdk_runner_factory() -> SDKRunner:
         system_prompt: str | None = None,
         settings_path: Path | None = None,
         event_log_path: Path | None = None,
-        permission_mode: str | None = "bypassPermissions",
+        permission_mode: Literal["bypassPermissions"] | None = "bypassPermissions",
     ) -> SDKResult:
         try:
             import anyio
@@ -381,16 +389,30 @@ class SDKDispatcher(CLIDispatcher):
             raise ValueError(
                 f"campaign.sandbox must be 'bypass' or 'default', got {resolved!r}"
             )
-        self._permission_mode = (
+        self._permission_mode: Literal["bypassPermissions"] | None = (
             "bypassPermissions" if resolved == "bypass" else None
         )
         # #201: silence threshold (seconds) for post-turn diagnostics.
         # Default 600s; opt out by setting to 0. Configured per-campaign
         # via campaign.sdk_timeouts.silence_threshold_seconds.
         timeouts = campaign.get("sdk_timeouts") or {}
-        self._silence_threshold = float(
-            timeouts.get("silence_threshold_seconds", 600)
-        )
+        raw_threshold = timeouts.get("silence_threshold_seconds", 600)
+        try:
+            self._silence_threshold = float(raw_threshold)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"campaign.sdk_timeouts.silence_threshold_seconds must be "
+                f"a non-negative number, got {raw_threshold!r}"
+            ) from exc
+        # Defensive Python-side validation. The schema enforces
+        # ``minimum: 0`` but ad-hoc dict callers (programmatic entry
+        # points, tests) bypass schema validation; mirror the
+        # ``sandbox`` enum check for consistency.
+        if self._silence_threshold < 0:
+            raise ValueError(
+                f"campaign.sdk_timeouts.silence_threshold_seconds must be "
+                f">= 0, got {self._silence_threshold}"
+            )
         # #127 Phase B: event log path is recomputed per-dispatch (it depends
         # on the iteration), so we don't store it on the dispatcher.
         self._event_log_path: Path | None = None
@@ -404,6 +426,10 @@ class SDKDispatcher(CLIDispatcher):
         between events larger than the configured threshold, append a
         ``failure_type: "sdk_silence"`` entry to retry_log.jsonl. Purely
         observational; doesn't interrupt or fail the turn.
+
+        ``campaign.sdk_timeouts.silence_threshold_seconds == 0`` (or
+        unset and ``< 0`` after Python-side validation) disables the
+        diagnostic entirely.
         """
         if self._silence_threshold <= 0 or self._event_log_path is None:
             return
@@ -449,7 +475,9 @@ class SDKDispatcher(CLIDispatcher):
             try:
                 self._maybe_log_silence(iteration=iteration, phase=phase)
             except Exception as exc:  # noqa: BLE001 — never break the turn
-                logger.debug("silence diagnostic skipped: %s", exc)
+                # warning, not debug: if the diagnostic crashes every
+                # turn, debug-only logs would never surface that.
+                logger.warning("silence diagnostic skipped: %s", exc)
             self._event_log_path = None
 
     # ------------------------------------------------------------------

--- a/orchestrator/validate.py
+++ b/orchestrator/validate.py
@@ -42,20 +42,44 @@ _KNOWN_ROOT_FILES = {
 }
 
 
-def _check_unexpected_files(iter_dir: Path) -> list[str]:
-    """Flag files at iter root that aren't known protocol artifacts."""
+def _check_unexpected_files(
+    iter_dir: Path,
+    extra_allowed: set[str] | frozenset[str] = frozenset(),
+) -> list[str]:
+    """Flag files at iter root that aren't known protocol artifacts.
+
+    #199: ``extra_allowed`` is a per-campaign extension to the global
+    ``_KNOWN_ROOT_FILES`` whitelist. Campaigns that need additional
+    iter-root artifacts (e.g. paper-* needing ``analysis_summary.json``
+    + ``manifest.json``) declare them via ``campaign.validation.iter_root_extensions``
+    in the campaign YAML.
+    """
     if not iter_dir.is_dir():
         return []
+    allowed = _KNOWN_ROOT_FILES | set(extra_allowed)
     errors = []
     for f in iter_dir.iterdir():
         if f.is_dir():
             continue
-        if f.name not in _KNOWN_ROOT_FILES:
+        if f.name not in allowed:
             errors.append(
                 f"unexpected file at iter root: {f.name} "
                 f"(should be in inputs/ or results/)"
             )
     return errors
+
+
+def _campaign_iter_root_extensions(campaign: dict | None) -> frozenset[str]:
+    """Read ``campaign.validation.iter_root_extensions`` (#199).
+
+    Returns an empty frozenset for campaigns that don't declare it (the
+    common case — most campaigns are fine with the global whitelist).
+    """
+    if not campaign:
+        return frozenset()
+    validation = campaign.get("validation") or {}
+    extensions = validation.get("iter_root_extensions") or []
+    return frozenset(str(x) for x in extensions if x)
 
 
 def _validate_ground_truth_independence(bundle: dict) -> list[str]:
@@ -208,8 +232,13 @@ def _validate_typed_arm_fields(bundle: dict) -> list[str]:
     return errors
 
 
-def validate_design(iter_dir: Path) -> dict:
-    """Check design artifacts exist and conform to schemas."""
+def validate_design(iter_dir: Path, campaign: dict | None = None) -> dict:
+    """Check design artifacts exist and conform to schemas.
+
+    #199: ``campaign`` is optional but recommended — it enables the
+    per-campaign iter-root whitelist extension via
+    ``campaign.validation.iter_root_extensions``.
+    """
     iter_dir = Path(iter_dir)
     errors = []
 
@@ -250,14 +279,16 @@ def validate_design(iter_dir: Path) -> dict:
     elif handoff_path.stat().st_size == 0:
         errors.append("handoff_snapshot.md is empty")
 
-    errors.extend(_check_unexpected_files(iter_dir))
+    errors.extend(
+        _check_unexpected_files(iter_dir, _campaign_iter_root_extensions(campaign))
+    )
 
     if errors:
         return {"status": "fail", "errors": errors}
     return {"status": "pass"}
 
 
-def validate_execution(iter_dir: Path) -> dict:
+def validate_execution(iter_dir: Path, campaign: dict | None = None) -> dict:
     """Check execution artifacts exist, conform to schemas, and patches are valid."""
     iter_dir = Path(iter_dir)
     errors = []
@@ -368,7 +399,9 @@ def validate_execution(iter_dir: Path) -> dict:
         except KeyError as exc:
             errors.append(f"bundle.yaml arm missing required field: {exc}")
 
-    errors.extend(_check_unexpected_files(iter_dir))
+    errors.extend(
+        _check_unexpected_files(iter_dir, _campaign_iter_root_extensions(campaign))
+    )
 
     if errors:
         return {"status": "fail", "errors": errors}

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -253,7 +253,14 @@ class TestResumeCompletedCampaign:
         assert engine.phase == "DESIGN"  # untouched
 
     def test_mid_flight_corrupt_iteration_falls_back_to_1(self, tmp_path, caplog):
-        """Mid-flight with iteration < 1 in state.json falls back to 1 with a warning."""
+        """Mid-flight with iteration < 1 in state.json falls back to 1.
+
+        #202: the message was rewarded from WARNING ("starting fresh", which
+        sounded like data loss) to INFO with informative wording. After
+        #194 this path is mostly dead — engine.transition increments
+        iteration on leaving INIT — but the safety net stays for any
+        legitimately-corrupt state.json that survives a crash mid-write.
+        """
         import logging
         from orchestrator.campaign import _resume_completed_campaign
         work_dir = _setup_work_dir(tmp_path)
@@ -262,10 +269,17 @@ class TestResumeCompletedCampaign:
         state["iteration"] = 0
         (work_dir / "state.json").write_text(json.dumps(state))
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.INFO):
             result = _resume_completed_campaign(work_dir, max_iterations=5)
         assert result == 1
-        assert any("iteration=0" in r.message for r in caplog.records)
+        assert any(
+            "iteration=0" in r.message and "preserved" in r.message
+            for r in caplog.records
+        ), (
+            "expected an INFO log mentioning iteration=0 and that artifacts "
+            "are preserved (#202); got: "
+            f"{[r.message for r in caplog.records]}"
+        )
 
     def test_mid_flight_exceeds_max_iterations_warns(self, tmp_path, caplog):
         """Mid-flight iteration > max_iterations logs a warning and returns start."""

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -136,6 +136,42 @@ class TestCLIDispatcherUnit:
         assert "Experiment Design" in content
         assert "Research Question" in content
 
+    def test_dispatch_log_uses_runtime_class_name(
+        self, work_dir: Path, campaign: dict, caplog,
+    ) -> None:
+        """#196: SDKDispatcher inherits from CLIDispatcher; the dispatch log
+        line must report the runtime class name so operators don't think the
+        retired claude -p path (#183) is being used."""
+        import logging
+        from orchestrator.cli_dispatch import CLIDispatcher
+
+        # A trivial subclass simulates SDKDispatcher's relationship without
+        # pulling in the SDK. The contract is purely about the log line.
+        class FakeSubclass(CLIDispatcher):
+            pass
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({
+            "result": "minimal output", "is_error": False, "usage": {},
+            "total_cost_usd": 0, "duration_ms": 100, "num_turns": 1,
+        })
+        mock_result.stderr = ""
+
+        caplog.set_level(logging.INFO, logger="orchestrator.cli_dispatch")
+        with patch("orchestrator.cli_dispatch.subprocess.run", return_value=mock_result):
+            d = FakeSubclass(work_dir=work_dir, campaign=campaign)
+            out = work_dir / "runs" / "iter-1" / "design.md"
+            d.dispatch("planner", "design", output_path=out, iteration=1)
+
+        # The dispatch log line should name the subclass.
+        relevant = [r for r in caplog.records if "role=planner" in r.getMessage()]
+        assert relevant, "expected a dispatch log line"
+        assert "FakeSubclass" in relevant[-1].getMessage(), (
+            f"log line should name the runtime class, got: "
+            f"{relevant[-1].getMessage()!r}"
+        )
+
     def test_dispatch_executor_execute_analyze_saves_raw_output(self, work_dir: Path, campaign: dict) -> None:
         from orchestrator.cli_dispatch import CLIDispatcher
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -150,13 +150,53 @@ class TestEngine:
         assert engine.phase == "DONE"
 
     def test_human_design_gate_reject(self, work_dir):
-        """Human rejects at design gate -> back to DESIGN without incrementing."""
+        """Human rejects at design gate -> back to DESIGN without incrementing.
+
+        #194: iteration ticks once on leaving INIT; rejecting at the gate
+        and looping back to DESIGN must NOT tick it again.
+        """
         engine = Engine(work_dir)
         for s in ["DESIGN", "HUMAN_DESIGN_GATE"]:
             engine.transition(s)
+        # After INIT→DESIGN→GATE we're in iter-1.
+        assert engine.iteration == 1
         engine.transition("DESIGN")  # human rejects
         assert engine.phase == "DESIGN"
-        assert engine.iteration == 0  # must NOT increment
+        assert engine.iteration == 1  # still iter-1, must NOT re-increment
+
+    def test_iteration_ticks_on_leaving_init(self, work_dir):
+        """#194: state.iteration must equal 1 once iter-1 starts."""
+        engine = Engine(work_dir)
+        assert engine.iteration == 0  # INIT
+        engine.transition("DESIGN")
+        assert engine.iteration == 1  # iter-1 has begun
+
+    def test_iteration_is_1_throughout_iter1_phases(self, work_dir):
+        """#194: state.iteration stays at 1 across all of iter-1's phases.
+
+        Pre-#194 the counter sat at 0 throughout iter-1, breaking
+        ``nous status --line`` (which read state.iteration) while artifacts
+        were correctly being written to runs/iter-1/. Pin it.
+        """
+        engine = Engine(work_dir)
+        for phase in [
+            "DESIGN", "HUMAN_DESIGN_GATE",
+            "EXECUTE_ANALYZE", "HUMAN_FINDINGS_GATE",
+        ]:
+            engine.transition(phase)
+            assert engine.iteration == 1, (
+                f"after transitioning to {phase}, iteration should be 1 "
+                f"(matching runs/iter-1/), got {engine.iteration}"
+            )
+
+    def test_iteration_ticks_on_leaving_init_via_pre_work(self, work_dir):
+        """#194 + #167: PRE_WORK is on the INIT→DESIGN path; counter must
+        tick on leaving INIT regardless of which path is taken."""
+        engine = Engine(work_dir)
+        engine.transition("PRE_WORK")
+        assert engine.iteration == 1  # already in iter-1's pre-work
+        engine.transition("DESIGN")
+        assert engine.iteration == 1  # still iter-1; no double-tick
 
     def test_iteration_increments_on_done_to_design(self, work_dir):
         engine = Engine(work_dir)
@@ -165,9 +205,9 @@ class TestEngine:
             "HUMAN_FINDINGS_GATE", "DONE",
         ]:
             engine.transition(s)
-        assert engine.iteration == 0
+        assert engine.iteration == 1  # iter-1 done; counter stable through phases
         engine.transition("DESIGN")
-        assert engine.iteration == 1
+        assert engine.iteration == 2  # iter-2 begins
 
     def test_human_findings_gate_reject(self, work_dir):
         engine = Engine(work_dir)
@@ -192,33 +232,38 @@ class TestEngine:
         assert engine.phase == "DESIGN"
 
     def test_done_to_design_increments_iteration(self, work_dir):
-        """DONE -> DESIGN must increment iteration (resume a campaign)."""
+        """DONE -> DESIGN must increment iteration (start the next iter).
+
+        #194: state.iteration is now 1 throughout iter-1, ticking to 2 on
+        DONE→DESIGN. Pre-#194 it stayed at 0 throughout iter-1.
+        """
         engine = Engine(work_dir)
         for s in [
             "DESIGN", "HUMAN_DESIGN_GATE", "EXECUTE_ANALYZE",
             "HUMAN_FINDINGS_GATE", "DONE",
         ]:
             engine.transition(s)
-        assert engine.iteration == 0
+        assert engine.iteration == 1  # iter-1 done; counter has been 1 throughout
         engine.transition("DESIGN")
-        assert engine.iteration == 1
+        assert engine.iteration == 2  # iter-2 begins
 
     def test_multi_iteration(self, work_dir):
+        """#194: counter is 1 from leaving INIT, ticks to 2 on DONE→DESIGN."""
         engine = Engine(work_dir)
         for s in [
             "DESIGN", "HUMAN_DESIGN_GATE", "EXECUTE_ANALYZE",
-            "HUMAN_FINDINGS_GATE", "DONE",
-        ]:
-            engine.transition(s)
-        engine.transition("DESIGN")  # iter 0 -> 1
-        assert engine.iteration == 1
-        for s in [
-            "HUMAN_DESIGN_GATE", "EXECUTE_ANALYZE",
             "HUMAN_FINDINGS_GATE", "DONE",
         ]:
             engine.transition(s)
         engine.transition("DESIGN")  # iter 1 -> 2
         assert engine.iteration == 2
+        for s in [
+            "HUMAN_DESIGN_GATE", "EXECUTE_ANALYZE",
+            "HUMAN_FINDINGS_GATE", "DONE",
+        ]:
+            engine.transition(s)
+        engine.transition("DESIGN")  # iter 2 -> 3
+        assert engine.iteration == 3
 
 
 class TestSaveStateAtomicity:

--- a/tests/test_execute_artifact_assertion.py
+++ b/tests/test_execute_artifact_assertion.py
@@ -137,3 +137,101 @@ class TestRetryLogEntryShape:
             "findings.json", "principle_updates.json",
         ]
         assert "timestamp" in row  # auto-stamped
+
+
+# ─── End-to-end: run_iteration EXECUTE_ANALYZE wiring ────────────────────
+
+
+class TestRunIterationRaisesOnIncompleteExecute:
+    """Pin the orchestrator glue (#200): when EXECUTE_ANALYZE's dispatch
+    returns success but the required artifacts aren't on disk, the
+    orchestrator (a) writes a structured retry_log row, (b) raises
+    ExecuteAnalyzeIncompleteError, and (c) cleans up the experiment
+    worktree before raising. A regression that silently swallowed the
+    error or skipped the retry-log write would be invisible without
+    this test."""
+
+    def test_dispatcher_returns_success_but_no_artifacts_raises(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        from orchestrator.inline_dispatch import InlineDispatcher
+        from orchestrator.iteration import (
+            ExecuteAnalyzeIncompleteError,
+            run_iteration,
+        )
+
+        # Stub InlineDispatcher.dispatch so EXECUTE_ANALYZE returns
+        # cleanly without writing the required artifacts — simulating
+        # the actual paper-burst friction case (max_turns exhausted /
+        # subprocess hang / polling-loop stall, no findings on disk).
+        monkeypatch.setattr(
+            InlineDispatcher, "dispatch", lambda self, *a, **kw: None,
+        )
+
+        # Set up a work_dir with state.json pointing past DESIGN so we
+        # land in EXECUTE_ANALYZE on the first run_iteration call.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        iter_dir = work_dir / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        # Pre-populate DESIGN artifacts so DESIGN doesn't fire.
+        (iter_dir / "problem.md").write_text("p")
+        (iter_dir / "bundle.yaml").write_text(
+            "metadata:\n  iteration: 1\n  family: t\n  research_question: q\n"
+            "arms:\n"
+            "  - type: h-main\n"
+            "    prediction: p\n    mechanism: m\n    diagnostic: d\n"
+        )
+        (iter_dir / "handoff_snapshot.md").write_text("h")
+        (work_dir / "state.json").write_text(json.dumps({
+            "phase": "EXECUTE_ANALYZE",
+            "iteration": 1,
+            "run_id": "exp",
+            "family": "test",
+            "timestamp": "2026-01-01T00:00:00Z",
+        }))
+        (work_dir / "ledger.json").write_text(json.dumps({"iterations": []}))
+        (work_dir / "principles.json").write_text(
+            json.dumps({"principles": []}),
+        )
+
+        campaign = {
+            "research_question": "q?",
+            "run_id": "exp",
+            "max_iterations": 1,
+            "target_system": {
+                "name": "T", "description": "d",
+                # No repo_path → no worktree to clean up. Keeps the test
+                # focused on the raise + retry_log contract.
+            },
+            "prompts": {"methodology_layer": "p"},
+        }
+
+        with pytest.raises(ExecuteAnalyzeIncompleteError) as excinfo:
+            run_iteration(
+                campaign, work_dir, iteration=1, agent="inline",
+                auto_approve=True,
+            )
+        # Error names every required artifact (none of them exist).
+        assert sorted(excinfo.value.missing) == [
+            "experiment_plan.yaml", "findings.json", "principle_updates.json",
+        ]
+
+        # retry_log entry shape pinned.
+        retry_log = work_dir / "retry_log.jsonl"
+        assert retry_log.exists()
+        rows = [
+            json.loads(line)
+            for line in retry_log.read_text().splitlines() if line
+        ]
+        execute_rows = [
+            r for r in rows if r.get("failure_type") == "execute_incomplete"
+        ]
+        assert len(execute_rows) == 1
+        assert execute_rows[0]["phase"] == "execute-analyze"
+        assert execute_rows[0]["iteration"] == 1
+        assert sorted(execute_rows[0]["missing_artifacts"]) == [
+            "experiment_plan.yaml", "findings.json", "principle_updates.json",
+        ]

--- a/tests/test_execute_artifact_assertion.py
+++ b/tests/test_execute_artifact_assertion.py
@@ -1,0 +1,139 @@
+"""Behavioral tests for the EXECUTE_ANALYZE-incomplete diagnostic (#200).
+
+Sister to #187 (DesignIncompleteError). When EXECUTE_ANALYZE exits
+without producing experiment_plan.yaml / findings.json /
+principle_updates.json, the orchestrator surfaces a structured
+ExecuteAnalyzeIncompleteError naming what's missing and the four common
+causes (max_turns exhaustion, subprocess hang, polling loop, API stall).
+
+These tests exercise the helper + error directly without spawning real
+LLM calls.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# ─── _missing_execute_artifacts helper ────────────────────────────────────
+
+
+class TestMissingExecuteArtifactsHelper:
+    def test_all_present_returns_empty_list(self, tmp_path: Path) -> None:
+        from orchestrator.iteration import _missing_execute_artifacts
+        for name in (
+            "experiment_plan.yaml", "findings.json", "principle_updates.json",
+        ):
+            (tmp_path / name).write_text("ok")
+        assert _missing_execute_artifacts(tmp_path) == []
+
+    def test_some_missing_lists_only_those(self, tmp_path: Path) -> None:
+        from orchestrator.iteration import _missing_execute_artifacts
+        (tmp_path / "experiment_plan.yaml").write_text("ok")
+        # findings.json + principle_updates.json absent
+        result = _missing_execute_artifacts(tmp_path)
+        assert "experiment_plan.yaml" not in result
+        assert "findings.json" in result
+        assert "principle_updates.json" in result
+
+    def test_all_missing_lists_all(self, tmp_path: Path) -> None:
+        from orchestrator.iteration import _missing_execute_artifacts
+        result = _missing_execute_artifacts(tmp_path)
+        assert sorted(result) == [
+            "experiment_plan.yaml", "findings.json", "principle_updates.json",
+        ]
+
+
+# ─── ExecuteAnalyzeIncompleteError shape ─────────────────────────────────
+
+
+class TestExecuteAnalyzeIncompleteError:
+    def test_message_names_each_missing_file(self, tmp_path: Path) -> None:
+        from orchestrator.iteration import ExecuteAnalyzeIncompleteError
+        err = ExecuteAnalyzeIncompleteError(
+            missing=["findings.json", "principle_updates.json"],
+            iter_dir=tmp_path,
+            max_turns=120,
+        )
+        msg = str(err)
+        assert "findings.json" in msg
+        assert "principle_updates.json" in msg
+
+    def test_message_mentions_max_turns(self, tmp_path: Path) -> None:
+        from orchestrator.iteration import ExecuteAnalyzeIncompleteError
+        err = ExecuteAnalyzeIncompleteError(
+            missing=["findings.json"], iter_dir=tmp_path, max_turns=137,
+        )
+        assert "137" in str(err)
+
+    def test_message_lists_actionable_recovery_hints(self, tmp_path: Path) -> None:
+        """All four common causes must be named so the operator can
+        self-diagnose without grepping the source."""
+        from orchestrator.iteration import ExecuteAnalyzeIncompleteError
+        msg = str(ExecuteAnalyzeIncompleteError(
+            missing=["findings.json"], iter_dir=tmp_path, max_turns=120,
+        )).lower()
+        assert "max_turns" in msg
+        assert "subprocess" in msg or "hang" in msg
+        assert "polling" in msg or "sleep" in msg
+        assert "stall" in msg or "transport" in msg
+
+    def test_message_points_at_executor_log_under_inputs(
+        self, tmp_path: Path,
+    ) -> None:
+        """#190: streaming log lives at inputs/executor_log.jsonl."""
+        from orchestrator.iteration import ExecuteAnalyzeIncompleteError
+        msg = str(ExecuteAnalyzeIncompleteError(
+            missing=["findings.json"], iter_dir=tmp_path, max_turns=120,
+        ))
+        assert "inputs/executor_log.jsonl" in msg or (
+            "inputs" in msg and "executor_log.jsonl" in msg
+        )
+
+    def test_attributes_preserved_for_callers(self, tmp_path: Path) -> None:
+        """The orchestrator inspects the exception to write retry_log
+        entries; data must be reachable, not just baked into the string."""
+        from orchestrator.iteration import ExecuteAnalyzeIncompleteError
+        err = ExecuteAnalyzeIncompleteError(
+            missing=["findings.json", "experiment_plan.yaml"],
+            iter_dir=tmp_path,
+            max_turns=120,
+        )
+        assert err.missing == ["findings.json", "experiment_plan.yaml"]
+        assert err.iter_dir == tmp_path
+        assert err.max_turns == 120
+
+
+# ─── retry_log.jsonl integration ─────────────────────────────────────────
+
+
+class TestRetryLogEntryShape:
+    """When EXECUTE_ANALYZE incomplete fires, a structured retry entry
+    must be appended so meta_findings (#170) and the operator can see it."""
+
+    def test_log_retry_event_shape(self, tmp_path: Path) -> None:
+        from orchestrator.metrics import log_retry_event
+        metrics_path = tmp_path / "llm_metrics.jsonl"
+        log_retry_event(metrics_path, {
+            "iteration": 1,
+            "phase": "execute-analyze",
+            "failure_type": "execute_incomplete",
+            "missing_artifacts": ["findings.json", "principle_updates.json"],
+            "max_turns": 120,
+        })
+        retry_log = tmp_path / "retry_log.jsonl"
+        assert retry_log.exists()
+        rows = [
+            json.loads(line)
+            for line in retry_log.read_text().splitlines() if line
+        ]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["failure_type"] == "execute_incomplete"
+        assert row["phase"] == "execute-analyze"
+        assert row["missing_artifacts"] == [
+            "findings.json", "principle_updates.json",
+        ]
+        assert "timestamp" in row  # auto-stamped

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -132,11 +132,13 @@ class TestSingleIterationHappyPath:
         engine.transition("HUMAN_FINDINGS_GATE")
         _merge_principles(campaign_dir, iter_dir)
         engine.transition("DONE")
-        assert engine.iteration == 0
+        # #194: iteration counter is 1 throughout iter-1 (incremented on
+        # leaving INIT). Pre-#194 it stayed at 0 until DONE→DESIGN.
+        assert engine.iteration == 1
 
         # Loop to next iteration
         engine.transition("DESIGN")
-        assert engine.iteration == 1
+        assert engine.iteration == 2
 
         # Iteration 2: refuted
         iter_dir2 = campaign_dir / "runs" / "iter-2"
@@ -155,7 +157,8 @@ class TestSingleIterationHappyPath:
         _merge_principles(campaign_dir, iter_dir2)
         engine.transition("DONE")
         assert engine.phase == "DONE"
-        assert engine.iteration == 1
+        # #194: iter-2 done; counter sat at 2 throughout iter-2.
+        assert engine.iteration == 2
 
         # Verify principles accumulated
         principles = json.loads((campaign_dir / "principles.json").read_text())

--- a/tests/test_integration_real_execution.py
+++ b/tests/test_integration_real_execution.py
@@ -28,8 +28,8 @@ class TestEnterPhase:
         (tmp_path / "state.json").write_text(json.dumps(state))
         engine = Engine(tmp_path)
 
-        assert _enter_phase(engine, "DESIGN") is False
-        assert _enter_phase(engine, "HUMAN_DESIGN_GATE") is False
+        assert _enter_phase(engine, "DESIGN", tmp_path) is False
+        assert _enter_phase(engine, "HUMAN_DESIGN_GATE", tmp_path) is False
         assert engine.phase == "EXECUTE_ANALYZE"  # unchanged
 
     def test_redo_current_phase(self, tmp_path):
@@ -41,7 +41,7 @@ class TestEnterPhase:
         (tmp_path / "state.json").write_text(json.dumps(state))
         engine = Engine(tmp_path)
 
-        assert _enter_phase(engine, "EXECUTE_ANALYZE") is True
+        assert _enter_phase(engine, "EXECUTE_ANALYZE", tmp_path) is True
         assert engine.phase == "EXECUTE_ANALYZE"  # no transition happened
 
     def test_advance_to_next_phase(self, tmp_path):
@@ -53,7 +53,7 @@ class TestEnterPhase:
         (tmp_path / "state.json").write_text(json.dumps(state))
         engine = Engine(tmp_path)
 
-        assert _enter_phase(engine, "DESIGN") is True
+        assert _enter_phase(engine, "DESIGN", tmp_path) is True
         assert engine.phase == "DESIGN"
 
     def test_done_skips_everything(self, tmp_path):
@@ -66,7 +66,7 @@ class TestEnterPhase:
         engine = Engine(tmp_path)
 
         for phase in _PHASE_ORDER:
-            assert _enter_phase(engine, phase) is (phase == "DONE")
+            assert _enter_phase(engine, phase, tmp_path) is (phase == "DONE")
 
     def test_phase_order_matches_engine_phases(self):
         """_PHASE_ORDER must contain exactly the same phases as the engine."""
@@ -86,11 +86,11 @@ class TestEnterPhase:
         (tmp_path / "state.json").write_text(json.dumps(state))
         engine = Engine(tmp_path)
 
-        assert _enter_phase(engine, "DESIGN") is False
-        assert _enter_phase(engine, "EXECUTE_ANALYZE") is True
+        assert _enter_phase(engine, "DESIGN", tmp_path) is False
+        assert _enter_phase(engine, "EXECUTE_ANALYZE", tmp_path) is True
         assert engine.phase == "EXECUTE_ANALYZE"
         # Can advance to next
-        assert _enter_phase(engine, "HUMAN_FINDINGS_GATE") is True
+        assert _enter_phase(engine, "HUMAN_FINDINGS_GATE", tmp_path) is True
         assert engine.phase == "HUMAN_FINDINGS_GATE"
 
 

--- a/tests/test_max_iterations_persist.py
+++ b/tests/test_max_iterations_persist.py
@@ -1,0 +1,176 @@
+"""Behavioral tests for max_iterations persistence across resume (#197).
+
+Pre-#197 a kill + ``nous resume`` without --max-iterations silently
+defaulted to 10, so a campaign launched with --max-iterations 1 would
+quietly extend to 10 iterations on resume — major operational footgun.
+After #197 the effective max_iterations is persisted into state.json
+on first run and read back on resume when no CLI flag is supplied.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _state_with(max_iter: int | None = None, **extra) -> dict:
+    state = {
+        "phase": "INIT",
+        "iteration": 0,
+        "run_id": "demo",
+        "family": "test",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }
+    if max_iter is not None:
+        state["max_iterations"] = max_iter
+    state.update(extra)
+    return state
+
+
+class TestPersistMaxIterations:
+    def test_persists_value_when_state_exists(self, tmp_path: Path) -> None:
+        from orchestrator.campaign import _persist_max_iterations
+        (tmp_path / "state.json").write_text(json.dumps(_state_with()))
+        _persist_max_iterations(tmp_path, 7)
+        state = json.loads((tmp_path / "state.json").read_text())
+        assert state["max_iterations"] == 7
+
+    def test_silently_skips_when_state_missing(self, tmp_path: Path) -> None:
+        """Best-effort: no state.json means no-op (run_campaign sets up
+        state via setup_work_dir before calling this in production)."""
+        from orchestrator.campaign import _persist_max_iterations
+        _persist_max_iterations(tmp_path, 7)  # must not raise
+        assert not (tmp_path / "state.json").exists()
+
+    def test_idempotent_when_value_unchanged(self, tmp_path: Path) -> None:
+        from orchestrator.campaign import _persist_max_iterations
+        (tmp_path / "state.json").write_text(json.dumps(_state_with(max_iter=5)))
+        before = (tmp_path / "state.json").stat().st_mtime_ns
+        _persist_max_iterations(tmp_path, 5)
+        after = (tmp_path / "state.json").stat().st_mtime_ns
+        assert before == after, "no-op rewrite should not touch the file"
+
+
+class TestReadPersistedMaxIterations:
+    def test_returns_value_when_present(self, tmp_path: Path) -> None:
+        from orchestrator.campaign import read_persisted_max_iterations
+        (tmp_path / "state.json").write_text(json.dumps(_state_with(max_iter=3)))
+        assert read_persisted_max_iterations(tmp_path) == 3
+
+    def test_returns_none_when_field_absent(self, tmp_path: Path) -> None:
+        from orchestrator.campaign import read_persisted_max_iterations
+        (tmp_path / "state.json").write_text(json.dumps(_state_with()))
+        assert read_persisted_max_iterations(tmp_path) is None
+
+    def test_returns_none_when_state_missing(self, tmp_path: Path) -> None:
+        from orchestrator.campaign import read_persisted_max_iterations
+        assert read_persisted_max_iterations(tmp_path) is None
+
+    def test_returns_none_when_state_corrupt(self, tmp_path: Path) -> None:
+        from orchestrator.campaign import read_persisted_max_iterations
+        (tmp_path / "state.json").write_text("not valid json{")
+        assert read_persisted_max_iterations(tmp_path) is None
+
+    def test_returns_none_for_invalid_value(self, tmp_path: Path) -> None:
+        """Defensive: max_iterations < 1 or non-int doesn't propagate as
+        a usable value."""
+        from orchestrator.campaign import read_persisted_max_iterations
+        for bad in (0, -3, "ten", None, [3]):
+            (tmp_path / "state.json").write_text(
+                json.dumps({**_state_with(), "max_iterations": bad})
+            )
+            assert read_persisted_max_iterations(tmp_path) is None, bad
+
+
+class TestResumeReadsPersistedCap:
+    """End-to-end via _cmd_resume: a campaign launched with --max-iterations 1
+    leaves max_iterations=1 in state.json; a resume without --max-iterations
+    must use that cap rather than defaulting to 10.
+    """
+
+    def test_resume_uses_persisted_cap_when_cli_flag_absent(
+        self, tmp_path: Path, monkeypatch, capsys,
+    ) -> None:
+        import argparse
+        from orchestrator import cli as cli_mod
+
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        work_dir = repo / ".nous" / "demo"
+        work_dir.mkdir(parents=True)
+        # Mid-flight state with persisted cap.
+        (work_dir / "state.json").write_text(json.dumps(
+            _state_with(max_iter=1, phase="DESIGN")
+        ))
+
+        campaign_file = tmp_path / "campaign.yaml"
+        campaign_file.write_text(
+            "run_id: demo\n"
+            "max_iterations: 99\n"  # Different from persisted cap
+            "research_question: q\n"
+            f"target_system:\n  name: t\n  description: d\n  repo_path: {repo}\n"
+            "prompts:\n  methodology_layer: p\n"
+        )
+
+        captured: dict = {}
+
+        def fake_run_campaign(*args, **kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(cli_mod, "_cmd_resume", cli_mod._cmd_resume)
+        # Patch run_campaign at the import site inside _cmd_resume
+        from orchestrator import campaign as campaign_mod
+        monkeypatch.setattr(campaign_mod, "run_campaign", fake_run_campaign)
+
+        args = argparse.Namespace(
+            target=str(campaign_file), max_iterations=None, model=None,
+            auto_approve=True, timeout=1800, max_cli_retries=10,
+            agent="sdk", verbose=False,
+        )
+        cli_mod._cmd_resume(args)
+
+        # Persisted cap (1) wins over campaign.yaml's max_iterations (99).
+        assert captured.get("max_iterations") == 1
+        out = capsys.readouterr().out
+        assert "persisted" in out
+
+    def test_resume_cli_flag_overrides_persisted(
+        self, tmp_path: Path, monkeypatch, capsys,
+    ) -> None:
+        """Explicit --max-iterations on resume always wins."""
+        import argparse
+        from orchestrator import cli as cli_mod
+        from orchestrator import campaign as campaign_mod
+
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        work_dir = repo / ".nous" / "demo"
+        work_dir.mkdir(parents=True)
+        (work_dir / "state.json").write_text(json.dumps(
+            _state_with(max_iter=1, phase="DESIGN")
+        ))
+        campaign_file = tmp_path / "campaign.yaml"
+        campaign_file.write_text(
+            "run_id: demo\n"
+            "research_question: q\n"
+            f"target_system:\n  name: t\n  description: d\n  repo_path: {repo}\n"
+            "prompts:\n  methodology_layer: p\n"
+        )
+
+        captured: dict = {}
+        monkeypatch.setattr(
+            campaign_mod, "run_campaign",
+            lambda *a, **kw: captured.update(kw),
+        )
+
+        args = argparse.Namespace(
+            target=str(campaign_file), max_iterations=5, model=None,
+            auto_approve=True, timeout=1800, max_cli_retries=10,
+            agent="sdk", verbose=False,
+        )
+        cli_mod._cmd_resume(args)
+
+        assert captured.get("max_iterations") == 5  # CLI wins
+        out = capsys.readouterr().out
+        assert "CLI override" in out

--- a/tests/test_max_iterations_persist.py
+++ b/tests/test_max_iterations_persist.py
@@ -135,6 +135,87 @@ class TestResumeReadsPersistedCap:
         out = capsys.readouterr().out
         assert "persisted" in out
 
+    def test_resume_falls_back_to_campaign_yaml_when_state_absent(
+        self, tmp_path: Path, monkeypatch, capsys,
+    ) -> None:
+        """#197 resolution chain step 3: state.json has no max_iterations
+        AND no CLI flag → fall back to campaign.yaml.max_iterations.
+        Pre-#197 state files don't carry the field; this preserves their
+        intended cap on resume."""
+        import argparse
+        from orchestrator import cli as cli_mod
+        from orchestrator import campaign as campaign_mod
+
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        work_dir = repo / ".nous" / "demo"
+        work_dir.mkdir(parents=True)
+        # state.json from a pre-#197 run: no max_iterations field.
+        (work_dir / "state.json").write_text(json.dumps(
+            _state_with(phase="DESIGN")  # no max_iter
+        ))
+        campaign_file = tmp_path / "campaign.yaml"
+        campaign_file.write_text(
+            "run_id: demo\n"
+            "max_iterations: 7\n"  # campaign.yaml's cap should be honoured
+            "research_question: q\n"
+            f"target_system:\n  name: t\n  description: d\n  repo_path: {repo}\n"
+            "prompts:\n  methodology_layer: p\n"
+        )
+        captured: dict = {}
+        monkeypatch.setattr(
+            campaign_mod, "run_campaign",
+            lambda *a, **kw: captured.update(kw),
+        )
+
+        args = argparse.Namespace(
+            target=str(campaign_file), max_iterations=None, model=None,
+            auto_approve=True, timeout=1800, max_cli_retries=10,
+            agent="sdk", verbose=False,
+        )
+        cli_mod._cmd_resume(args)
+        assert captured.get("max_iterations") == 7
+        out = capsys.readouterr().out
+        assert "campaign.yaml" in out
+
+    def test_resume_falls_back_to_default_10_when_neither_set(
+        self, tmp_path: Path, monkeypatch, capsys,
+    ) -> None:
+        """#197 resolution chain step 4: state has no field, campaign.yaml
+        has no field, no CLI flag → hardcoded default 10."""
+        import argparse
+        from orchestrator import cli as cli_mod
+        from orchestrator import campaign as campaign_mod
+
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        work_dir = repo / ".nous" / "demo"
+        work_dir.mkdir(parents=True)
+        (work_dir / "state.json").write_text(json.dumps(
+            _state_with(phase="DESIGN")
+        ))
+        campaign_file = tmp_path / "campaign.yaml"
+        # No max_iterations field at all.
+        campaign_file.write_text(
+            "run_id: demo\n"
+            "research_question: q\n"
+            f"target_system:\n  name: t\n  description: d\n  repo_path: {repo}\n"
+            "prompts:\n  methodology_layer: p\n"
+        )
+        captured: dict = {}
+        monkeypatch.setattr(
+            campaign_mod, "run_campaign",
+            lambda *a, **kw: captured.update(kw),
+        )
+
+        args = argparse.Namespace(
+            target=str(campaign_file), max_iterations=None, model=None,
+            auto_approve=True, timeout=1800, max_cli_retries=10,
+            agent="sdk", verbose=False,
+        )
+        cli_mod._cmd_resume(args)
+        assert captured.get("max_iterations") == 10  # hardcoded default
+
     def test_resume_cli_flag_overrides_persisted(
         self, tmp_path: Path, monkeypatch, capsys,
     ) -> None:

--- a/tests/test_nous_stop.py
+++ b/tests/test_nous_stop.py
@@ -282,18 +282,91 @@ class TestEnterPhaseHonorsSentinel:
         result = _enter_phase(engine, "DESIGN", tmp_path)
         assert result is False
 
-    def test_enter_phase_without_work_dir_skips_sentinel_check(
-        self, tmp_path: Path,
-    ) -> None:
-        """Backwards-compat: callers passing no work_dir get the old
-        behavior (no sentinel check). Keeps ad-hoc test fixtures simple."""
+    def test_enter_phase_requires_work_dir(self, tmp_path: Path) -> None:
+        """``work_dir`` is required (post-PR-#204 review tightening).
+
+        A default of ``None`` would silently skip the stop-sentinel check
+        for any caller that forgot to pass it. Failing fast at TypeError
+        is the right shape — all in-repo callers pass it.
+        """
         from orchestrator.engine import Engine
-        from orchestrator.iteration import _enter_phase, STOP_SENTINEL_NAME
+        from orchestrator.iteration import _enter_phase
 
         _seed_init_state(tmp_path)
         engine = Engine(tmp_path)
-        (tmp_path / STOP_SENTINEL_NAME).write_text("ignored\n")
+        with pytest.raises(TypeError):
+            _enter_phase(engine, "DESIGN")  # missing work_dir → TypeError
 
-        result = _enter_phase(engine, "DESIGN")  # no work_dir
-        assert result is True
-        assert engine.phase == "DESIGN"
+
+# ─── End-to-end: run_iteration honours mid-iteration sentinel (#198) ─────
+
+
+class TestRunIterationHaltsAtPhaseBoundary:
+    """Pin the call-site wiring (#198): run_iteration's four _enter_phase
+    calls each pass work_dir, so a STOP sentinel written mid-iteration
+    halts at the next phase boundary instead of waiting for the next
+    iteration. A regression that drops work_dir from any of the four
+    call sites would not be caught by the _enter_phase unit tests
+    alone.
+    """
+
+    def test_sentinel_after_design_halts_before_design_gate(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """Stage state at DESIGN, write sentinel, run_iteration must
+        raise CampaignStopped naming the next phase boundary."""
+        from orchestrator.inline_dispatch import InlineDispatcher
+        from orchestrator.iteration import (
+            CampaignStopped,
+            STOP_SENTINEL_NAME,
+            run_iteration,
+        )
+
+        # Make InlineDispatcher.dispatch a no-op so DESIGN doesn't
+        # actually try to do anything; the test focuses on the
+        # phase-boundary sentinel honor on transition out of DESIGN.
+        monkeypatch.setattr(
+            InlineDispatcher, "dispatch", lambda self, *a, **kw: None,
+        )
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        iter_dir = work_dir / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        # Pre-stage all DESIGN artifacts so DESIGN's own "incomplete"
+        # check passes and we proceed toward HUMAN_DESIGN_GATE.
+        (iter_dir / "problem.md").write_text("p")
+        (iter_dir / "bundle.yaml").write_text(
+            "metadata:\n  iteration: 1\n  family: t\n  research_question: q\n"
+            "arms:\n  - type: h-main\n"
+            "    prediction: p\n    mechanism: m\n    diagnostic: d\n"
+        )
+        (iter_dir / "handoff_snapshot.md").write_text("h")
+        (work_dir / "state.json").write_text(json.dumps({
+            "phase": "DESIGN", "iteration": 1, "run_id": "exp",
+            "family": "test", "timestamp": "2026-01-01T00:00:00Z",
+        }))
+        (work_dir / "ledger.json").write_text(json.dumps({"iterations": []}))
+        (work_dir / "principles.json").write_text(
+            json.dumps({"principles": []}),
+        )
+        # Sentinel pre-staged: as soon as run_iteration tries to
+        # transition out of DESIGN into HUMAN_DESIGN_GATE, the
+        # _enter_phase check at that call site must honour it.
+        (work_dir / STOP_SENTINEL_NAME).write_text("test halt\n")
+
+        campaign = {
+            "research_question": "q?",
+            "run_id": "exp",
+            "max_iterations": 1,
+            "target_system": {"name": "T", "description": "d"},
+            "prompts": {"methodology_layer": "p"},
+        }
+
+        with pytest.raises(CampaignStopped, match="HUMAN_DESIGN_GATE"):
+            run_iteration(
+                campaign, work_dir, iteration=1, agent="inline",
+                auto_approve=True,
+            )

--- a/tests/test_nous_stop.py
+++ b/tests/test_nous_stop.py
@@ -205,3 +205,95 @@ class TestCampaignLoopHonoursSentinel:
             "stopped_by_user" in (r.get("error") or "")
             for r in rows
         ), f"ledger should record stopped_by_user; got {rows}"
+
+
+# ─── Phase-boundary stop checks (#198) ───────────────────────────────────
+
+
+def _seed_init_state(work_dir: Path) -> None:
+    """Write a minimal INIT-phase state.json so Engine() can initialize."""
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / "state.json").write_text(json.dumps({
+        "phase": "INIT",
+        "iteration": 0,
+        "run_id": "test",
+        "family": "test",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }))
+
+
+class TestEnterPhaseHonorsSentinel:
+    """#198: _enter_phase honours the STOP sentinel before transitioning,
+    so an in-flight iteration halts at the next phase boundary instead of
+    waiting for the next iteration loop."""
+
+    def test_enter_phase_with_no_sentinel_proceeds(self, tmp_path: Path) -> None:
+        from orchestrator.engine import Engine
+        from orchestrator.iteration import _enter_phase
+
+        _seed_init_state(tmp_path)
+        engine = Engine(tmp_path)
+        # Fresh state: phase=INIT. Should transition to DESIGN cleanly.
+        result = _enter_phase(engine, "DESIGN", tmp_path)
+        assert result is True
+        assert engine.phase == "DESIGN"
+
+    def test_enter_phase_with_sentinel_raises_before_transition(
+        self, tmp_path: Path,
+    ) -> None:
+        """Mid-iter scenario: the operator wrote a STOP sentinel while
+        DESIGN was running. As we try to enter HUMAN_DESIGN_GATE the next
+        phase boundary should honour the sentinel and raise CampaignStopped
+        without advancing the engine."""
+        from orchestrator.engine import Engine
+        from orchestrator.iteration import (
+            CampaignStopped, STOP_SENTINEL_NAME, _enter_phase,
+        )
+
+        _seed_init_state(tmp_path)
+        engine = Engine(tmp_path)
+        engine.transition("DESIGN")
+        (tmp_path / STOP_SENTINEL_NAME).write_text("user halt mid-design\n")
+
+        with pytest.raises(CampaignStopped, match="HUMAN_DESIGN_GATE"):
+            _enter_phase(engine, "HUMAN_DESIGN_GATE", tmp_path)
+        # Engine state preserved at the pre-transition phase.
+        assert engine.phase == "DESIGN"
+
+    def test_enter_phase_skip_path_does_not_check_sentinel(
+        self, tmp_path: Path,
+    ) -> None:
+        """When _enter_phase is asked for a phase already passed (skip-past
+        on resume), no transition happens and we should NOT honour the
+        sentinel — that scenario is for the iter-loop's own stop check."""
+        from orchestrator.engine import Engine
+        from orchestrator.iteration import (
+            STOP_SENTINEL_NAME, _enter_phase,
+        )
+
+        _seed_init_state(tmp_path)
+        engine = Engine(tmp_path)
+        for p in ["DESIGN", "HUMAN_DESIGN_GATE", "EXECUTE_ANALYZE",
+                  "HUMAN_FINDINGS_GATE", "DONE"]:
+            engine.transition(p)
+        (tmp_path / STOP_SENTINEL_NAME).write_text("late stop\n")
+
+        # Asking for DESIGN now (we're past it) returns False without raising.
+        result = _enter_phase(engine, "DESIGN", tmp_path)
+        assert result is False
+
+    def test_enter_phase_without_work_dir_skips_sentinel_check(
+        self, tmp_path: Path,
+    ) -> None:
+        """Backwards-compat: callers passing no work_dir get the old
+        behavior (no sentinel check). Keeps ad-hoc test fixtures simple."""
+        from orchestrator.engine import Engine
+        from orchestrator.iteration import _enter_phase, STOP_SENTINEL_NAME
+
+        _seed_init_state(tmp_path)
+        engine = Engine(tmp_path)
+        (tmp_path / STOP_SENTINEL_NAME).write_text("ignored\n")
+
+        result = _enter_phase(engine, "DESIGN")  # no work_dir
+        assert result is True
+        assert engine.phase == "DESIGN"

--- a/tests/test_sdk_dispatch.py
+++ b/tests/test_sdk_dispatch.py
@@ -347,3 +347,76 @@ class TestSDKDispatchErrorResult:
         retry_log = _read_jsonl(tmp_path / "retry_log.jsonl")
         assert len(retry_log) == 1
         assert "rate limit exceeded" in retry_log[0]["error"]
+
+
+# ─── _tee_event extraction (#195) ─────────────────────────────────────────
+
+
+class _FakeToolUseBlock:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _FakeTextBlock:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class _FakeAssistantMessage:
+    """Mimics SDK message shape: tool_name not at top level; lives on
+    ToolUseBlock instances inside the content list."""
+    def __init__(self, content: list):
+        self.content = content
+
+
+class TestTeeEventToolNameExtraction:
+    """#195: _tee_event must extract tool_name from ToolUseBlock entries
+    inside content, not from the message top-level (which is empty)."""
+
+    def test_extracts_tool_name_from_tool_use_block(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import _tee_event
+        log = tmp_path / "executor_log.jsonl"
+        msg = _FakeAssistantMessage(content=[
+            _FakeTextBlock("thinking..."),
+            _FakeToolUseBlock(name="Bash"),
+        ])
+        _tee_event(log, msg, "AssistantMessage")
+        rows = [json.loads(l) for l in log.read_text().splitlines() if l]
+        assert len(rows) == 1
+        assert rows[0]["tool_name"] == "Bash"
+
+    def test_picks_last_tool_block_when_multiple(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import _tee_event
+        log = tmp_path / "executor_log.jsonl"
+        msg = _FakeAssistantMessage(content=[
+            _FakeToolUseBlock(name="Read"),
+            _FakeToolUseBlock(name="Bash"),
+            _FakeToolUseBlock(name="Edit"),
+        ])
+        _tee_event(log, msg, "AssistantMessage")
+        rows = [json.loads(l) for l in log.read_text().splitlines() if l]
+        # Last tool wins — most recent action.
+        assert rows[0]["tool_name"] == "Edit"
+
+    def test_no_tool_block_means_no_tool_name(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import _tee_event
+        log = tmp_path / "executor_log.jsonl"
+        msg = _FakeAssistantMessage(content=[_FakeTextBlock("just text")])
+        _tee_event(log, msg, "AssistantMessage")
+        rows = [json.loads(l) for l in log.read_text().splitlines() if l]
+        assert "tool_name" not in rows[0]
+
+    def test_top_level_tool_name_still_wins_when_present(self, tmp_path: Path) -> None:
+        """Forward-compat: if a future SDK release puts tool_name at
+        message top-level, prefer that over the content-walk fallback."""
+        from orchestrator.sdk_dispatch import _tee_event
+        log = tmp_path / "executor_log.jsonl"
+
+        class _MsgWithTopLevelToolName:
+            tool_name = "TopLevelTool"
+            content = [_FakeToolUseBlock(name="Bash")]
+
+        _tee_event(log, _MsgWithTopLevelToolName(), "AssistantMessage")
+        rows = [json.loads(l) for l in log.read_text().splitlines() if l]
+        assert rows[0]["tool_name"] == "TopLevelTool"
+

--- a/tests/test_sdk_sandbox.py
+++ b/tests/test_sdk_sandbox.py
@@ -134,6 +134,84 @@ class TestSandboxValidation:
             )
 
 
+class TestCmdRunSandboxFlag:
+    """End-to-end (#193): the --sandbox CLI flag mutates campaign["sandbox"]
+    before run_campaign sees it, so SDKDispatcher reads the override.
+    A regression that drops the mutation at orchestrator/cli.py would
+    not be caught by the constructor-kwarg unit tests alone."""
+
+    def test_cli_flag_overrides_campaign_sandbox(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        import argparse
+        from orchestrator import cli as cli_mod
+        from orchestrator import campaign as campaign_mod
+
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        campaign_file = tmp_path / "campaign.yaml"
+        campaign_file.write_text(
+            "run_id: demo\n"
+            "max_iterations: 1\n"
+            "research_question: q\n"
+            f"target_system:\n  name: t\n  description: d\n  repo_path: {repo}\n"
+            "prompts:\n  methodology_layer: p\n"
+            "sandbox: bypass\n"  # campaign says bypass, CLI will override
+        )
+        captured: dict = {}
+        monkeypatch.setattr(
+            campaign_mod, "run_campaign",
+            lambda campaign, *a, **kw: captured.update(
+                campaign=campaign, **kw,
+            ),
+        )
+
+        args = argparse.Namespace(
+            campaign=str(campaign_file), max_iterations=1, model=None,
+            run_id=None, auto_approve=True, timeout=1800,
+            max_cli_retries=10, agent="sdk", sandbox="default",
+            bundle=None, problem_md=None, handoff_md=None, verbose=False,
+        )
+        cli_mod._cmd_run(args)
+        # CLI flag mutated campaign["sandbox"] from "bypass" → "default".
+        assert captured["campaign"]["sandbox"] == "default"
+
+    def test_cli_flag_absent_preserves_campaign_sandbox(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """When --sandbox is not passed, campaign.yaml's value should
+        flow through unchanged."""
+        import argparse
+        from orchestrator import cli as cli_mod
+        from orchestrator import campaign as campaign_mod
+
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        campaign_file = tmp_path / "campaign.yaml"
+        campaign_file.write_text(
+            "run_id: demo\n"
+            "max_iterations: 1\n"
+            "research_question: q\n"
+            f"target_system:\n  name: t\n  description: d\n  repo_path: {repo}\n"
+            "prompts:\n  methodology_layer: p\n"
+            "sandbox: default\n"
+        )
+        captured: dict = {}
+        monkeypatch.setattr(
+            campaign_mod, "run_campaign",
+            lambda campaign, *a, **kw: captured.update(campaign=campaign),
+        )
+        args = argparse.Namespace(
+            campaign=str(campaign_file), max_iterations=1, model=None,
+            run_id=None, auto_approve=True, timeout=1800,
+            max_cli_retries=10, agent="sdk", sandbox=None,
+            bundle=None, problem_md=None, handoff_md=None, verbose=False,
+        )
+        cli_mod._cmd_run(args)
+        # No CLI flag → campaign.yaml's value preserved.
+        assert captured["campaign"]["sandbox"] == "default"
+
+
 class TestSandboxSchema:
     def test_campaign_yaml_accepts_sandbox_bypass(self) -> None:
         import jsonschema, yaml

--- a/tests/test_sdk_sandbox.py
+++ b/tests/test_sdk_sandbox.py
@@ -1,0 +1,173 @@
+"""Behavioral tests for SDK sandbox configuration (#193).
+
+Pre-#193: the SDK sandbox blocked BLIS subprocess writes outside cwd.
+The friction-test workaround hardcoded ``permission_mode="bypassPermissions"``.
+After #193 the bypass is configurable via ``campaign.sandbox`` (default
+``bypass``, with ``default`` as the explicit opt-out) and overridable
+via ``nous run --sandbox``.
+
+These tests don't spawn the real SDK — they inject a fake sdk_runner
+that captures the kwargs it received, including ``permission_mode``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.sdk_dispatch import SDKDispatcher, SDKResult
+
+
+class _CapturingRunner:
+    def __init__(self):
+        self.kwargs: dict | None = None
+
+    def __call__(self, **kwargs) -> SDKResult:
+        self.kwargs = kwargs
+        return SDKResult(text="ok")
+
+
+def _campaign(repo_path: Path, **extra) -> dict:
+    return {
+        "research_question": "?",
+        "target_system": {
+            "name": "t",
+            "description": "d",
+            "repo_path": str(repo_path),
+        },
+        **extra,
+    }
+
+
+class TestSandboxDefault:
+    def test_default_passes_bypass_permissions(self, tmp_path: Path) -> None:
+        """#193: campaigns get bypassPermissions by default — without it,
+        BLIS subprocess writes outside cwd silently fail."""
+        runner = _CapturingRunner()
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign(tmp_path),
+            sdk_runner=runner,
+        )
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+        assert runner.kwargs is not None
+        assert runner.kwargs.get("permission_mode") == "bypassPermissions"
+
+
+class TestSandboxOptOut:
+    def test_campaign_sandbox_default_disables_bypass(self, tmp_path: Path) -> None:
+        """campaign.sandbox='default' means: don't bypass; let the SDK
+        apply its default permission gating. permission_mode passed to
+        the runner is None."""
+        runner = _CapturingRunner()
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign(tmp_path, sandbox="default"),
+            sdk_runner=runner,
+        )
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+        assert runner.kwargs is not None
+        assert runner.kwargs.get("permission_mode") is None
+
+    def test_explicit_bypass_round_trips(self, tmp_path: Path) -> None:
+        """campaign.sandbox='bypass' is the same as the default, just
+        explicit — useful for documentation."""
+        runner = _CapturingRunner()
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign(tmp_path, sandbox="bypass"),
+            sdk_runner=runner,
+        )
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+        assert runner.kwargs is not None
+        assert runner.kwargs.get("permission_mode") == "bypassPermissions"
+
+
+class TestSandboxKwargOverride:
+    def test_explicit_sandbox_kwarg_wins_over_campaign(self, tmp_path: Path) -> None:
+        """The CLI flag --sandbox flows through to the SDKDispatcher
+        constructor's ``sandbox`` kwarg, which overrides campaign.sandbox."""
+        runner = _CapturingRunner()
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign(tmp_path, sandbox="default"),
+            sandbox="bypass",  # explicit kwarg beats campaign value
+            sdk_runner=runner,
+        )
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+        assert runner.kwargs is not None
+        assert runner.kwargs.get("permission_mode") == "bypassPermissions"
+
+
+class TestSandboxValidation:
+    def test_invalid_sandbox_value_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="must be 'bypass' or 'default'"):
+            SDKDispatcher(
+                work_dir=tmp_path,
+                campaign=_campaign(tmp_path, sandbox="off"),
+                sdk_runner=_CapturingRunner(),
+            )
+
+    def test_invalid_sandbox_kwarg_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="must be 'bypass' or 'default'"):
+            SDKDispatcher(
+                work_dir=tmp_path,
+                campaign=_campaign(tmp_path),
+                sandbox="permissive",
+                sdk_runner=_CapturingRunner(),
+            )
+
+
+class TestSandboxSchema:
+    def test_campaign_yaml_accepts_sandbox_bypass(self) -> None:
+        import jsonschema, yaml
+        SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+        schema = yaml.safe_load((SCHEMAS_DIR / "campaign.schema.yaml").read_text())
+        campaign = {
+            "research_question": "q",
+            "target_system": {"name": "x", "description": "d"},
+            "prompts": {"methodology_layer": "p"},
+            "sandbox": "bypass",
+        }
+        jsonschema.validate(campaign, schema)
+
+    def test_campaign_yaml_accepts_sandbox_default(self) -> None:
+        import jsonschema, yaml
+        SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+        schema = yaml.safe_load((SCHEMAS_DIR / "campaign.schema.yaml").read_text())
+        campaign = {
+            "research_question": "q",
+            "target_system": {"name": "x", "description": "d"},
+            "prompts": {"methodology_layer": "p"},
+            "sandbox": "default",
+        }
+        jsonschema.validate(campaign, schema)
+
+    def test_campaign_yaml_rejects_unknown_sandbox(self) -> None:
+        import jsonschema, yaml
+        SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+        schema = yaml.safe_load((SCHEMAS_DIR / "campaign.schema.yaml").read_text())
+        campaign = {
+            "research_question": "q",
+            "target_system": {"name": "x", "description": "d"},
+            "prompts": {"methodology_layer": "p"},
+            "sandbox": "lockdown",
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(campaign, schema)

--- a/tests/test_sdk_silence_detector.py
+++ b/tests/test_sdk_silence_detector.py
@@ -1,0 +1,223 @@
+"""Behavioral tests for the SDK silence detector (#201).
+
+After each SDK turn the dispatcher walks the streaming executor_log.jsonl,
+finds the longest gap between consecutive events, and (if the gap
+exceeds ``campaign.sdk_timeouts.silence_threshold_seconds``) writes a
+``failure_type: "sdk_silence"`` entry to retry_log.jsonl.
+
+Observation-only today — doesn't interrupt or fail the turn. The hard-kill
+on prolonged silence is a future addition (issue body's stretch goal).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# ─── summarize_silence_gaps helper ─────────────────────────────────────
+
+
+class TestSummarizeSilenceGaps:
+    def test_no_log_returns_zero(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import summarize_silence_gaps
+        out = summarize_silence_gaps(tmp_path / "missing.jsonl")
+        assert out == {"max_gap_seconds": 0.0, "event_count": 0}
+
+    def test_empty_log_returns_zero(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import summarize_silence_gaps
+        log = tmp_path / "events.jsonl"
+        log.write_text("")
+        out = summarize_silence_gaps(log)
+        assert out == {"max_gap_seconds": 0.0, "event_count": 0}
+
+    def test_single_event_no_gap(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import summarize_silence_gaps
+        log = tmp_path / "events.jsonl"
+        log.write_text(json.dumps({"type": "X", "ts": 100.0}) + "\n")
+        out = summarize_silence_gaps(log)
+        assert out == {"max_gap_seconds": 0.0, "event_count": 1}
+
+    def test_finds_longest_gap_across_events(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import summarize_silence_gaps
+        log = tmp_path / "events.jsonl"
+        # Timestamps with deltas: 5s, 1200s (gap), 2s, 3s — max = 1200s
+        log.write_text("\n".join(json.dumps({"type": "X", "ts": t}) for t in [
+            100.0, 105.0, 1305.0, 1307.0, 1310.0,
+        ]) + "\n")
+        out = summarize_silence_gaps(log)
+        assert out["event_count"] == 5
+        assert out["max_gap_seconds"] == pytest.approx(1200.0)
+
+    def test_skips_corrupt_lines(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import summarize_silence_gaps
+        log = tmp_path / "events.jsonl"
+        log.write_text(
+            json.dumps({"type": "X", "ts": 100.0}) + "\n"
+            "not valid json\n"
+            + json.dumps({"type": "X", "ts": 110.0}) + "\n"
+        )
+        out = summarize_silence_gaps(log)
+        # Two valid events; gap = 10s.
+        assert out == {"max_gap_seconds": 10.0, "event_count": 2}
+
+    def test_skips_events_without_timestamps(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import summarize_silence_gaps
+        log = tmp_path / "events.jsonl"
+        log.write_text(
+            json.dumps({"type": "X", "ts": 100.0}) + "\n"
+            + json.dumps({"type": "Y"}) + "\n"  # missing ts
+            + json.dumps({"type": "X", "ts": 105.0}) + "\n"
+        )
+        out = summarize_silence_gaps(log)
+        # Two timestamped events; gap = 5s.
+        assert out["max_gap_seconds"] == pytest.approx(5.0)
+        assert out["event_count"] == 2
+
+
+# ─── End-to-end: silence triggers retry_log entry ─────────────────────
+
+
+class _StaticRunner:
+    """Runner that pre-stages the streaming log so the silence detector
+    has something to scan. Returns a minimal SDKResult."""
+
+    def __init__(self, gap_seconds: float):
+        self.gap_seconds = gap_seconds
+
+    def __call__(self, **kwargs):
+        from orchestrator.sdk_dispatch import SDKResult
+        log_path = kwargs.get("event_log_path")
+        if log_path is not None:
+            t0 = 1_000_000.0
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.write_text("\n".join(
+                json.dumps({"type": "AssistantMessage", "ts": t})
+                for t in [t0, t0 + self.gap_seconds, t0 + self.gap_seconds + 1]
+            ) + "\n")
+        return SDKResult(text="ok")
+
+
+def _campaign(repo_path: Path, **extra) -> dict:
+    return {
+        "research_question": "?",
+        "target_system": {
+            "name": "t",
+            "description": "d",
+            "repo_path": str(repo_path),
+        },
+        **extra,
+    }
+
+
+class TestSilenceTriggersRetryLog:
+    def test_gap_above_threshold_writes_retry_entry(self, tmp_path: Path) -> None:
+        """#201: a streaming log with a silence > threshold leaves a
+        ``failure_type: sdk_silence`` row in retry_log.jsonl."""
+        from orchestrator.sdk_dispatch import SDKDispatcher
+
+        runner = _StaticRunner(gap_seconds=900)  # 15-min gap
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign(
+                tmp_path,
+                sdk_timeouts={"silence_threshold_seconds": 600},
+            ),
+            sdk_runner=runner,
+        )
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+
+        retry_log = tmp_path / "retry_log.jsonl"
+        assert retry_log.exists()
+        rows = [
+            json.loads(line) for line in retry_log.read_text().splitlines() if line
+        ]
+        silence_rows = [r for r in rows if r.get("failure_type") == "sdk_silence"]
+        assert len(silence_rows) == 1
+        row = silence_rows[0]
+        assert row["max_gap_seconds"] == pytest.approx(900.0)
+        assert row["threshold_seconds"] == 600
+        assert row["phase"] == "design"
+        assert row["iteration"] == 1
+        assert row["event_count"] == 3
+
+    def test_gap_below_threshold_no_retry_entry(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import SDKDispatcher
+
+        runner = _StaticRunner(gap_seconds=10)  # well under 600
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign(tmp_path),  # default 600s threshold
+            sdk_runner=runner,
+        )
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+        retry_log = tmp_path / "retry_log.jsonl"
+        if retry_log.exists():
+            rows = [
+                json.loads(line) for line in retry_log.read_text().splitlines() if line
+            ]
+            assert not any(r.get("failure_type") == "sdk_silence" for r in rows)
+
+    def test_threshold_zero_disables_detector(self, tmp_path: Path) -> None:
+        """campaign.sdk_timeouts.silence_threshold_seconds=0 opts out."""
+        from orchestrator.sdk_dispatch import SDKDispatcher
+
+        runner = _StaticRunner(gap_seconds=10000)  # huge gap
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign(
+                tmp_path,
+                sdk_timeouts={"silence_threshold_seconds": 0},
+            ),
+            sdk_runner=runner,
+        )
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+        retry_log = tmp_path / "retry_log.jsonl"
+        if retry_log.exists():
+            rows = [
+                json.loads(line) for line in retry_log.read_text().splitlines() if line
+            ]
+            assert not any(r.get("failure_type") == "sdk_silence" for r in rows)
+
+
+# ─── Schema accepts the sdk_timeouts block ────────────────────────────
+
+
+class TestSdkTimeoutsSchema:
+    def test_accepts_silence_threshold(self) -> None:
+        import jsonschema, yaml
+        SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+        schema = yaml.safe_load((SCHEMAS_DIR / "campaign.schema.yaml").read_text())
+        campaign = {
+            "research_question": "q",
+            "target_system": {"name": "x", "description": "d"},
+            "prompts": {"methodology_layer": "p"},
+            "sdk_timeouts": {"silence_threshold_seconds": 1200},
+        }
+        jsonschema.validate(campaign, schema)
+
+    def test_rejects_negative_threshold(self) -> None:
+        import jsonschema, yaml
+        SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+        schema = yaml.safe_load((SCHEMAS_DIR / "campaign.schema.yaml").read_text())
+        campaign = {
+            "research_question": "q",
+            "target_system": {"name": "x", "description": "d"},
+            "prompts": {"methodology_layer": "p"},
+            "sdk_timeouts": {"silence_threshold_seconds": -1},
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(campaign, schema)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -144,6 +144,68 @@ class TestValidateDesign:
         result = validate_design(d)
         assert result["status"] == "pass"
 
+    def test_campaign_iter_root_extensions_allow_extra_files(self, tmp_path: Path) -> None:
+        """#199: campaign.validation.iter_root_extensions adds to the
+        global whitelist. Paper-* campaigns need this for analysis_summary.json,
+        manifest.json, probe_report.md.
+        """
+        d = tmp_path / "iter-1"
+        _setup_design(d)
+        (d / "analysis_summary.json").write_text("{}")
+        (d / "manifest.json").write_text("{}")
+        (d / "probe_report.md").write_text("# Probe report")
+
+        # Without the extension: reject all three.
+        result = validate_design(d)
+        assert result["status"] == "fail"
+        assert sum(
+            1 for e in result["errors"]
+            if any(name in e for name in (
+                "analysis_summary.json",
+                "manifest.json",
+                "probe_report.md",
+            ))
+        ) == 3
+
+        # With the extension: pass.
+        campaign = {
+            "validation": {
+                "iter_root_extensions": [
+                    "analysis_summary.json",
+                    "manifest.json",
+                    "probe_report.md",
+                ],
+            },
+        }
+        result = validate_design(d, campaign=campaign)
+        assert result["status"] == "pass", result
+
+    def test_extension_does_not_disable_whitelist(self, tmp_path: Path) -> None:
+        """#199: even with extensions, files outside both lists still fail."""
+        d = tmp_path / "iter-1"
+        _setup_design(d)
+        (d / "analysis_summary.json").write_text("{}")  # extension
+        (d / "rogue_file.txt").write_text("nope")        # not extension
+        campaign = {
+            "validation": {"iter_root_extensions": ["analysis_summary.json"]},
+        }
+        result = validate_design(d, campaign=campaign)
+        assert result["status"] == "fail"
+        assert any("rogue_file.txt" in e for e in result["errors"])
+        assert not any(
+            "analysis_summary.json" in e and "unexpected file" in e
+            for e in result["errors"]
+        )
+
+    def test_no_validation_block_keeps_strict_default(self, tmp_path: Path) -> None:
+        """#199: campaigns that don't declare extensions get the strict default."""
+        d = tmp_path / "iter-1"
+        _setup_design(d)
+        (d / "analysis_summary.json").write_text("{}")  # not on default whitelist
+        result = validate_design(d, campaign={})  # no validation block
+        assert result["status"] == "fail"
+        assert any("analysis_summary.json" in e for e in result["errors"])
+
     def test_executor_log_at_iter_root_still_rejected(self, tmp_path: Path) -> None:
         """#190 contract: the iter root remains artifact-only.
 


### PR DESCRIPTION
Closes #193, #194, #195, #196, #197, #198, #199, #200, #201, #202. Refs #203.

## Why

A clean-room friction-test of the `paper-burst` campaign on top of post-#189 nous (PR #192) surfaced ten distinct paper-cuts ranging from a critical sandbox blocker to operator-UX polish. Each is captured as a subissue under #203 with reproduction; this PR lands fixes + regression coverage for all ten in one shot.

Local pytest: **993 passed, 1 skipped, 0 failed** (up from 939 on `reflective`; +54 new tests, 0 regressions).

## What changes

### Critical

- **#193** — SDK sandbox configurable. `ClaudeAgentOptions.permission_mode` defaults to `"bypassPermissions"` so campaigns can write outside the launched cwd (the orchestrator runs the agent with `cwd=worktree` but BLIS / build / test outputs land at `<main-repo>/.nous/<run>/runs/iter-N/results/`, which the default sandbox blocked silently). Operators opt out via `campaign.sandbox: default` or `nous run --sandbox default`.
- **#194** — `state.json.iteration` matches `runs/iter-N/` from the start of iter-1. Engine now increments on leaving INIT in addition to DONE→DESIGN. Fixes `nous status` showing \"iter 0\" while artifacts live in iter-1/.

### Operator UX

- **#195** — `nous status` \"last tool\" view actually populates. `_tee_event` walks `message.content` for `ToolUseBlock` entries (where `name` actually lives) instead of trying `getattr(message, \"tool_name\")` on the top-level message (which was always `None`).
- **#197** — `--max-iterations` survives `nous resume`. The effective cap is persisted to `state.json` on first run and read back on resume. CLI flag still wins; resume prints which source it used.
- **#198** — `nous stop` honours phase boundaries. `_enter_phase` checks the STOP sentinel before each transition, so a long EXECUTE_ANALYZE can be halted at the next gate boundary instead of waiting for the next iteration.

### Structural / extensibility

- **#199** — Per-campaign iter-root whitelist extension. `campaign.validation.iter_root_extensions` lets paper-* campaigns declare `analysis_summary.json` / `manifest.json` / etc. as allowed iter-root artifacts.
- **#200** — `ExecuteAnalyzeIncompleteError` analog of #187 for the EXECUTE phase. Fires before `validate_execution` when `experiment_plan.yaml` / `findings.json` / `principle_updates.json` is missing. Lists the four common causes (max_turns exhaustion, subprocess hang, polling-loop stall, API stall) with concrete artifacts to inspect. Writes `failure_type: \"execute_incomplete\"` to retry_log.
- **#201** — Post-turn SDK silence detector. After each SDK turn, walks the streaming `executor_log.jsonl` and writes `failure_type: \"sdk_silence\"` to retry_log when the longest gap between events exceeds `campaign.sdk_timeouts.silence_threshold_seconds` (default 600s). Observation-only.

### Polish

- **#196** — Dispatch log line uses `type(self).__name__` so SDK campaigns log as `SDKDispatcher`, not the parent `CLIDispatcher`.
- **#202** — Resume's \"starting fresh\" warning rephrased to informational wording (\"treating as iter-1; existing artifacts preserved\"), demoted WARNING → INFO. After #194 this path mostly never fires anyway.

## Tests

New test files: `test_sdk_sandbox.py`, `test_sdk_silence_detector.py`, `test_max_iterations_persist.py`, `test_execute_artifact_assertion.py`.

Updated coverage in `test_engine.py`, `test_campaign.py`, `test_validate.py`, `test_nous_stop.py`, `test_cli_dispatch.py`, `test_sdk_dispatch.py`, `test_integration.py`.

All adhere to the no-live-LLM rule (`tests/conftest.py::block_live_llm_calls`).

## Migration notes

- No breaking changes. All new schema fields (`sandbox`, `sdk_timeouts`, `validation.iter_root_extensions`) are optional with sensible defaults.
- `validate_design` / `validate_execution` accept an optional `campaign` kwarg now; omitting it preserves the strict default whitelist.
- `state.json` gains an optional `max_iterations` field. Old state files without it work fine on resume.

## Test plan

- [x] Full pytest run green (993 passed, 1 skipped) locally.
- [x] No live LLM calls (autouse guard in `tests/conftest.py`).
- [x] Each issue has at least one named regression test.
- [ ] CI green on this PR.
- [ ] Re-run paper-burst friction-test on this branch to confirm sandbox no longer needs the manual workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)