### PR TITLE
fix: clear all post-#204 friction (#205-#217) — rehearsal mode + reliable iters + operational handoff

### DIFF
--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -196,10 +196,11 @@ def _cmd_stop(args):
     """Ask a running campaign to wind down cleanly between phases.
 
     Writes a ``STOP`` sentinel at the campaign work_dir root. The
-    next time the orchestrator passes a checkpoint (between
-    iterations today; between phases is on the roadmap), it raises
-    ``CampaignStopped``, persists a ``stopped_by_user`` ledger row,
-    and exits without orphaning worktrees or pending dispatcher calls.
+    next time the orchestrator passes a checkpoint — at the start of
+    each iteration AND at every phase transition within an iteration
+    (#198) — it raises ``CampaignStopped``, persists a
+    ``stopped_by_user`` ledger row, and exits without orphaning
+    worktrees or pending dispatcher calls.
 
     For mid-iteration interruption, ``Ctrl+C`` still works — the
     engine's atomic checkpoint means the next ``nous resume`` picks
@@ -229,8 +230,10 @@ def _cmd_stop(args):
     if reason:
         print(f"Reason: {reason}")
     print(
-        "The campaign will halt at the next iteration boundary. To "
-        "cancel the stop request, delete the sentinel file."
+        "The campaign will halt at the next phase boundary (a phase "
+        "transition within the current iteration, or the start of "
+        "the next iteration — whichever comes first). To cancel the "
+        "stop request, delete the sentinel file."
     )
 
 

--- a/orchestrator/complexity_tier.py
+++ b/orchestrator/complexity_tier.py
@@ -37,7 +37,12 @@ TIER_NAMES: dict[int, str] = {
 
 
 def _read_bundle_tier(path: Path) -> int | None:
-    """Read complexity_tier from a bundle.yaml. None if missing or malformed."""
+    """Read complexity_tier from a bundle.yaml. None if missing or malformed.
+
+    Looks under ``metadata`` first, then falls back to the legacy top-level
+    location (#206). When both are populated, the metadata value wins so
+    ``metadata`` is the canonical place to put it going forward.
+    """
     if not path.exists():
         return None
     try:
@@ -46,9 +51,29 @@ def _read_bundle_tier(path: Path) -> int | None:
         return None
     if not isinstance(data, dict):
         return None
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict):
+        tier = metadata.get("complexity_tier")
+        if isinstance(tier, int) and 1 <= tier <= 4:
+            return tier
     tier = data.get("complexity_tier")
     if isinstance(tier, int) and 1 <= tier <= 4:
         return tier
+    return None
+
+
+def _read_bundle_justification(bundle: object) -> str | None:
+    """Pull tier_justification from metadata, falling back to root (#206)."""
+    if not isinstance(bundle, dict):
+        return None
+    metadata = bundle.get("metadata")
+    if isinstance(metadata, dict):
+        j = metadata.get("tier_justification")
+        if isinstance(j, str) and j.strip():
+            return j
+    j = bundle.get("tier_justification")
+    if isinstance(j, str) and j.strip():
+        return j
     return None
 
 
@@ -139,7 +164,7 @@ def format_tier_summary(
     # Show justification if present.
     try:
         bundle = yaml.safe_load(Path(bundle_path).read_text())
-        justification = bundle.get("tier_justification") if isinstance(bundle, dict) else None
+        justification = _read_bundle_justification(bundle)
     except (OSError, yaml.YAMLError):
         justification = None
     if justification:

--- a/orchestrator/iteration_mode.py
+++ b/orchestrator/iteration_mode.py
@@ -1,0 +1,104 @@
+"""Per-iteration mode resolution (#212).
+
+A campaign's ``iterations: [...]`` list, when present, lets operators tag
+each iteration as ``rehearsal`` or ``real``. The DESIGN methodology reads
+the resolved mode from its prompt context and scope-shrinks accordingly:
+rehearsal iterations focus on the *apparatus check* (does the workload
+spec parse, do BLIS args bind, does analysis validate?) and the
+*feasibility check* (does the parameter regime engage the mechanism?),
+emitting ``brief_amendments.md`` for any campaign-spec friction. Real
+iterations run the full bundle at full scope.
+
+This module is **pure Python — no LLM, no I/O**. The orchestrator and
+LLMDispatcher import the resolver to populate prompt context;
+test_iteration_mode covers the cases.
+"""
+from __future__ import annotations
+
+
+# Default when the campaign omits ``iterations``, or when an iteration
+# index is out of range. Real iterations are the safe default — agents
+# at sonnet level have always run real iterations until #212.
+DEFAULT_MODE = "real"
+
+VALID_MODES = ("rehearsal", "real")
+
+
+def iteration_mode_for(campaign: dict, iteration: int) -> str:
+    """Return the mode for iteration N, defaulting to ``real``.
+
+    Out-of-range index, missing block, or malformed entry: ``real``.
+    """
+    if iteration < 1:
+        return DEFAULT_MODE
+    iters = campaign.get("iterations")
+    if not isinstance(iters, list) or not iters:
+        return DEFAULT_MODE
+    idx = iteration - 1
+    if idx >= len(iters):
+        return DEFAULT_MODE
+    entry = iters[idx]
+    if not isinstance(entry, dict):
+        return DEFAULT_MODE
+    mode = entry.get("mode")
+    if mode in VALID_MODES:
+        return mode
+    return DEFAULT_MODE
+
+
+REHEARSAL_GUIDANCE = """\
+This iteration is a **REHEARSAL** (#212). Optimize for fast feedback over
+scientific completeness. Two distinct goals — score them separately:
+
+1. **Apparatus check.** Does the experimental machinery work end-to-end?
+   - Does the workload spec parse?
+   - Do BLIS / target-system args bind correctly?
+   - Does the analysis script schema-validate at least one result?
+   - Are the canonical seeds usable, or do they trip a known bug?
+
+2. **Feasibility check.** Is the parameter regime worth running?
+   - Does the workload actually engage the mechanism under test? (e.g.
+     does the burst create KV pressure, vs all adversary requests being
+     dropped_unservable?)
+   - Does the policy contrast actually differentiate on this workload,
+     or do both arms produce identical metrics?
+
+**Scope discipline for rehearsals:**
+- Use ONE seed (the first canonical seed for this campaign).
+- Use the contrast-pair arms only (h-main vs the most direct control).
+   Do NOT fan out across all arms in a multi-arm bundle.
+- Keep wall-time small. If a rehearsal is going to take more than ~5–10
+   minutes, you're doing too much.
+
+**What to emit alongside findings:**
+If you find any campaign-spec or brief inconsistencies (paths the
+validator rejects, broken argv quoting, wall-time claims that don't
+match reality, single-tenant probes when the target requires multi-
+tenant, etc.), write them to ``runs/iter-N/brief_amendments.md`` —
+one entry per finding, with file path + suggested change. The next
+``real`` iteration will read this; future runs of the same campaign
+will benefit indefinitely.
+
+**Do NOT:**
+- Author full multi-arm bundles. Keep arms minimal.
+- Run all canonical seeds. One seed is enough to verify apparatus
+   + feasibility.
+- Conclude on the research question. Rehearsals don't confirm or
+   refute hypotheses; they validate the apparatus.
+"""
+
+REAL_GUIDANCE = """\
+This iteration is a **REAL** run (#212). Run the bundle at full scope:
+all arms, full seed list, full workload. Do not scope-shrink.
+
+If a prior ``rehearsal`` iteration emitted ``brief_amendments.md``,
+read it before authoring the bundle — apply the amendments and don't
+re-discover the same friction.
+"""
+
+
+def mode_guidance_for(mode: str) -> str:
+    """Return the prompt block that guides the agent for ``mode``."""
+    if mode == "rehearsal":
+        return REHEARSAL_GUIDANCE
+    return REAL_GUIDANCE

--- a/orchestrator/iteration_mode.py
+++ b/orchestrator/iteration_mode.py
@@ -1,4 +1,4 @@
-"""Per-iteration mode resolution (#212).
+"""Per-iteration mode resolution.
 
 A campaign's ``iterations: [...]`` list, when present, lets operators tag
 each iteration as ``rehearsal`` or ``real``. The DESIGN methodology reads
@@ -15,16 +15,23 @@ test_iteration_mode covers the cases.
 """
 from __future__ import annotations
 
+from typing import Literal
+
+
+# Type alias used by callers that want the type-checker to enforce the
+# enum at the API surface (instead of duck-typed strings flowing through).
+Mode = Literal["rehearsal", "real"]
 
 # Default when the campaign omits ``iterations``, or when an iteration
-# index is out of range. Real iterations are the safe default — agents
-# at sonnet level have always run real iterations until #212.
-DEFAULT_MODE = "real"
+# index is out of range. ``real`` is the conservative default — a
+# rehearsal-mode iteration scope-shrinks; defaulting to it could mean
+# "skip the full experiment by accident."
+DEFAULT_MODE: Mode = "real"
 
-VALID_MODES = ("rehearsal", "real")
+VALID_MODES: tuple[Mode, ...] = ("rehearsal", "real")
 
 
-def iteration_mode_for(campaign: dict, iteration: int) -> str:
+def iteration_mode_for(campaign: dict, iteration: int) -> Mode:
     """Return the mode for iteration N, defaulting to ``real``.
 
     Out-of-range index, missing block, or malformed entry: ``real``.
@@ -42,7 +49,7 @@ def iteration_mode_for(campaign: dict, iteration: int) -> str:
         return DEFAULT_MODE
     mode = entry.get("mode")
     if mode in VALID_MODES:
-        return mode
+        return mode  # type: ignore[return-value] — narrowed by membership
     return DEFAULT_MODE
 
 
@@ -97,8 +104,18 @@ re-discover the same friction.
 """
 
 
-def mode_guidance_for(mode: str) -> str:
-    """Return the prompt block that guides the agent for ``mode``."""
+def mode_guidance_for(mode: Mode) -> str:
+    """Return the prompt block that guides the agent for ``mode``.
+
+    Raises ``ValueError`` on an unknown mode value. Silently defaulting
+    to REAL_GUIDANCE was the prior behavior; that's the more dangerous
+    default (rehearsal is the conservative one), so we fail loudly
+    instead of running a full experiment when a typo says otherwise.
+    """
     if mode == "rehearsal":
         return REHEARSAL_GUIDANCE
-    return REAL_GUIDANCE
+    if mode == "real":
+        return REAL_GUIDANCE
+    raise ValueError(
+        f"unknown iteration mode {mode!r}; expected one of {VALID_MODES}"
+    )

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -133,6 +133,63 @@ def _format_results_summary(work_dir: Path) -> str:
     return "\n".join(lines)
 
 
+def _format_bundle_amendments_summary(work_dir: Path) -> str:
+    """#211: surface bundle_amendments.jsonl entries to the REPORT extractor.
+
+    EXECUTE_ANALYZE writes one entry per parameter override during
+    smoke/validation cycles (e.g. kv_blocks 1100 → 1200 because smoke
+    showed dropped_unservable). Without this, the silent drift becomes
+    invisible in the report — and the next campaign run re-discovers
+    the same friction.
+
+    Walks ``runs/iter-*/inputs/bundle_amendments.jsonl`` and produces
+    a per-iter listing. Pure deterministic Python.
+    """
+    runs_dir = work_dir / "runs"
+    if not runs_dir.is_dir():
+        return "(no iteration directories — no amendments to report.)"
+    iter_dirs = sorted(
+        (d for d in runs_dir.iterdir()
+         if d.is_dir() and d.name.startswith("iter-")),
+        key=lambda d: d.name,
+    )
+    sections: list[str] = []
+    total = 0
+    for iter_dir in iter_dirs:
+        log = iter_dir / "inputs" / "bundle_amendments.jsonl"
+        if not log.exists():
+            continue
+        rows: list[dict] = []
+        for line in log.read_text().splitlines():
+            if not line.strip():
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        if not rows:
+            continue
+        total += len(rows)
+        sections.append(f"- {iter_dir.name}: {len(rows)} amendment(s)")
+        for r in rows[:20]:
+            param = r.get("parameter", "?")
+            prescribed = r.get("prescribed_value", "?")
+            actual = r.get("actual_value", "?")
+            reason = r.get("reason", "")
+            sections.append(
+                f"  - {param}: {prescribed!r} → {actual!r}"
+                + (f" — {reason}" if reason else "")
+            )
+        if len(rows) > 20:
+            sections.append(f"  - ... and {len(rows) - 20} more")
+    if total == 0:
+        return (
+            "(no bundle_amendments.jsonl entries — DESIGN's experiment_spec "
+            "ran unmodified through EXECUTE_ANALYZE.)"
+        )
+    return "\n".join(sections)
+
+
 def _format_retry_log_summary(work_dir: Path) -> str:
     """#214: surface retry_log entries to the REPORT extractor so it can
     distinguish 'no data because iteration failed cleanly' from 'no data
@@ -572,6 +629,13 @@ class LLMDispatcher:
             # 80% data as "no data" — search-orientation violation.
             ctx["results_summary"] = _format_results_summary(self.work_dir)
             ctx["retry_log_summary"] = _format_retry_log_summary(self.work_dir)
+            # #211: surface any silent parameter overrides EXECUTE_ANALYZE
+            # logged during smoke / validation, so the report doesn't
+            # describe the prescribed bundle when the actual run used
+            # different values.
+            ctx["bundle_amendments_summary"] = (
+                _format_bundle_amendments_summary(self.work_dir)
+            )
 
         return ctx
 

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -88,6 +88,80 @@ def _normalize_theory_references(refs) -> list[dict]:
     return out
 
 
+def _format_results_summary(work_dir: Path) -> str:
+    """#214: enumerate per-iteration result files for the REPORT extractor.
+
+    Walks ``runs/iter-*/results/`` and produces a structured listing the
+    extractor can engage with directly. Without this, a campaign that
+    completed 4/5 policies × 10 seeds (40 valid arms) but failed on the
+    5th policy can have its report dismiss all 40 results as "no data"
+    — a search-orientation violation. Pre-rendering the file inventory
+    forces the extractor to acknowledge what's on disk.
+
+    Pure deterministic Python — no LLM, no I/O beyond directory walks.
+    """
+    runs_dir = work_dir / "runs"
+    if not runs_dir.is_dir():
+        return "No iteration directories found."
+    lines: list[str] = []
+    iter_dirs = sorted(
+        (d for d in runs_dir.iterdir()
+         if d.is_dir() and d.name.startswith("iter-")),
+        key=lambda d: d.name,
+    )
+    if not iter_dirs:
+        return "No iteration directories found."
+    for iter_dir in iter_dirs:
+        results_dir = iter_dir / "results"
+        if not results_dir.is_dir():
+            lines.append(f"- {iter_dir.name}: results/ directory absent")
+            continue
+        files = sorted(p for p in results_dir.iterdir() if p.is_file())
+        if not files:
+            lines.append(f"- {iter_dir.name}: 0 result files in {results_dir}")
+            continue
+        lines.append(
+            f"- {iter_dir.name}: {len(files)} result file(s) "
+            f"under {results_dir}"
+        )
+        # Cap per-iter listing to keep prompts bounded.
+        cap = 50
+        for f in files[:cap]:
+            lines.append(f"  - {f.name}")
+        if len(files) > cap:
+            lines.append(f"  - ... and {len(files) - cap} more")
+    return "\n".join(lines)
+
+
+def _format_retry_log_summary(work_dir: Path) -> str:
+    """#214: surface retry_log entries to the REPORT extractor so it can
+    distinguish 'no data because iteration failed cleanly' from 'no data
+    because the apparatus broke mid-run'. Empty when the log is missing
+    or empty.
+    """
+    log = work_dir / "retry_log.jsonl"
+    if not log.exists():
+        return "(retry_log.jsonl not present — no dispatcher-level retries.)"
+    rows: list[dict] = []
+    for line in log.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    if not rows:
+        return "(retry_log.jsonl is empty — no dispatcher-level retries.)"
+    by_type: dict[str, int] = {}
+    for r in rows:
+        ft = r.get("failure_type") or "unknown"
+        by_type[ft] = by_type.get(ft, 0) + 1
+    parts = [f"{len(rows)} entry/entries by failure_type:"]
+    for ft, n in sorted(by_type.items(), key=lambda kv: -kv[1]):
+        parts.append(f"  - {ft}: {n}")
+    return "\n".join(parts)
+
+
 def _format_theory_references(refs) -> str:
     """Render theory_references as a Markdown bullet list for the DESIGN
     prompt. Empty when no references are declared.
@@ -315,6 +389,16 @@ class LLMDispatcher:
             iter_dir = self.work_dir / "runs" / f"iter-{iteration}"
             ctx["iter_dir"] = str(iter_dir.resolve())
             ctx["nous_dir"] = str(Path(__file__).resolve().parent.parent)
+            # #212: per-iteration mode (rehearsal | real). Default = real
+            # for backward compat. Mode-specific guidance is rendered into
+            # the prompt directly so the design template doesn't need
+            # conditional logic.
+            from orchestrator.iteration_mode import (
+                iteration_mode_for, mode_guidance_for,
+            )
+            mode = iteration_mode_for(self.campaign, iteration)
+            ctx["iteration_mode"] = mode
+            ctx["mode_guidance"] = mode_guidance_for(mode)
             # #185: surface a top-level pre-registered ground_truth block
             # to the designer so the immutable direction-claim and pass
             # condition reach the LLM directly. When absent, the
@@ -481,6 +565,13 @@ class LLMDispatcher:
                 ctx["final_principles"] = principles_path.read_text()
             else:
                 ctx["final_principles"] = "No principles extracted."
+            # #214: Pre-render an enumeration of per-iteration result
+            # files so the extractor surfaces partial data EVEN WHEN an
+            # iteration failed mid-execute. Without this, the extractor
+            # has no way to know what's on disk and frequently dismisses
+            # 80% data as "no data" — search-orientation violation.
+            ctx["results_summary"] = _format_results_summary(self.work_dir)
+            ctx["retry_log_summary"] = _format_retry_log_summary(self.work_dir)
 
         return ctx
 

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -159,18 +159,38 @@ def _format_bundle_amendments_summary(work_dir: Path) -> str:
         log = iter_dir / "inputs" / "bundle_amendments.jsonl"
         if not log.exists():
             continue
+        try:
+            text = log.read_text()
+        except OSError as exc:
+            sections.append(
+                f"- {iter_dir.name}: bundle_amendments.jsonl unreadable "
+                f"({type(exc).__name__})"
+            )
+            continue
         rows: list[dict] = []
-        for line in log.read_text().splitlines():
+        skipped_malformed = 0
+        for line in text.splitlines():
             if not line.strip():
                 continue
             try:
                 rows.append(json.loads(line))
             except json.JSONDecodeError:
-                continue
-        if not rows:
+                skipped_malformed += 1
+        if not rows and skipped_malformed == 0:
             continue
+        # Header for this iter — single line whether or not malformed
+        # rows were skipped; the skip count is appended in-line so the
+        # operator sees both the valid count and the corruption count.
+        if skipped_malformed:
+            sections.append(
+                f"- {iter_dir.name}: {len(rows)} amendment(s) + "
+                f"{skipped_malformed} malformed line(s) skipped"
+            )
+            if not rows:
+                continue
+        else:
+            sections.append(f"- {iter_dir.name}: {len(rows)} amendment(s)")
         total += len(rows)
-        sections.append(f"- {iter_dir.name}: {len(rows)} amendment(s)")
         for r in rows[:20]:
             param = r.get("parameter", "?")
             prescribed = r.get("prescribed_value", "?")
@@ -182,7 +202,7 @@ def _format_bundle_amendments_summary(work_dir: Path) -> str:
             )
         if len(rows) > 20:
             sections.append(f"  - ... and {len(rows) - 20} more")
-    if total == 0:
+    if not sections:
         return (
             "(no bundle_amendments.jsonl entries — DESIGN's experiment_spec "
             "ran unmodified through EXECUTE_ANALYZE.)"

--- a/orchestrator/meta_findings.py
+++ b/orchestrator/meta_findings.py
@@ -287,6 +287,61 @@ def _detect_nous_asks(
                 "kind": "dispatch",
             })
 
+    # #215: surface specific failure types that always warrant operator
+    # attention — even a single occurrence. The post-#204 paper-burst
+    # rerun produced 1 api_error + 1 sdk_silence row and the previous
+    # threshold (>= 5 entries) swallowed both, leaving operators with
+    # no actionable nous_asks despite a real iteration failure.
+    silence_entries = [
+        e for e in retry_entries if e.get("failure_type") == "sdk_silence"
+    ]
+    if silence_entries:
+        worst = max(
+            silence_entries,
+            key=lambda e: float(e.get("max_gap_seconds") or 0),
+        )
+        gap = float(worst.get("max_gap_seconds") or 0)
+        threshold = float(worst.get("threshold_seconds") or 0)
+        phase = worst.get("phase") or "(unknown)"
+        asks.append({
+            "ask": (
+                "Investigate sources of mid-turn SDK silence (#205). The "
+                "live watchdog cancelled at least one turn; consider "
+                "tightening turn_silence_threshold_seconds or splitting "
+                "long-running parallel tool calls into smaller batches "
+                "so progress events flow more often."
+            ),
+            "evidence": (
+                f"retry_log.jsonl: failure_type=sdk_silence with "
+                f"max_gap_seconds={gap:.1f} (threshold={threshold:.0f}) "
+                f"in phase={phase}."
+            ),
+            "kind": "dispatch",
+        })
+
+    api_error_entries = [
+        e for e in retry_entries if e.get("failure_type") == "api_error"
+    ]
+    unhelpful = [
+        e for e in api_error_entries
+        if not (e.get("error") or "").strip()
+        or (e.get("error") or "").strip().lower() in ("none", "unknown")
+    ]
+    if unhelpful:
+        asks.append({
+            "ask": (
+                "Capture richer diagnostic context for SDK api_error "
+                "failures (#216) — at least one retry_log row recorded "
+                "an empty or 'None' error message, leaving operators "
+                "with nothing to diagnose."
+            ),
+            "evidence": (
+                f"retry_log.jsonl: {len(unhelpful)} api_error row(s) "
+                f"have empty/None error text."
+            ),
+            "kind": "dispatch",
+        })
+
     return asks
 
 
@@ -416,11 +471,24 @@ def emit_meta_findings(
         or payload["target_system_asks"]
         or payload["nous_asks"]
     ):
-        payload["notes"] = (
-            "No surprises detected from artifacts. This is rare — typically "
-            "indicates a very short campaign (single iteration, no retries, "
-            "no token-budget anomalies)."
-        )
+        if retries:
+            # #215: don't claim "no surprises" when retry_log has entries
+            # but the heuristics didn't fire on any of them. That's a
+            # heuristics gap, not a clean campaign — say so.
+            payload["notes"] = (
+                f"retry_log.jsonl has {len(retries)} entry(ies) but the "
+                f"heuristics didn't classify any of them as a campaign "
+                f"design lesson, target-system ask, or nous ask. This is "
+                f"a heuristics gap — review retry_log.jsonl directly and "
+                f"consider adding a detector to "
+                f"orchestrator/meta_findings.py."
+            )
+        else:
+            payload["notes"] = (
+                "No surprises detected from artifacts. This is rare — "
+                "typically indicates a very short campaign (single "
+                "iteration, no retries, no token-budget anomalies)."
+            )
 
     return payload
 

--- a/orchestrator/schemas/bundle.schema.yaml
+++ b/orchestrator/schemas/bundle.schema.yaml
@@ -24,6 +24,18 @@ properties:
       research_question:
         type: string
         minLength: 1
+      # #206: accept complexity_tier / tier_justification under metadata
+      # too (where iteration / family / research_question already live).
+      # The legacy top-level location is still accepted for backward-compat;
+      # readers prefer metadata when both are present.
+      complexity_tier:
+        type: integer
+        minimum: 1
+        maximum: 4
+        description: "See top-level complexity_tier — accepted here for ergonomics (#206)."
+      tier_justification:
+        type: string
+        description: "See top-level tier_justification — accepted here for ergonomics (#206)."
 
   arm_selection_rationale:
     type: string

--- a/orchestrator/schemas/bundle.schema.yaml
+++ b/orchestrator/schemas/bundle.schema.yaml
@@ -85,6 +85,57 @@ properties:
         type: boolean
         description: "Author's self-assessment. true ⇒ tautological by construction; validator REJECTS. false ⇒ explicit declaration of independence."
 
+  # ─── #209/#210: operational experiment_spec block ───────────────────────
+  # Optional structured block that lets the DESIGN agent pin operational
+  # decisions (build commands, fan-out template, classification logic,
+  # verified parameters) so the EXECUTE_ANALYZE agent doesn't re-derive
+  # them in a fresh worktree. All fields are optional; freeform
+  # experiment_spec content alongside (top-level allows additional
+  # properties anyway) remains supported for backward compat.
+  experiment_spec:
+    type: object
+    additionalProperties: true
+    description: >
+      Operational handoff from DESIGN to EXECUTE_ANALYZE. Pin decisions
+      that don't belong in narrative form: commands the executor must
+      run before the main fan-out (#209), how to classify per-request
+      output when tenant_id isn't reliable (#210), the parallel-fan-out
+      template (#210), and any parameters the DESIGN phase verified
+      against the target system (#210).
+    properties:
+      preflight_commands:
+        type: array
+        items: { type: string, minLength: 1 }
+        description: >
+          Shell commands the EXECUTE_ANALYZE agent must run before the
+          main fan-out (#209). Use for build steps that don't carry
+          across the fresh git worktree (e.g. ``go build -o blis main.go``)
+          and any one-off setup the design agent verified manually.
+      fanout_template:
+        type: string
+        minLength: 1
+        description: >
+          The exact shell template EXECUTE_ANALYZE should use to fan
+          arms out in parallel (#210). Avoids GNU-parallel quoting
+          gotchas that the DESIGN agent already worked through.
+      classification_function:
+        type: string
+        minLength: 1
+        description: >
+          Plain-Python expression or short snippet describing how to
+          label a result row (e.g. cooperators vs adversaries) when
+          the target's per-request output lacks the obvious tag (#210).
+          Frees EXECUTE_ANALYZE from re-grepping the target's source
+          to re-derive what DESIGN already figured out.
+      verified_parameters:
+        type: object
+        additionalProperties: true
+        description: >
+          Parameters the DESIGN phase verified work for the target
+          system, e.g. ``{total_kv_blocks: 1200}``. EXECUTE_ANALYZE
+          treats them as canonical; deviations require an entry in
+          ``bundle_amendments.jsonl`` (#211).
+
   arms:
     type: array
     minItems: 1

--- a/orchestrator/schemas/bundle.schema.yaml
+++ b/orchestrator/schemas/bundle.schema.yaml
@@ -94,7 +94,13 @@ properties:
   # properties anyway) remains supported for backward compat.
   experiment_spec:
     type: object
-    additionalProperties: true
+    # Locked enum: typo'd field names (e.g. preflight_command singular,
+    # verifid_parameters) would otherwise pass schema validation and
+    # silently fail at runtime when the executor doesn't see them. The
+    # four sub-fields are an enumerated DESIGN→EXECUTE_ANALYZE contract;
+    # adding a new one requires a schema change so executor-side
+    # consumers update in lockstep.
+    additionalProperties: false
     description: >
       Operational handoff from DESIGN to EXECUTE_ANALYZE. Pin decisions
       that don't belong in narrative form: commands the executor must

--- a/orchestrator/schemas/campaign.schema.yaml
+++ b/orchestrator/schemas/campaign.schema.yaml
@@ -26,6 +26,37 @@ properties:
     minimum: 1
     description: "Maximum number of iterations for run_campaign.py. CLI --max-iterations overrides this. Default: 10."
 
+  iterations:
+    type: array
+    minItems: 1
+    description: >
+      Optional per-iteration overrides (#212). When present, each entry
+      is consulted by index for that iteration's ``mode``. iter-1 looks
+      up ``iterations[0]``, iter-2 ``iterations[1]``, and so on. Out-of-
+      range iterations fall back to mode=real.
+
+      v1 supports the ``mode`` field: a ``rehearsal`` iteration tells
+      the design agent to keep scope minimal — focus on the apparatus
+      (does the workload spec parse? do BLIS args bind? does analysis
+      validate?) and the feasibility check (does the parameter regime
+      actually engage the mechanism?). Surface any campaign-spec
+      friction as ``brief_amendments.md`` so subsequent runs of the
+      same campaign benefit. A ``real`` iteration is the full run.
+
+      Operators typically schedule iter-1 as rehearsal and iter-2+ as
+      real. That's not enforced, just the documented usage.
+    items:
+      type: object
+      required: [mode]
+      additionalProperties: false
+      properties:
+        mode:
+          type: string
+          enum: [rehearsal, real]
+          description: >
+            ``rehearsal`` = surgical scope check (#212). ``real`` = full
+            arms × full seed list × no scope shrink.
+
   target_system:
     type: object
     required: [name, description]

--- a/orchestrator/sdk_dispatch.py
+++ b/orchestrator/sdk_dispatch.py
@@ -70,6 +70,89 @@ def _load_methodology_preamble(methodology_dir: Path) -> str | None:
     return "\n\n---\n\n".join(blocks)
 
 
+def build_error_message(message, *, message_class_counts: dict | None = None) -> str:
+    """Construct a useful error_message from an SDK ResultMessage with is_error=True.
+
+    #216: when ``message.result`` is missing, ``None``, or empty string,
+    the dispatcher would otherwise log ``error: "None"`` to retry_log
+    — useless for diagnosing what broke. This helper falls back to
+    a structured summary built from whatever attributes ARE available
+    (``stop_reason``, ``num_turns``, ``subtype``, message-class counts
+    seen during the turn).
+
+    Pure Python — testable without ``claude_agent_sdk``. Tests construct
+    a duck-typed object with the fields they want to exercise.
+    """
+    raw = getattr(message, "result", None)
+    if isinstance(raw, str) and raw.strip() and raw.strip().lower() != "none":
+        return raw
+
+    fields: list[str] = []
+    stop_reason = getattr(message, "stop_reason", None)
+    if stop_reason:
+        fields.append(f"stop_reason={stop_reason}")
+    subtype = getattr(message, "subtype", None)
+    if subtype:
+        fields.append(f"subtype={subtype}")
+    num_turns = getattr(message, "num_turns", None)
+    if isinstance(num_turns, int) and num_turns > 0:
+        fields.append(f"num_turns={num_turns}")
+    duration_ms = getattr(message, "duration_ms", None)
+    if isinstance(duration_ms, int) and duration_ms > 0:
+        fields.append(f"duration_ms={duration_ms}")
+    if message_class_counts:
+        seen = ",".join(
+            f"{k}={v}" for k, v in sorted(message_class_counts.items()) if v
+        )
+        if seen:
+            fields.append(f"messages_seen={seen}")
+
+    if fields:
+        return (
+            "SDK reported is_error=True with no result text; "
+            "captured context: " + " ".join(fields)
+        )
+    return (
+        "SDK reported is_error=True with no result text and no diagnostic "
+        "context (no stop_reason, subtype, num_turns, or message stream). "
+        "See executor_log.jsonl for the SDK message types observed in this turn."
+    )
+
+
+async def aiter_with_silence_watchdog(aiter, threshold: float | None):
+    """Yield messages from ``aiter``, raising SDKTransientError on silence.
+
+    #205: when ``threshold`` is positive, each ``__anext__`` is wrapped
+    in ``anyio.fail_after``. If no message arrives within ``threshold``
+    seconds, raise :class:`SDKTransientError` so the existing retry
+    machinery can recover instead of blocking indefinitely.
+
+    ``threshold=None`` or ``<= 0`` disables the watchdog (yields the
+    underlying iterator transparently).
+
+    Pulled out as a standalone async helper so it's testable without
+    ``claude_agent_sdk`` (which the test guard hard-fails). Tests inject
+    a tiny async iterator that controls when (or whether) values arrive.
+    """
+    import anyio  # local import — keep top-level import-time clean
+    wd = float(threshold) if threshold and threshold > 0 else None
+    while True:
+        try:
+            if wd is not None:
+                with anyio.fail_after(wd):
+                    message = await aiter.__anext__()
+            else:
+                message = await aiter.__anext__()
+        except StopAsyncIteration:
+            return
+        except TimeoutError as exc:
+            raise SDKTransientError(
+                f"SDK turn observed >{wd:.0f}s silence between events; "
+                f"aborting turn so the dispatcher can retry (#205)."
+            ) from exc
+        yield message
+
+
 def summarize_silence_gaps(event_log_path: Path) -> dict:
     """Walk an executor_log.jsonl and report the longest silence gap (#201).
 
@@ -201,6 +284,7 @@ class SDKRunner(Protocol):
         settings_path: Path | None = None,
         event_log_path: Path | None = None,
         permission_mode: Literal["bypassPermissions"] | None = None,
+        turn_silence_threshold: float | None = None,
     ) -> SDKResult:
         """One SDK turn.
 
@@ -209,6 +293,15 @@ class SDKRunner(Protocol):
         see #193). ``None`` means: don't pass the flag — let the SDK
         apply its own default permission gating. The dispatcher
         translates ``campaign.sandbox`` to one of these two values.
+
+        ``turn_silence_threshold``: per-message live watchdog (#205).
+        If more than ``turn_silence_threshold`` seconds elapse between
+        SDK events while the agent is mid-turn, raise
+        :class:`SDKTransientError` so the existing retry machinery can
+        recover the campaign instead of blocking indefinitely. ``None``
+        or ``<= 0`` disables the watchdog. Different from
+        ``campaign.sdk_timeouts.silence_threshold_seconds`` (which is
+        post-mortem; this one is live).
         """
         ...
 
@@ -230,6 +323,7 @@ def _default_sdk_runner_factory() -> SDKRunner:
         settings_path: Path | None = None,
         event_log_path: Path | None = None,
         permission_mode: Literal["bypassPermissions"] | None = "bypassPermissions",
+        turn_silence_threshold: float | None = None,
     ) -> SDKResult:
         try:
             import anyio
@@ -277,10 +371,24 @@ def _default_sdk_runner_factory() -> SDKRunner:
             duration_ms = 0
             num_turns = 0
             t0 = time.time()
+            # #216: track message-class counts so a downstream is_error
+            # path can synthesize a useful diagnostic when result text is
+            # missing (instead of recording the literal string "None").
+            message_class_counts: dict[str, int] = {}
             if event_log_path is not None:
                 Path(event_log_path).parent.mkdir(parents=True, exist_ok=True)
-            async for message in query(prompt=prompt, options=options):
+            # #205: per-message live watchdog. When a positive
+            # ``turn_silence_threshold`` is set, ``aiter_with_silence_watchdog``
+            # wraps each ``__anext__`` in ``anyio.fail_after`` so a
+            # model-side hang surfaces as ``SDKTransientError``. The
+            # existing transient-retry machinery (lines below) catches
+            # it and retries instead of blocking the campaign forever.
+            aiter = query(prompt=prompt, options=options).__aiter__()
+            async for message in aiter_with_silence_watchdog(
+                aiter, turn_silence_threshold,
+            ):
                 cls = type(message).__name__
+                message_class_counts[cls] = message_class_counts.get(cls, 0) + 1
                 # #127 Phase B: tee every SDK message as a JSONL event so
                 # `nous status --watch` can render live progress.
                 _tee_event(event_log_path, message, cls)
@@ -296,7 +404,12 @@ def _default_sdk_runner_factory() -> SDKRunner:
                     if getattr(message, "is_error", False):
                         return SDKResult(
                             text="".join(text_chunks),
-                            error_message=str(getattr(message, "result", "unknown")),
+                            # #216: build a diagnostic-rich error_message
+                            # so retry_log rows aren't literally "None".
+                            error_message=build_error_message(
+                                message,
+                                message_class_counts=message_class_counts,
+                            ),
                             is_error=True,
                             input_tokens=int(usage.get("input_tokens", 0) or 0),
                             output_tokens=int(usage.get("output_tokens", 0) or 0),
@@ -412,6 +525,29 @@ class SDKDispatcher(CLIDispatcher):
             raise ValueError(
                 f"campaign.sdk_timeouts.silence_threshold_seconds must be "
                 f">= 0, got {self._silence_threshold}"
+            )
+        # #205: live mid-turn watchdog. Defaults to the post-mortem
+        # threshold (so by default the live watchdog catches what the
+        # post-mortem would otherwise only diagnose after the fact).
+        # Operators can split the two by setting
+        # ``campaign.sdk_timeouts.turn_silence_threshold_seconds`` to a
+        # different value, or to 0 to disable the live watchdog while
+        # keeping the post-mortem analyzer.
+        raw_turn_threshold = timeouts.get(
+            "turn_silence_threshold_seconds",
+            self._silence_threshold,
+        )
+        try:
+            self._turn_silence_threshold = float(raw_turn_threshold)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"campaign.sdk_timeouts.turn_silence_threshold_seconds must be "
+                f"a non-negative number, got {raw_turn_threshold!r}"
+            ) from exc
+        if self._turn_silence_threshold < 0:
+            raise ValueError(
+                f"campaign.sdk_timeouts.turn_silence_threshold_seconds must be "
+                f">= 0, got {self._turn_silence_threshold}"
             )
         # #127 Phase B: event log path is recomputed per-dispatch (it depends
         # on the iteration), so we don't store it on the dispatcher.
@@ -532,6 +668,7 @@ class SDKDispatcher(CLIDispatcher):
                     settings_path=self._settings_path,
                     event_log_path=self._event_log_path,
                     permission_mode=self._permission_mode,
+                    turn_silence_threshold=self._turn_silence_threshold,
                 )
             except SDKTransientError as exc:
                 failure_count += 1

--- a/orchestrator/sdk_dispatch.py
+++ b/orchestrator/sdk_dispatch.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Literal, Protocol, runtime_checkable
 
@@ -122,13 +122,19 @@ def build_error_message(message, *, message_class_counts: dict | None = None) ->
 async def aiter_with_silence_watchdog(aiter, threshold: float | None):
     """Yield messages from ``aiter``, raising SDKTransientError on silence.
 
-    #205: when ``threshold`` is positive, each ``__anext__`` is wrapped
-    in ``anyio.fail_after``. If no message arrives within ``threshold``
-    seconds, raise :class:`SDKTransientError` so the existing retry
-    machinery can recover instead of blocking indefinitely.
+    Per-message live watchdog (#205): when ``threshold`` is positive,
+    each ``__anext__`` is wrapped in ``anyio.fail_after``. If no message
+    arrives within ``threshold`` seconds, raise
+    :class:`SDKTransientError` so the existing retry machinery can
+    recover instead of blocking indefinitely.
 
     ``threshold=None`` or ``<= 0`` disables the watchdog (yields the
     underlying iterator transparently).
+
+    Resource hygiene: when raising on timeout (or any other exception),
+    we explicitly call ``aiter.aclose()`` if it's an async generator,
+    so the underlying SDK stream's tasks/sockets get released instead
+    of being orphaned for GC. A test asserts this contract.
 
     Pulled out as a standalone async helper so it's testable without
     ``claude_agent_sdk`` (which the test guard hard-fails). Tests inject
@@ -136,21 +142,33 @@ async def aiter_with_silence_watchdog(aiter, threshold: float | None):
     """
     import anyio  # local import — keep top-level import-time clean
     wd = float(threshold) if threshold and threshold > 0 else None
-    while True:
-        try:
-            if wd is not None:
-                with anyio.fail_after(wd):
+    try:
+        while True:
+            try:
+                if wd is not None:
+                    with anyio.fail_after(wd):
+                        message = await aiter.__anext__()
+                else:
                     message = await aiter.__anext__()
-            else:
-                message = await aiter.__anext__()
-        except StopAsyncIteration:
-            return
-        except TimeoutError as exc:
-            raise SDKTransientError(
-                f"SDK turn observed >{wd:.0f}s silence between events; "
-                f"aborting turn so the dispatcher can retry (#205)."
-            ) from exc
-        yield message
+            except StopAsyncIteration:
+                return
+            except TimeoutError as exc:
+                raise SDKTransientError(
+                    f"SDK turn observed >{wd:.0f}s silence between events; "
+                    f"aborting turn so the dispatcher can retry."
+                ) from exc
+            yield message
+    finally:
+        # Release the underlying SDK stream's resources. Only async
+        # generators have ``aclose``; plain async iterators don't, so
+        # guard with ``hasattr``. Best-effort: if aclose itself raises,
+        # we don't mask the original exception we're already unwinding.
+        aclose = getattr(aiter, "aclose", None)
+        if callable(aclose):
+            try:
+                await aclose()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
 
 
 def summarize_silence_gaps(event_log_path: Path) -> dict:
@@ -248,6 +266,13 @@ class SDKResult:
     The dispatcher reads only these fields. Producers (real or fake) must
     populate ``text`` (assistant final text); usage/cost fields default
     to zero so trivial fakes need not set them.
+
+    Invariant: ``is_error=True`` requires a non-empty ``error_message``.
+    Locked in ``__post_init__`` so producers (real or fake) can't ship
+    an unactionable error path the way the friction-test rerun did
+    (retry_log row recorded ``error: "None"``). ``build_error_message``
+    is the canonical producer when SDK reports is_error with empty
+    result text.
     """
 
     text: str
@@ -260,7 +285,15 @@ class SDKResult:
     num_turns: int = 1
     is_error: bool = False
     error_message: str = ""
-    extra: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.is_error and not self.error_message.strip():
+            raise ValueError(
+                "SDKResult(is_error=True) requires a non-empty "
+                "error_message — see build_error_message() for the "
+                "canonical producer when the SDK returns is_error with "
+                "no result text."
+            )
 
 
 @runtime_checkable

--- a/orchestrator/status.py
+++ b/orchestrator/status.py
@@ -37,9 +37,20 @@ class StatusSnapshot:
     phase: str = "?"
     iteration: int = 0
     completed_iterations: int = 0
+    # #217: separate counter for iterations that ran but ended in
+    # failure (ledger row with ``status: "FAILED"``). Treating these as
+    # "Completed" makes a botched run look identical to a clean refute.
+    failed_iterations: int = 0
     active_principles: int = 0
     last_event: dict[str, Any] | None = None
     elapsed_since_last_event: float | None = None  # seconds; None if no event
+    # #207: most recent event in the log that has a `tool_name`. Distinct
+    # from `last_event` because the very last logged event is often a
+    # SystemMessage / TaskNotificationMessage / pure ThinkingBlock that
+    # carries no `tool_name`, even though a Bash/Read happened seconds
+    # earlier. The reader walks backward to find the nearest tool-bearing
+    # event so the operator sees a useful tool name in `nous status`.
+    last_tool_name: str | None = None
     stuck: bool = False
     raw: dict[str, Any] = field(default_factory=dict)
 
@@ -49,9 +60,11 @@ class StatusSnapshot:
             "phase": self.phase,
             "iteration": self.iteration,
             "completed_iterations": self.completed_iterations,
+            "failed_iterations": self.failed_iterations,
             "active_principles": self.active_principles,
             "last_event": self.last_event,
             "elapsed_since_last_event": self.elapsed_since_last_event,
+            "last_tool_name": self.last_tool_name,
             "stuck": self.stuck,
         }
 
@@ -83,6 +96,49 @@ def _last_log_event(log_path: Path) -> tuple[dict | None, float | None]:
     return last, mtime
 
 
+# #207: walkback window. Most turns produce dozens of events between
+# tool calls (thinking blocks, hook events, sub-task notifications); a
+# bounded window keeps the cost cheap while still recovering the
+# operator-useful tool name in practice.
+_TOOL_WALKBACK_LIMIT = 200
+
+
+def _walkback_for_tool_name(
+    log_path: Path, *, limit: int = _TOOL_WALKBACK_LIMIT,
+) -> str | None:
+    """#207: walk backward through executor_log.jsonl looking for the
+    nearest event with a populated ``tool_name``.
+
+    Returns the tool name (e.g. ``"Bash"``) or ``None`` if no
+    tool-bearing event exists within the walkback window. Reads at most
+    ``limit`` recent lines so a 50k-event log doesn't dominate the cost
+    of `nous status`.
+    """
+    if not log_path.exists():
+        return None
+    try:
+        lines = log_path.read_text().splitlines()
+    except OSError:
+        return None
+    # Walk newest-first; stop after `limit` candidate lines.
+    inspected = 0
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        inspected += 1
+        if inspected > limit:
+            break
+        try:
+            evt = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        tool = evt.get("tool_name") or evt.get("tool")
+        if isinstance(tool, str) and tool.strip():
+            return tool.strip()
+    return None
+
+
 def read_status_snapshot(
     work_dir: Path,
     *,
@@ -111,12 +167,19 @@ def read_status_snapshot(
     if isinstance(ledger, dict):
         rows = ledger.get("iterations", [])
         if isinstance(rows, list):
-            snap.completed_iterations = sum(
-                1 for r in rows
+            valid_rows = [
+                r for r in rows
                 if isinstance(r, dict)
                 and isinstance(r.get("iteration"), int)
                 and r["iteration"] >= 1
+            ]
+            # #217: split clean completions from failures so the operator
+            # can tell a botched run apart from a clean refute. ``status``
+            # is the field ``append_failed_row`` writes; clean rows omit it.
+            snap.failed_iterations = sum(
+                1 for r in valid_rows if r.get("status") == "FAILED"
             )
+            snap.completed_iterations = len(valid_rows) - snap.failed_iterations
 
     principles = _read_json(work_dir / "principles.json")
     if isinstance(principles, dict):
@@ -141,23 +204,37 @@ def read_status_snapshot(
         current = now if now is not None else time.time()
         snap.elapsed_since_last_event = max(0.0, current - mtime)
         snap.stuck = snap.elapsed_since_last_event >= stuck_threshold_seconds
+    # #207: separate from `last_event` because the very last event often
+    # has no `tool_name` even when a tool call happened moments before.
+    snap.last_tool_name = _walkback_for_tool_name(log_path)
 
     return snap
 
 
 def format_one_liner(snap: StatusSnapshot) -> str:
     """Single-line summary suitable for a shell prompt or CI log."""
+    # #217: surface failed-iteration count so a clean refute (which would
+    # show e.g. "1 done") is distinguishable from a botched run ("1 failed").
+    done_segment = f"{snap.completed_iterations} done"
+    if snap.failed_iterations:
+        done_segment += f" / {snap.failed_iterations} failed"
     parts = [
         snap.run_id,
         snap.phase,
         f"iter {snap.iteration}",
-        f"{snap.completed_iterations} done",
+        done_segment,
         f"{snap.active_principles} principles",
     ]
-    if snap.last_event:
-        tool = snap.last_event.get("tool_name") or snap.last_event.get("tool") or ""
-        if tool:
-            parts.append(f"last={tool}")
+    # #207: prefer the walkback-resolved tool name; fall back to the very
+    # last event's tool field for compat with logs that don't have any
+    # tool-bearing event recently (rare).
+    tool = snap.last_tool_name
+    if not tool and snap.last_event:
+        cand = snap.last_event.get("tool_name") or snap.last_event.get("tool") or ""
+        if cand:
+            tool = cand
+    if tool:
+        parts.append(f"last={tool}")
     if snap.stuck:
         parts.append("STUCK")
     return " · ".join(parts)
@@ -174,10 +251,21 @@ def format_watch_panel(snap: StatusSnapshot) -> str:
         f"Phase:      {snap.phase}",
         f"Iteration:  {snap.iteration}",
         f"Completed:  {snap.completed_iterations} iteration(s)",
-        f"Principles: {snap.active_principles} active",
     ]
+    # #217: only render the Failed line when there are actually failed
+    # iterations — keeps the panel uncluttered for healthy campaigns.
+    if snap.failed_iterations:
+        lines.append(
+            f"Failed:     {snap.failed_iterations} iteration(s) "
+            f"— see ledger.json for details",
+        )
+    lines.append(f"Principles: {snap.active_principles} active")
     if snap.last_event:
-        tool = snap.last_event.get("tool_name") or snap.last_event.get("tool") or "?"
+        # #207: use the walkback-resolved tool name when available;
+        # otherwise fall back to the last event's tool fields, then "?".
+        tool = snap.last_tool_name
+        if not tool:
+            tool = snap.last_event.get("tool_name") or snap.last_event.get("tool") or "?"
         lines.append(f"Last tool:  {tool}")
         if snap.elapsed_since_last_event is not None:
             lines.append(f"Last seen:  {snap.elapsed_since_last_event:.0f}s ago")

--- a/orchestrator/status.py
+++ b/orchestrator/status.py
@@ -30,6 +30,16 @@ from typing import Any
 
 _STUCK_THRESHOLD_SECONDS = 5 * 60
 
+# The set of ledger-row ``status`` values that count as a *failed*
+# iteration (vs a clean completion that may have CONFIRMED or REFUTED
+# the hypothesis). Any new failure status that ``append_failed_row``
+# (or future ledger writers) introduces must be added here so
+# ``failed_iterations`` doesn't silently misclassify it. Today only
+# ``"FAILED"`` exists — but pinning it as an explicit set means a
+# future ``"TIMEOUT"`` or ``"CANCELLED"`` status won't slip into the
+# completed bucket undetected.
+_TERMINAL_FAILURE_STATUSES: frozenset[str] = frozenset({"FAILED"})
+
 
 @dataclass
 class StatusSnapshot:
@@ -37,19 +47,21 @@ class StatusSnapshot:
     phase: str = "?"
     iteration: int = 0
     completed_iterations: int = 0
-    # #217: separate counter for iterations that ran but ended in
-    # failure (ledger row with ``status: "FAILED"``). Treating these as
-    # "Completed" makes a botched run look identical to a clean refute.
+    # Separate counter for iterations that ran but ended in failure
+    # (ledger row with ``status`` in ``_TERMINAL_FAILURE_STATUSES``).
+    # Counting these as "Completed" would make a botched run look
+    # identical to a clean refute.
     failed_iterations: int = 0
     active_principles: int = 0
     last_event: dict[str, Any] | None = None
     elapsed_since_last_event: float | None = None  # seconds; None if no event
-    # #207: most recent event in the log that has a `tool_name`. Distinct
-    # from `last_event` because the very last logged event is often a
+    # Most recent event in the log that has a ``tool_name``. Distinct
+    # from ``last_event`` because the very last logged event is often a
     # SystemMessage / TaskNotificationMessage / pure ThinkingBlock that
-    # carries no `tool_name`, even though a Bash/Read happened seconds
-    # earlier. The reader walks backward to find the nearest tool-bearing
-    # event so the operator sees a useful tool name in `nous status`.
+    # carries no ``tool_name`` even when a Bash/Read happened seconds
+    # earlier. The reader walks backward to find the nearest
+    # tool-bearing event (see ``_walkback_for_tool_name``) so the
+    # operator sees a useful tool name in ``nous status``.
     last_tool_name: str | None = None
     stuck: bool = False
     raw: dict[str, Any] = field(default_factory=dict)
@@ -96,39 +108,38 @@ def _last_log_event(log_path: Path) -> tuple[dict | None, float | None]:
     return last, mtime
 
 
-# #207: walkback window. Most turns produce dozens of events between
-# tool calls (thinking blocks, hook events, sub-task notifications); a
-# bounded window keeps the cost cheap while still recovering the
-# operator-useful tool name in practice.
+# Walkback window for ``_walkback_for_tool_name``. Most turns produce
+# dozens of events between tool calls (thinking blocks, hook events,
+# sub-task notifications); a bounded window keeps the cost cheap while
+# still recovering the operator-useful tool name in practice.
 _TOOL_WALKBACK_LIMIT = 200
 
 
 def _walkback_for_tool_name(
     log_path: Path, *, limit: int = _TOOL_WALKBACK_LIMIT,
 ) -> str | None:
-    """#207: walk backward through executor_log.jsonl looking for the
-    nearest event with a populated ``tool_name``.
+    """Walk backward through executor_log.jsonl for the nearest tool_name.
 
     Returns the tool name (e.g. ``"Bash"``) or ``None`` if no
-    tool-bearing event exists within the walkback window. Reads at most
-    ``limit`` recent lines so a 50k-event log doesn't dominate the cost
-    of `nous status`.
+    tool-bearing event exists within the walkback window. Bounded I/O:
+    uses ``collections.deque`` with ``maxlen`` so the file is streamed
+    line-by-line and only the last ``limit`` lines are retained — for a
+    50k-event log this is a couple of MB scanned per ``nous status``
+    refresh, not 50 MB.
     """
     if not log_path.exists():
         return None
+    from collections import deque
     try:
-        lines = log_path.read_text().splitlines()
+        with open(log_path, "r") as f:
+            tail: deque = deque(f, maxlen=limit)
     except OSError:
         return None
-    # Walk newest-first; stop after `limit` candidate lines.
-    inspected = 0
-    for line in reversed(lines):
+    # Walk the tail newest-first.
+    for line in reversed(tail):
         line = line.strip()
         if not line:
             continue
-        inspected += 1
-        if inspected > limit:
-            break
         try:
             evt = json.loads(line)
         except json.JSONDecodeError:
@@ -173,11 +184,15 @@ def read_status_snapshot(
                 and isinstance(r.get("iteration"), int)
                 and r["iteration"] >= 1
             ]
-            # #217: split clean completions from failures so the operator
-            # can tell a botched run apart from a clean refute. ``status``
-            # is the field ``append_failed_row`` writes; clean rows omit it.
+            # Split clean completions from failures so a botched run is
+            # distinguishable from a clean refute. ``status`` is the
+            # field ``append_failed_row`` writes; clean rows omit it.
+            # Membership-test against _TERMINAL_FAILURE_STATUSES so
+            # future "TIMEOUT"/"CANCELLED" values don't silently bucket
+            # as completions.
             snap.failed_iterations = sum(
-                1 for r in valid_rows if r.get("status") == "FAILED"
+                1 for r in valid_rows
+                if r.get("status") in _TERMINAL_FAILURE_STATUSES
             )
             snap.completed_iterations = len(valid_rows) - snap.failed_iterations
 
@@ -204,8 +219,6 @@ def read_status_snapshot(
         current = now if now is not None else time.time()
         snap.elapsed_since_last_event = max(0.0, current - mtime)
         snap.stuck = snap.elapsed_since_last_event >= stuck_threshold_seconds
-    # #207: separate from `last_event` because the very last event often
-    # has no `tool_name` even when a tool call happened moments before.
     snap.last_tool_name = _walkback_for_tool_name(log_path)
 
     return snap
@@ -213,8 +226,9 @@ def read_status_snapshot(
 
 def format_one_liner(snap: StatusSnapshot) -> str:
     """Single-line summary suitable for a shell prompt or CI log."""
-    # #217: surface failed-iteration count so a clean refute (which would
-    # show e.g. "1 done") is distinguishable from a botched run ("1 failed").
+    # Surface failed-iteration count so a clean refute (which would
+    # show e.g. "1 done") is distinguishable from a botched run
+    # ("1 failed"). See ``failed_iterations`` field for the source.
     done_segment = f"{snap.completed_iterations} done"
     if snap.failed_iterations:
         done_segment += f" / {snap.failed_iterations} failed"
@@ -225,9 +239,9 @@ def format_one_liner(snap: StatusSnapshot) -> str:
         done_segment,
         f"{snap.active_principles} principles",
     ]
-    # #207: prefer the walkback-resolved tool name; fall back to the very
-    # last event's tool field for compat with logs that don't have any
-    # tool-bearing event recently (rare).
+    # Prefer the walkback-resolved tool name; fall back to the very
+    # last event's tool field for logs whose tail has no tool-bearing
+    # event recently (rare).
     tool = snap.last_tool_name
     if not tool and snap.last_event:
         cand = snap.last_event.get("tool_name") or snap.last_event.get("tool") or ""
@@ -252,7 +266,7 @@ def format_watch_panel(snap: StatusSnapshot) -> str:
         f"Iteration:  {snap.iteration}",
         f"Completed:  {snap.completed_iterations} iteration(s)",
     ]
-    # #217: only render the Failed line when there are actually failed
+    # Only render the Failed line when there are actually failed
     # iterations — keeps the panel uncluttered for healthy campaigns.
     if snap.failed_iterations:
         lines.append(
@@ -261,8 +275,6 @@ def format_watch_panel(snap: StatusSnapshot) -> str:
         )
     lines.append(f"Principles: {snap.active_principles} active")
     if snap.last_event:
-        # #207: use the walkback-resolved tool name when available;
-        # otherwise fall back to the last event's tool fields, then "?".
         tool = snap.last_tool_name
         if not tool:
             tool = snap.last_event.get("tool_name") or snap.last_event.get("tool") or "?"

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -2,6 +2,12 @@ You are a scientific planner for the Nous hypothesis-driven experimentation fram
 
 Your task is to **explore the target system, frame the problem, and design a hypothesis bundle** — all in one pass. You have full code access and shell tools. Use them.
 
+## Iteration mode
+
+This iteration's mode is: **{{iteration_mode}}**
+
+{{mode_guidance}}
+
 ## Artifact Directory
 
 Write all artifacts to: `{{iter_dir}}`
@@ -181,8 +187,10 @@ Now design a hypothesis bundle based on what you actually observed and verified:
 
 ## Complexity tier (issue #159)
 
-Each bundle declares an optional `complexity_tier` (1..4) and a
-`tier_justification`:
+Each bundle's `metadata` block may declare an optional `complexity_tier`
+(1..4) and a `tier_justification`. Put both fields **inside `metadata`**
+(alongside `iteration`, `family`, `research_question`); the legacy
+top-level location is still accepted for backward compat (#206):
 
 | Tier | When to use it |
 |---|---|

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -178,7 +178,26 @@ Now design a hypothesis bundle based on what you actually observed and verified:
 
    Include a brief note explaining which arms you chose and why.
 
-3. Each arm must have:
+3. **experiment_spec** *(operational handoff to EXECUTE_ANALYZE — #209/#210)*:
+   When you've manually verified things during exploration that the
+   EXECUTE_ANALYZE agent shouldn't have to re-derive in a fresh
+   worktree, pin them in an `experiment_spec` block. All fields are
+   optional but populating them prevents the executor from spending
+   tokens on work you already did:
+
+   - `preflight_commands`: list of shell commands the executor must
+     run before the main fan-out. Use for build steps that don't
+     survive the fresh git worktree (e.g. `["go build -o blis main.go"]`).
+   - `fanout_template`: the exact shell template you've validated for
+     parallel arm execution — saves the executor from re-discovering
+     GNU-parallel quoting gotchas.
+   - `classification_function`: when the target's per-result output
+     lacks an obvious tag (e.g. tenant_id missing in BLIS output), give
+     the executor a plain-Python expression that labels each row.
+   - `verified_parameters`: parameters you confirmed work for this
+     target (e.g. `{total_kv_blocks: 1200}`). Treat as canonical.
+
+4. Each arm must have:
    - `type`: One of h-main, h-ablation, h-super-additivity, h-control-negative, h-robustness, h-dose-response, h-tradeoff.
    - `prediction`: A **directional**, falsifiable claim referencing observable metrics. State the expected direction and relative magnitude (e.g., "increasing X will decrease Y consistently across seeds"). Do NOT invent arbitrary numeric thresholds (e.g., ">10% improvement") unless the campaign.yaml specifies one. The hypothesis bundle's multi-seed design tests significance — your prediction tests direction and mechanism.
    - `mechanism`: A causal explanation grounded in the code you read.

--- a/prompts/methodology/design_thin.md
+++ b/prompts/methodology/design_thin.md
@@ -5,6 +5,12 @@
 > consult CLAUDE.md for the hypothesis-bundle structure, prediction taxonomy,
 > arm types, and writing standards.
 
+## Iteration mode
+
+This iteration's mode is: **{{iteration_mode}}**
+
+{{mode_guidance}}
+
 ## Research question
 {{research_question}}
 

--- a/prompts/methodology/execute_analyze.md
+++ b/prompts/methodology/execute_analyze.md
@@ -62,8 +62,46 @@ The Nous project is at: `{{nous_dir}}`
 
 ## Phase 1: Prepare
 
+### Step 0: Apply operational handoff (#209/#210)
+If the bundle declares `experiment_spec`, treat it as authoritative
+operational handoff from DESIGN. Specifically:
+
+- **`experiment_spec.preflight_commands`** (#209): run these first, in
+  order. They typically include build steps (`go build -o blis main.go`)
+  that the worktree's fresh checkout doesn't carry. Failing fast here is
+  better than discovering missing binaries during fan-out.
+- **`experiment_spec.fanout_template`** (#210): use this exact shell
+  template for the parallel fan-out below. The DESIGN agent has already
+  worked through GNU-parallel quoting gotchas; reuse their work.
+- **`experiment_spec.classification_function`** (#210): apply this when
+  labelling per-result rows (cooperators vs adversaries, treatment vs
+  control, etc.). DO NOT re-derive what DESIGN already verified by
+  re-grepping the target's source.
+- **`experiment_spec.verified_parameters`** (#210): treat as canonical.
+  If smoke / validation reveals a parameter must change, see "Bundle
+  amendments" in Step 1 below — don't override silently.
+
 ### Step 1: Build the system
-Use the build command from the designer handoff. Verify it succeeds.
+Use the build command from the designer handoff (or
+`experiment_spec.preflight_commands` if present). Verify it succeeds.
+
+If during smoke-testing you discover a parameter the DESIGN phase
+prescribed must be changed (e.g. `total_kv_blocks` was too tight,
+producing `dropped_unservable`), append an entry to
+`{{iter_dir}}/inputs/bundle_amendments.jsonl` BEFORE running the main
+experiment with the changed value (#211):
+
+```jsonl
+{"parameter": "total_kv_blocks", "prescribed_value": 1100, "actual_value": 1200, "reason": "smoke produced dropped_unservable=120; raising cache to ensure adv requests engage KV pressure"}
+```
+
+Each line is one JSON object with: `parameter` (string),
+`prescribed_value` (any), `actual_value` (any), `reason` (string,
+plain English). Append-only — do not edit prior entries.
+
+This is **not optional**. Silent parameter overrides break the
+campaign's reproducibility manifest. The REPORT phase reads this file
+and surfaces the divergence.
 
 ### Step 2: Validate the baseline command
 Run the baseline command from the handoff with reduced scale. Verify it exits 0 and produces output with expected metric fields. Fix until it works.

--- a/prompts/methodology/report.md
+++ b/prompts/methodology/report.md
@@ -20,6 +20,10 @@ You are writing the final report for a Nous research campaign.
 
 {{retry_log_summary}}
 
+## Bundle amendments (executed parameters vs prescribed)
+
+{{bundle_amendments_summary}}
+
 ## Instructions
 
 Write a concise research report in markdown answering the research question. Structure:

--- a/prompts/methodology/report.md
+++ b/prompts/methodology/report.md
@@ -12,6 +12,14 @@ You are writing the final report for a Nous research campaign.
 
 {{final_principles}}
 
+## Result files on disk (per-iteration)
+
+{{results_summary}}
+
+## Dispatcher retry/silence summary
+
+{{retry_log_summary}}
+
 ## Instructions
 
 Write a concise research report in markdown answering the research question. Structure:
@@ -20,12 +28,22 @@ Write a concise research report in markdown answering the research question. Str
 1-3 sentences directly answering the research question with specific numbers.
 
 ### Evidence
-Key findings from each iteration that support the answer. Reference specific metrics.
+Key findings from each iteration that support the answer. Reference specific
+metrics. **If "Result files on disk" lists ANY files, you MUST acknowledge
+them in this section** — even if the iteration failed mid-flight, partial
+data is meaningful (search-orientation discipline, #214). Read the files
+to extract actual values when relevant; do not dismiss them as "no data".
+If the apparatus failed before producing data, say so explicitly and cite
+the dispatcher retry/silence summary above.
 
 ### Principles Discovered
 List the active principles with confidence levels and applicability regimes.
 
 ### Limitations & Open Questions
 What wasn't answered. What would the next campaign investigate.
+Distinguish *scientific* gaps (the experiment's design limits) from
+*infrastructure* gaps (the run was interrupted by a dispatcher failure —
+see retry_log summary above). Use this to inform the next iteration's
+bundle.
 
 Output ONLY the markdown. No preamble.

--- a/tests/test_complexity_tier.py
+++ b/tests/test_complexity_tier.py
@@ -30,7 +30,14 @@ def _load_bundle_schema() -> dict:
 
 
 def _make_bundle(*, iteration: int, tier: int | None = None,
-                 justification: str | None = None) -> dict:
+                 justification: str | None = None,
+                 in_metadata: bool = False) -> dict:
+    """Build a bundle for tests.
+
+    ``in_metadata=True`` puts complexity_tier / tier_justification under
+    ``metadata`` (the post-#206 canonical location); the default keeps them
+    at root for backward-compat coverage.
+    """
     bundle: dict = {
         "metadata": {
             "iteration": iteration, "family": "test",
@@ -41,10 +48,11 @@ def _make_bundle(*, iteration: int, tier: int | None = None,
              "diagnostic": "d"},
         ],
     }
+    target = bundle["metadata"] if in_metadata else bundle
     if tier is not None:
-        bundle["complexity_tier"] = tier
+        target["complexity_tier"] = tier
     if justification is not None:
-        bundle["tier_justification"] = justification
+        target["tier_justification"] = justification
     return bundle
 
 
@@ -74,6 +82,51 @@ class TestSchemaAcceptsTier:
         bundle = _make_bundle(iteration=1, tier=5)
         with self_assertions_raises(jsonschema.ValidationError):
             jsonschema.validate(bundle, _load_bundle_schema())
+
+    # ─── #206: tier fields also accepted under `metadata` ───────────────
+
+    def test_bundle_with_tier_in_metadata_validates(self) -> None:
+        """#206: agents that put complexity_tier inside metadata (where
+        iteration / family / research_question already live) should not
+        be rejected. Both locations are accepted post-#206."""
+        bundle = _make_bundle(iteration=1, tier=1,
+                              justification="iter 1, simplest", in_metadata=True)
+        jsonschema.validate(bundle, _load_bundle_schema())
+
+    def test_bundle_with_invalid_tier_in_metadata_rejected(self) -> None:
+        bundle = _make_bundle(iteration=1, tier=5, in_metadata=True)
+        with self_assertions_raises(jsonschema.ValidationError):
+            jsonschema.validate(bundle, _load_bundle_schema())
+
+    def test_read_bundle_tier_finds_in_metadata(self, tmp_path: Path) -> None:
+        """The reader finds complexity_tier in metadata too (post-#206)."""
+        from orchestrator.complexity_tier import _read_bundle_tier
+        bundle = _make_bundle(iteration=1, tier=2, in_metadata=True)
+        path = tmp_path / "bundle.yaml"
+        path.write_text(yaml.safe_dump(bundle))
+        assert _read_bundle_tier(path) == 2
+
+    def test_read_bundle_tier_metadata_wins_over_root(self, tmp_path: Path) -> None:
+        """If both locations are populated (legacy + metadata), metadata wins."""
+        from orchestrator.complexity_tier import _read_bundle_tier
+        bundle = _make_bundle(iteration=1, tier=2, in_metadata=True)
+        bundle["complexity_tier"] = 1  # legacy location with stale value
+        path = tmp_path / "bundle.yaml"
+        path.write_text(yaml.safe_dump(bundle))
+        assert _read_bundle_tier(path) == 2
+
+    def test_format_tier_summary_reads_justification_from_metadata(
+            self, tmp_path: Path) -> None:
+        """The gate panel renders justification from either location."""
+        bundle = _make_bundle(iteration=1, tier=1,
+                              justification="canary text",
+                              in_metadata=True)
+        path = tmp_path / "bundle.yaml"
+        path.write_text(yaml.safe_dump(bundle))
+        rendered = format_tier_summary(
+            iteration=1, bundle_path=path, work_dir=None,
+        )
+        assert "canary text" in rendered
 
     def test_bundle_with_tier_zero_rejected(self) -> None:
         bundle = _make_bundle(iteration=1, tier=0)

--- a/tests/test_experiment_spec.py
+++ b/tests/test_experiment_spec.py
@@ -1,0 +1,240 @@
+"""Tests for the operational ``experiment_spec`` block on bundles
+(#209/#210) and the ``bundle_amendments.jsonl`` drift record (#211).
+
+The block lets DESIGN pin operational decisions (build commands, fan-out
+template, classification logic, verified parameters) so EXECUTE_ANALYZE
+doesn't re-derive them in a fresh worktree. Amendments record overrides
+EXECUTE_ANALYZE makes during smoke / validation, so REPORT can surface
+the drift instead of describing the prescribed bundle.
+
+No live LLM calls — pure schema validation + helpers + LLMDispatcher
+seam injection.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.llm_dispatch import (
+    LLMDispatcher,
+    _format_bundle_amendments_summary,
+)
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+
+
+def _load_bundle_schema() -> dict:
+    return yaml.safe_load((SCHEMAS_DIR / "bundle.schema.yaml").read_text())
+
+
+def _make_bundle(*, experiment_spec: dict | None = None) -> dict:
+    bundle: dict = {
+        "metadata": {
+            "iteration": 1, "family": "test",
+            "research_question": "Does X work?",
+        },
+        "arms": [
+            {"type": "h-main", "prediction": "p", "mechanism": "m",
+             "diagnostic": "d"},
+        ],
+    }
+    if experiment_spec is not None:
+        bundle["experiment_spec"] = experiment_spec
+    return bundle
+
+
+def _make_completion(responses: list[str]):
+    call_log: list[dict] = []
+    idx = {"n": 0}
+
+    def _fn(**kwargs):
+        call_log.append(kwargs)
+        resp = MagicMock()
+        resp.choices = [
+            MagicMock(message=MagicMock(content=responses[idx["n"]])),
+        ]
+        idx["n"] += 1
+        return resp
+
+    _fn.call_log = call_log  # type: ignore[attr-defined]
+    return _fn
+
+
+def _make_campaign() -> dict:
+    return {
+        "research_question": "?",
+        "target_system": {
+            "name": "TestSys", "description": "test",
+            "observable_metrics": ["m"], "controllable_knobs": ["k"],
+        },
+        "prompts": {"methodology_layer": "prompts/methodology",
+                    "domain_adapter_layer": None},
+    }
+
+
+# ─── Schema acceptance for experiment_spec ───────────────────────────────
+
+
+class TestSchemaAcceptsExperimentSpec:
+    def test_no_experiment_spec_validates(self):
+        """Backward compat: bundles without experiment_spec still pass."""
+        jsonschema.validate(_make_bundle(), _load_bundle_schema())
+
+    def test_preflight_commands_validates(self):
+        b = _make_bundle(experiment_spec={
+            "preflight_commands": ["go build -o blis main.go"],
+        })
+        jsonschema.validate(b, _load_bundle_schema())
+
+    def test_full_experiment_spec_validates(self):
+        b = _make_bundle(experiment_spec={
+            "preflight_commands": ["go build -o blis main.go"],
+            "fanout_template":
+                "cat /tmp/args.txt | parallel -j $N './blis run {} > {}.log 2>&1'",
+            "classification_function":
+                "lambda r: 'adv' if r['num_prefill_tokens'] > 4096 else 'coop'",
+            "verified_parameters": {"total_kv_blocks": 1200, "horizon_us": 3e8},
+        })
+        jsonschema.validate(b, _load_bundle_schema())
+
+    def test_preflight_must_be_list_of_strings(self):
+        b = _make_bundle(experiment_spec={"preflight_commands": "go build"})
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(b, _load_bundle_schema())
+
+    def test_empty_string_in_preflight_rejected(self):
+        b = _make_bundle(experiment_spec={"preflight_commands": [""]})
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(b, _load_bundle_schema())
+
+    def test_freeform_extra_keys_in_experiment_spec_allowed(self):
+        """experiment_spec is additionalProperties: true so existing
+        freeform usage (e.g. a custom workload block) keeps working."""
+        b = _make_bundle(experiment_spec={
+            "preflight_commands": ["build"],
+            "custom_block": {"any": "shape"},
+        })
+        jsonschema.validate(b, _load_bundle_schema())
+
+
+# ─── #211: bundle_amendments.jsonl rendering ─────────────────────────────
+
+
+class TestBundleAmendmentsSummary:
+    def test_no_runs_dir_returns_friendly_marker(self, tmp_path: Path) -> None:
+        out = _format_bundle_amendments_summary(tmp_path / "campaign")
+        assert "no iteration directories" in out.lower()
+
+    def test_no_amendments_files_returns_clean_marker(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        (wd / "runs" / "iter-1").mkdir(parents=True)
+        out = _format_bundle_amendments_summary(wd)
+        assert "no bundle_amendments" in out.lower()
+
+    def test_renders_single_amendment(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        inputs = wd / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        (inputs / "bundle_amendments.jsonl").write_text(json.dumps({
+            "parameter": "total_kv_blocks",
+            "prescribed_value": 1100,
+            "actual_value": 1200,
+            "reason": "smoke produced dropped_unservable=120",
+        }) + "\n")
+
+        out = _format_bundle_amendments_summary(wd)
+        assert "iter-1" in out
+        assert "total_kv_blocks" in out
+        assert "1100" in out
+        assert "1200" in out
+        assert "dropped_unservable" in out
+
+    def test_renders_multiple_amendments(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        inputs = wd / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        rows = [
+            json.dumps({"parameter": "kv_blocks", "prescribed_value": 1100,
+                        "actual_value": 1200, "reason": "drop fix"}),
+            json.dumps({"parameter": "horizon", "prescribed_value": 60,
+                        "actual_value": 300, "reason": "burst tail"}),
+        ]
+        (inputs / "bundle_amendments.jsonl").write_text("\n".join(rows) + "\n")
+
+        out = _format_bundle_amendments_summary(wd)
+        assert "2 amendment(s)" in out
+        assert "kv_blocks" in out
+        assert "horizon" in out
+
+    def test_caps_long_amendment_lists(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        inputs = wd / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        rows = [
+            json.dumps({"parameter": f"p{i}", "prescribed_value": i,
+                        "actual_value": i + 1, "reason": "x"})
+            for i in range(50)
+        ]
+        (inputs / "bundle_amendments.jsonl").write_text("\n".join(rows) + "\n")
+
+        out = _format_bundle_amendments_summary(wd)
+        assert "50 amendment(s)" in out
+        assert "and 30 more" in out  # 50 - 20 cap
+
+
+class TestReportContextIncludesAmendments:
+    """#211: REPORT extractor's prompt must include the amendment summary
+    so the report can surface 'we ran with kv_blocks=1200, not the bundle's
+    1100'."""
+
+    def test_amendments_appear_in_extractor_prompt(
+            self, tmp_path: Path,
+            monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        # Set up an iter with both results and an amendment.
+        results = tmp_path / "runs" / "iter-1" / "results"
+        results.mkdir(parents=True)
+        (results / "h-main_seed42.json").write_text("{}")
+
+        inputs = tmp_path / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        (inputs / "bundle_amendments.jsonl").write_text(json.dumps({
+            "parameter": "total_kv_blocks",
+            "prescribed_value": 1100,
+            "actual_value": 1200,
+            "reason": "smoke showed dropped_unservable",
+        }) + "\n")
+
+        (tmp_path / "ledger.json").write_text(json.dumps({"iterations": []}))
+        (tmp_path / "principles.json").write_text(json.dumps({"principles": []}))
+
+        d = LLMDispatcher(
+            work_dir=tmp_path,
+            campaign=_make_campaign(),
+            completion_fn=_make_completion(["# stub report"]),
+        )
+        d.dispatch(
+            "extractor", "report",
+            output_path=tmp_path / "report.md",
+            iteration=0,
+        )
+
+        all_prompt = ""
+        for call in d._completion.call_log:  # type: ignore[attr-defined]
+            for msg in call.get("messages", []):
+                all_prompt += msg.get("content", "") + "\n"
+
+        assert "total_kv_blocks" in all_prompt, (
+            "#211: REPORT extractor must see bundle_amendments so the "
+            "report can describe the actually-executed parameters."
+        )
+        assert "1200" in all_prompt
+        assert "1100" in all_prompt

--- a/tests/test_experiment_spec.py
+++ b/tests/test_experiment_spec.py
@@ -113,12 +113,36 @@ class TestSchemaAcceptsExperimentSpec:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(b, _load_bundle_schema())
 
-    def test_freeform_extra_keys_in_experiment_spec_allowed(self):
-        """experiment_spec is additionalProperties: true so existing
-        freeform usage (e.g. a custom workload block) keeps working."""
+    def test_typo_field_rejected(self):
+        """#2 critical-fix regression: experiment_spec is additionalProperties:
+        false, so a typo'd field name (preflight_command singular,
+        verifid_parameters, etc.) fails validation loudly instead of
+        silently skipping the operational handoff."""
+        b = _make_bundle(experiment_spec={
+            "preflight_command": ["build"],  # typo: should be plural
+        })
+        with pytest.raises(jsonschema.ValidationError, match="preflight_command"):
+            jsonschema.validate(b, _load_bundle_schema())
+
+    def test_unknown_top_level_field_rejected(self):
         b = _make_bundle(experiment_spec={
             "preflight_commands": ["build"],
-            "custom_block": {"any": "shape"},
+            "verifid_parameters": {"x": 1},  # typo
+        })
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(b, _load_bundle_schema())
+
+    def test_verified_parameters_keeps_open_value_namespace(self):
+        """#2 fix scope: verified_parameters is the one place where
+        additionalProperties: true is correct — it's a target-knob
+        namespace and the keys can't be enumerated. Verify the locked
+        outer block doesn't accidentally lock down inner knobs."""
+        b = _make_bundle(experiment_spec={
+            "verified_parameters": {
+                "any_target_knob": 1100,
+                "another_one": "string-value",
+                "nested": {"k": 2},
+            },
         })
         jsonschema.validate(b, _load_bundle_schema())
 
@@ -172,6 +196,57 @@ class TestBundleAmendmentsSummary:
         assert "2 amendment(s)" in out
         assert "kv_blocks" in out
         assert "horizon" in out
+
+    def test_malformed_lines_surfaced_not_silently_skipped(
+            self, tmp_path: Path) -> None:
+        """A corrupted amendment line is *exactly* the divergence #211
+        was added to surface. Skipping it silently re-introduces the
+        silence — the helper must announce the skip count so operators
+        know the amendment record may be incomplete."""
+        wd = tmp_path / "campaign"
+        inputs = wd / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        (inputs / "bundle_amendments.jsonl").write_text(
+            json.dumps({"parameter": "kv_blocks", "prescribed_value": 1100,
+                        "actual_value": 1200, "reason": "valid row"}) + "\n"
+            + "not valid json {\n"
+            + "{\"another_invalid\":\n"
+            + json.dumps({"parameter": "p2", "prescribed_value": 1,
+                          "actual_value": 2, "reason": "another valid row"}) + "\n"
+        )
+
+        out = _format_bundle_amendments_summary(wd)
+        # The valid rows render
+        assert "kv_blocks" in out
+        assert "p2" in out
+        # The malformed lines are SURFACED, not silently dropped
+        assert "malformed" in out.lower()
+        assert "2" in out  # 2 malformed lines
+
+    def test_unreadable_amendments_log_surfaced(
+            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When read_text raises OSError (e.g., permission denied), the
+        helper produces a visible row instead of silently dropping the
+        iter from the report's view."""
+        wd = tmp_path / "campaign"
+        inputs = wd / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        log = inputs / "bundle_amendments.jsonl"
+        log.write_text("{}")  # exists; we'll patch read_text
+
+        from pathlib import Path as _Path
+        original_read_text = _Path.read_text
+
+        def _failing_read_text(self, *args, **kwargs):
+            if self == log:
+                raise PermissionError("simulated unreadable")
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(_Path, "read_text", _failing_read_text)
+
+        out = _format_bundle_amendments_summary(wd)
+        assert "unreadable" in out.lower()
+        assert "PermissionError" in out
 
     def test_caps_long_amendment_lists(self, tmp_path: Path) -> None:
         wd = tmp_path / "campaign"

--- a/tests/test_iteration_mode.py
+++ b/tests/test_iteration_mode.py
@@ -146,8 +146,13 @@ class TestModeGuidance:
         assert "full scope" in text.lower() or "full bundle" in text.lower()
         assert "brief_amendments" in text
 
-    def test_unknown_mode_falls_back_to_real(self):
-        assert mode_guidance_for("turbo") == REAL_GUIDANCE
+    def test_unknown_mode_raises_value_error(self):
+        """Behavioral: silently defaulting to REAL on unknown mode is the
+        more dangerous default (an unintended typo could run a full
+        experiment when scope-shrink was meant). Fail loudly instead.
+        """
+        with pytest.raises(ValueError, match=r"unknown iteration mode"):
+            mode_guidance_for("turbo")  # type: ignore[arg-type]
 
 
 # ─── Schema accepts the new iterations block ─────────────────────────────
@@ -186,15 +191,46 @@ class TestSchemaIterationsBlock:
 # ─── Design phase prompt includes the mode block ─────────────────────────
 
 
+def _collected_prompt_text(dispatcher) -> str:
+    """Aggregate every message content the dispatcher sent to the LLM.
+
+    Helper so tests don't reach into the private completion_fn structure
+    individually — if the dispatcher's message-shape ever evolves, this
+    is the single point of update.
+    """
+    text_blocks: list[str] = []
+    for call in dispatcher._completion.call_log:  # type: ignore[attr-defined]
+        for msg in call.get("messages", []):
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                text_blocks.append(content)
+    return "\n".join(text_blocks)
+
+
 class TestDesignPromptIncludesMode:
     """The DESIGN extractor's prompt must include both placeholders so the
-    methodology template can render mode-specific guidance."""
+    methodology template can render mode-specific guidance.
 
-    def test_rehearsal_iteration_renders_rehearsal_guidance_in_prompt(
-            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Provide a stub API key so LLMDispatcher initialises a completion fn
-        # — we'll override via completion_fn anyway.
+    Covers BOTH the full-template path (no work_dir CLAUDE.md, used by
+    fresh installs and tests with bare tmp_path) AND the thin-template
+    path (work_dir CLAUDE.md present, the production hot path —
+    campaign.py writes one before iter 1). A regression that drops
+    placeholders from EITHER template is caught here.
+    """
+
+    @pytest.mark.parametrize("with_claude_md", [False, True],
+                             ids=["full_template", "thin_template"])
+    def test_rehearsal_renders_in_both_template_paths(
+            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+            with_claude_md: bool) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        if with_claude_md:
+            # #212 production-path coverage: the loader prefers the THIN
+            # template when work_dir/CLAUDE.md exists. Without writing
+            # this file, the test would silently exercise design.md
+            # (full) and miss a regression in design_thin.md.
+            (tmp_path / "CLAUDE.md").write_text("# Per-campaign methodology\n")
 
         c = _make_campaign(iterations=[{"mode": "rehearsal"}])
         d = LLMDispatcher(
@@ -202,34 +238,37 @@ class TestDesignPromptIncludesMode:
             campaign=c,
             completion_fn=_make_completion(["# stub design output"]),
         )
-        # Pre-create iter dir so the dispatcher can write into it.
         (tmp_path / "runs" / "iter-1").mkdir(parents=True)
-
         d.dispatch(
             "planner", "design",
             output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
             iteration=1,
         )
 
-        # The first call's user message should contain rehearsal guidance.
-        all_prompt = ""
-        for call in d._completion.call_log:  # type: ignore[attr-defined]
-            for msg in call.get("messages", []):
-                all_prompt += msg.get("content", "") + "\n"
-
-        assert "REHEARSAL" in all_prompt, (
-            "#212: rehearsal iteration's prompt should announce the mode."
+        prompt_text = _collected_prompt_text(d)
+        # Mode header is rendered (placeholder substituted, no leak).
+        assert "rehearsal" in prompt_text, (
+            f"#212: rehearsal mode must surface in the prompt regardless "
+            f"of which template path is taken (with_claude_md="
+            f"{with_claude_md}). Got prompt: {prompt_text[:600]}"
         )
-        assert "Apparatus check" in all_prompt, (
-            "#212: rehearsal guidance must include the apparatus-check goal."
-        )
-        assert "Feasibility check" in all_prompt
-        # Default mode would put REAL guidance here — verify rehearsal won.
-        assert "ONE seed" in all_prompt
+        # Specific rehearsal-mode guidance the agent needs to scope-shrink.
+        assert "Apparatus check" in prompt_text
+        assert "Feasibility check" in prompt_text
+        assert "ONE seed" in prompt_text
+        # Sanity: no unfilled placeholders leaked through.
+        assert "{{mode_guidance}}" not in prompt_text
+        assert "{{iteration_mode}}" not in prompt_text
 
-    def test_real_iteration_renders_real_guidance_in_prompt(
-            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize("with_claude_md", [False, True],
+                             ids=["full_template", "thin_template"])
+    def test_real_iteration_does_not_leak_rehearsal_guidance(
+            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+            with_claude_md: bool) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        if with_claude_md:
+            (tmp_path / "CLAUDE.md").write_text("# Per-campaign methodology\n")
+
         c = _make_campaign()  # no iterations block — defaults to real
         d = LLMDispatcher(
             work_dir=tmp_path,
@@ -243,12 +282,15 @@ class TestDesignPromptIncludesMode:
             iteration=1,
         )
 
-        all_prompt = ""
-        for call in d._completion.call_log:  # type: ignore[attr-defined]
-            for msg in call.get("messages", []):
-                all_prompt += msg.get("content", "") + "\n"
-
-        # No rehearsal-specific guidance leaked into a real-mode iter.
-        assert "REHEARSAL" not in all_prompt or all_prompt.count("REHEARSAL") <= 1
-        # The real-mode guidance phrase is present.
-        assert "full scope" in all_prompt.lower() or "full bundle" in all_prompt.lower()
+        prompt_text = _collected_prompt_text(d)
+        # The mode value flows through.
+        assert "real" in prompt_text.lower()
+        # Rehearsal-specific scope-shrink language is NOT present.
+        assert "ONE seed" not in prompt_text, (
+            "#212 regression: real-mode iter leaked rehearsal scope "
+            "guidance (with_claude_md=" + str(with_claude_md) + ")."
+        )
+        assert "Apparatus check" not in prompt_text
+        # No unfilled placeholders leaked.
+        assert "{{mode_guidance}}" not in prompt_text
+        assert "{{iteration_mode}}" not in prompt_text

--- a/tests/test_iteration_mode.py
+++ b/tests/test_iteration_mode.py
@@ -1,0 +1,254 @@
+"""Tests for per-iteration mode resolution (#212).
+
+The campaign's optional ``iterations: [...]`` list lets operators schedule
+rehearsal vs real iterations. The DESIGN methodology reads the mode and
+adapts. Tests below assert: (1) the resolver returns the right mode for
+each iteration index, (2) the resolver defaults to ``real`` for missing
+or malformed config, (3) the design context includes both ``iteration_mode``
+and ``mode_guidance`` keys, and (4) the schema accepts the new block.
+
+No live LLM calls — pure helpers + LLMDispatcher seam injection.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import jsonschema
+import pytest
+import yaml
+
+from orchestrator.iteration_mode import (
+    DEFAULT_MODE,
+    REAL_GUIDANCE,
+    REHEARSAL_GUIDANCE,
+    VALID_MODES,
+    iteration_mode_for,
+    mode_guidance_for,
+)
+from orchestrator.llm_dispatch import LLMDispatcher
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
+
+
+def _load_campaign_schema() -> dict:
+    return yaml.safe_load((SCHEMAS_DIR / "campaign.schema.yaml").read_text())
+
+
+def _make_completion(responses: list[str]):
+    """Mock completion fn that records call kwargs."""
+    call_log: list[dict] = []
+    idx = {"n": 0}
+
+    def _fn(**kwargs):
+        call_log.append(kwargs)
+        resp = MagicMock()
+        resp.choices = [
+            MagicMock(message=MagicMock(content=responses[idx["n"]])),
+        ]
+        idx["n"] += 1
+        return resp
+
+    _fn.call_log = call_log  # type: ignore[attr-defined]
+    return _fn
+
+
+def _make_campaign(*, iterations=None) -> dict:
+    c = {
+        "research_question": "Does X work?",
+        "target_system": {
+            "name": "X",
+            "description": "test target",
+            "observable_metrics": ["m"],
+            "controllable_knobs": ["k"],
+        },
+        "prompts": {
+            "methodology_layer": "prompts/methodology",
+            "domain_adapter_layer": None,
+        },
+    }
+    if iterations is not None:
+        c["iterations"] = iterations
+    return c
+
+
+# ─── iteration_mode_for resolver ─────────────────────────────────────────
+
+
+class TestIterationModeFor:
+    def test_no_iterations_block_returns_real(self):
+        assert iteration_mode_for({}, 1) == "real"
+        assert iteration_mode_for(_make_campaign(), 1) == "real"
+
+    def test_empty_iterations_list_returns_real(self):
+        assert iteration_mode_for(_make_campaign(iterations=[]), 1) == "real"
+
+    def test_explicit_rehearsal_for_iter_1(self):
+        c = _make_campaign(iterations=[{"mode": "rehearsal"}])
+        assert iteration_mode_for(c, 1) == "rehearsal"
+
+    def test_per_index_lookup(self):
+        c = _make_campaign(iterations=[
+            {"mode": "rehearsal"},
+            {"mode": "real"},
+            {"mode": "real"},
+        ])
+        assert iteration_mode_for(c, 1) == "rehearsal"
+        assert iteration_mode_for(c, 2) == "real"
+        assert iteration_mode_for(c, 3) == "real"
+
+    def test_out_of_range_iteration_returns_default(self):
+        c = _make_campaign(iterations=[{"mode": "rehearsal"}])
+        # Only 1 entry; iter-2 falls back to real.
+        assert iteration_mode_for(c, 2) == "real"
+        assert iteration_mode_for(c, 99) == "real"
+
+    def test_zero_or_negative_iteration_returns_default(self):
+        c = _make_campaign(iterations=[{"mode": "rehearsal"}])
+        assert iteration_mode_for(c, 0) == "real"
+        assert iteration_mode_for(c, -1) == "real"
+
+    def test_malformed_entry_returns_default(self):
+        # Entry isn't a dict
+        c = _make_campaign(iterations=["rehearsal"])
+        assert iteration_mode_for(c, 1) == "real"
+        # Entry has no mode field
+        c = _make_campaign(iterations=[{"other": "x"}])
+        assert iteration_mode_for(c, 1) == "real"
+        # Entry has invalid mode
+        c = _make_campaign(iterations=[{"mode": "fast"}])
+        assert iteration_mode_for(c, 1) == "real"
+
+    def test_default_mode_constant(self):
+        assert DEFAULT_MODE == "real"
+        assert "rehearsal" in VALID_MODES
+        assert "real" in VALID_MODES
+
+
+# ─── mode_guidance_for renders the right text ────────────────────────────
+
+
+class TestModeGuidance:
+    def test_rehearsal_guidance_mentions_apparatus_and_feasibility(self):
+        text = mode_guidance_for("rehearsal")
+        assert text == REHEARSAL_GUIDANCE
+        assert "Apparatus check" in text
+        assert "Feasibility check" in text
+        assert "brief_amendments" in text
+        assert "ONE seed" in text
+
+    def test_real_guidance_mentions_full_scope(self):
+        text = mode_guidance_for("real")
+        assert text == REAL_GUIDANCE
+        assert "full scope" in text.lower() or "full bundle" in text.lower()
+        assert "brief_amendments" in text
+
+    def test_unknown_mode_falls_back_to_real(self):
+        assert mode_guidance_for("turbo") == REAL_GUIDANCE
+
+
+# ─── Schema accepts the new iterations block ─────────────────────────────
+
+
+class TestSchemaIterationsBlock:
+    def test_no_iterations_block_validates(self):
+        c = _make_campaign()
+        jsonschema.validate(c, _load_campaign_schema())
+
+    def test_iterations_block_validates(self):
+        c = _make_campaign(iterations=[
+            {"mode": "rehearsal"},
+            {"mode": "real"},
+        ])
+        jsonschema.validate(c, _load_campaign_schema())
+
+    def test_invalid_mode_value_rejected(self):
+        c = _make_campaign(iterations=[{"mode": "fast"}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(c, _load_campaign_schema())
+
+    def test_unknown_field_rejected(self):
+        c = _make_campaign(iterations=[
+            {"mode": "rehearsal", "unknown_field": "x"},
+        ])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(c, _load_campaign_schema())
+
+    def test_missing_mode_rejected(self):
+        c = _make_campaign(iterations=[{}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(c, _load_campaign_schema())
+
+
+# ─── Design phase prompt includes the mode block ─────────────────────────
+
+
+class TestDesignPromptIncludesMode:
+    """The DESIGN extractor's prompt must include both placeholders so the
+    methodology template can render mode-specific guidance."""
+
+    def test_rehearsal_iteration_renders_rehearsal_guidance_in_prompt(
+            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Provide a stub API key so LLMDispatcher initialises a completion fn
+        # — we'll override via completion_fn anyway.
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        c = _make_campaign(iterations=[{"mode": "rehearsal"}])
+        d = LLMDispatcher(
+            work_dir=tmp_path,
+            campaign=c,
+            completion_fn=_make_completion(["# stub design output"]),
+        )
+        # Pre-create iter dir so the dispatcher can write into it.
+        (tmp_path / "runs" / "iter-1").mkdir(parents=True)
+
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+
+        # The first call's user message should contain rehearsal guidance.
+        all_prompt = ""
+        for call in d._completion.call_log:  # type: ignore[attr-defined]
+            for msg in call.get("messages", []):
+                all_prompt += msg.get("content", "") + "\n"
+
+        assert "REHEARSAL" in all_prompt, (
+            "#212: rehearsal iteration's prompt should announce the mode."
+        )
+        assert "Apparatus check" in all_prompt, (
+            "#212: rehearsal guidance must include the apparatus-check goal."
+        )
+        assert "Feasibility check" in all_prompt
+        # Default mode would put REAL guidance here — verify rehearsal won.
+        assert "ONE seed" in all_prompt
+
+    def test_real_iteration_renders_real_guidance_in_prompt(
+            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        c = _make_campaign()  # no iterations block — defaults to real
+        d = LLMDispatcher(
+            work_dir=tmp_path,
+            campaign=c,
+            completion_fn=_make_completion(["# stub"]),
+        )
+        (tmp_path / "runs" / "iter-1").mkdir(parents=True)
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+
+        all_prompt = ""
+        for call in d._completion.call_log:  # type: ignore[attr-defined]
+            for msg in call.get("messages", []):
+                all_prompt += msg.get("content", "") + "\n"
+
+        # No rehearsal-specific guidance leaked into a real-mode iter.
+        assert "REHEARSAL" not in all_prompt or all_prompt.count("REHEARSAL") <= 1
+        # The real-mode guidance phrase is present.
+        assert "full scope" in all_prompt.lower() or "full bundle" in all_prompt.lower()

--- a/tests/test_llm_dispatch.py
+++ b/tests/test_llm_dispatch.py
@@ -653,3 +653,136 @@ class TestNoApiKey:
         monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:8000/v1")
         d = LLMDispatcher(work_dir=tmp_path, campaign=SAMPLE_CAMPAIGN)
         assert d._completion is None
+
+
+# ─── #214: REPORT extractor sees per-iteration results & retry_log ────────
+
+
+from orchestrator.llm_dispatch import (
+    _format_results_summary,
+    _format_retry_log_summary,
+)
+
+
+class TestFormatResultsSummary:
+    """#214: a pure helper that walks runs/iter-*/results/ so the REPORT
+    extractor can engage with partial data even when an iteration failed."""
+
+    def test_empty_work_dir_returns_friendly_marker(self, tmp_path: Path) -> None:
+        out = _format_results_summary(tmp_path / "campaign")
+        assert "No iteration directories found" in out
+
+    def test_no_iter_dirs_returns_friendly_marker(self, tmp_path: Path) -> None:
+        (tmp_path / "runs").mkdir()
+        out = _format_results_summary(tmp_path)
+        assert "No iteration directories found" in out
+
+    def test_lists_files_per_iteration(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        results = wd / "runs" / "iter-1" / "results"
+        results.mkdir(parents=True)
+        (results / "ea-wfq_seed42.json").write_text("{}")
+        (results / "wfq_seed42.json").write_text("{}")
+
+        out = _format_results_summary(wd)
+        assert "iter-1" in out
+        assert "2 result file" in out
+        assert "ea-wfq_seed42.json" in out
+        assert "wfq_seed42.json" in out
+
+    def test_caps_listing_for_huge_dirs(self, tmp_path: Path) -> None:
+        """Don't blow the prompt budget when an iter has hundreds of arms."""
+        wd = tmp_path / "campaign"
+        results = wd / "runs" / "iter-1" / "results"
+        results.mkdir(parents=True)
+        for i in range(120):
+            (results / f"arm_seed{i:03d}.json").write_text("{}")
+        out = _format_results_summary(wd)
+        assert "120 result file" in out
+        assert "and 70 more" in out  # 120 - 50 cap
+
+    def test_iter_with_no_results_dir_explicit(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        (wd / "runs" / "iter-1").mkdir(parents=True)
+        # No results/ subdir — iter exists but no data was attempted.
+        out = _format_results_summary(wd)
+        assert "iter-1" in out
+        assert "results/ directory absent" in out
+
+
+class TestFormatRetryLogSummary:
+    """#214: the retry_log summary lets the REPORT extractor distinguish
+    'apparatus failure' from 'experiment cleanly produced null'."""
+
+    def test_missing_log_returns_marker(self, tmp_path: Path) -> None:
+        out = _format_retry_log_summary(tmp_path)
+        assert "not present" in out or "no dispatcher-level retries" in out
+
+    def test_empty_log_returns_marker(self, tmp_path: Path) -> None:
+        (tmp_path / "retry_log.jsonl").write_text("")
+        out = _format_retry_log_summary(tmp_path)
+        assert "no dispatcher-level retries" in out
+
+    def test_groups_entries_by_failure_type(self, tmp_path: Path) -> None:
+        (tmp_path / "retry_log.jsonl").write_text(
+            json.dumps({"failure_type": "api_error", "error": "None"}) + "\n"
+            + json.dumps({"failure_type": "sdk_silence",
+                          "max_gap_seconds": 600.3}) + "\n"
+        )
+        out = _format_retry_log_summary(tmp_path)
+        assert "2 entry" in out
+        assert "api_error: 1" in out
+        assert "sdk_silence: 1" in out
+
+
+class TestReportContextIncludesPartialResults:
+    """#214: when phase=report, the extractor's prompt must include
+    results_summary AND retry_log_summary so it can engage with partial
+    data and infrastructure-failure context."""
+
+    def test_results_files_appear_in_extractor_prompt(self, work_dir: Path) -> None:
+        # Simulate a campaign that completed 4/5 policies before failing.
+        results = work_dir / "runs" / "iter-1" / "results"
+        results.mkdir(parents=True)
+        for policy in ("drf", "ea-wfq", "wfq"):
+            for seed in (42, 123):
+                (results / f"{policy}_seed{seed}.json").write_text("{}")
+        # Add a retry_log row that records the failure shape.
+        (work_dir / "retry_log.jsonl").write_text(json.dumps({
+            "iteration": 1, "phase": "execute-analyze",
+            "failure_type": "sdk_silence", "max_gap_seconds": 600.3,
+            "threshold_seconds": 600.0, "event_count": 593,
+        }) + "\n")
+        # Minimal ledger / principles for context completeness.
+        (work_dir / "ledger.json").write_text(json.dumps({"iterations": []}))
+        (work_dir / "principles.json").write_text(json.dumps({
+            "principles": [],
+        }))
+
+        d = _make_dispatcher(work_dir, ["# Report\n\nMinimal stub."])
+        d.dispatch(
+            "extractor", "report",
+            output_path=work_dir / "report.md",
+            iteration=0,
+        )
+
+        # Inspect the prompt the dispatcher sent to the LLM.
+        completion_calls = d._completion.call_log  # type: ignore[attr-defined]
+        # Concatenate all message contents to search.
+        all_prompt_text = ""
+        for call in completion_calls:
+            for msg in call.get("messages", []):
+                all_prompt_text += msg.get("content", "") + "\n"
+
+        # The extractor must see specific result files...
+        assert "ea-wfq_seed42.json" in all_prompt_text, (
+            "#214: the REPORT extractor's prompt must enumerate per-iter "
+            "results so it can engage with partial data."
+        )
+        assert "wfq_seed42.json" in all_prompt_text
+        # ...and the retry_log shape (so it knows the apparatus failed).
+        assert "sdk_silence" in all_prompt_text, (
+            "#214: the REPORT extractor's prompt must include the "
+            "retry_log summary so it can distinguish apparatus failure "
+            "from null experimental outcome."
+        )

--- a/tests/test_meta_findings.py
+++ b/tests/test_meta_findings.py
@@ -244,6 +244,91 @@ class TestNousAskDetection:
         assert token_asks
         assert any("cache" in a["evidence"] for a in token_asks)
 
+    def test_sdk_silence_in_retry_log_surfaces_ask(self, tmp_path: Path) -> None:
+        """#215: a single sdk_silence row is enough to produce a nous_ask
+        (the previous >=5-entry threshold swallowed real friction)."""
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1)
+        _append_jsonl(work_dir / "retry_log.jsonl", [{
+            "iteration": 1, "phase": "execute-analyze",
+            "failure_type": "sdk_silence",
+            "max_gap_seconds": 600.3, "threshold_seconds": 600.0,
+            "event_count": 593,
+        }])
+
+        payload = emit_meta_findings(
+            work_dir,
+            campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        silence_asks = [a for a in payload["nous_asks"]
+                        if "silence" in a["ask"].lower() or "#205" in a["ask"]]
+        assert silence_asks, (
+            f"#215: a single sdk_silence row should produce a nous_ask; "
+            f"got {payload['nous_asks']!r}"
+        )
+        # Evidence cites the actual gap value
+        assert any("600" in a["evidence"] for a in silence_asks)
+
+    def test_unhelpful_api_error_in_retry_log_surfaces_ask(
+            self, tmp_path: Path) -> None:
+        """#215+#216: an api_error row with error='None' (the post-#204
+        bug shape) should produce a nous_ask about diagnostic context."""
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1)
+        _append_jsonl(work_dir / "retry_log.jsonl", [{
+            "role": "executor", "phase": "execute-analyze",
+            "failure_type": "api_error", "attempt": 1, "error": "None",
+        }])
+
+        payload = emit_meta_findings(
+            work_dir,
+            campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        diag_asks = [a for a in payload["nous_asks"]
+                     if "diagnostic" in a["ask"].lower() or "#216" in a["ask"]]
+        assert diag_asks, (
+            f"#215+#216: api_error rows with empty/'None' error should "
+            f"surface a diagnostic-context ask; got {payload['nous_asks']!r}"
+        )
+
+    def test_retries_present_but_no_asks_says_heuristics_gap(
+            self, tmp_path: Path) -> None:
+        """#215: the notes field must NOT say 'no surprises' when
+        retry_log has entries the heuristics failed to classify."""
+        work_dir = tmp_path / "campaign"
+        _write_state(work_dir)
+        _write_ledger(work_dir, [1])
+        _write_findings(work_dir, 1)
+        # An unrecognized failure_type — heuristics don't know how to
+        # classify it, but we still shouldn't claim "no surprises".
+        _append_jsonl(work_dir / "retry_log.jsonl", [{
+            "iteration": 1, "phase": "design",
+            "failure_type": "novel_unknown_failure", "attempt": 1,
+            "error": "something the heuristics don't recognize",
+        }])
+
+        payload = emit_meta_findings(
+            work_dir,
+            campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        if not payload["nous_asks"] and not payload["campaign_design_lessons"]:
+            # Heuristics didn't fire — the notes field must own that gap.
+            assert "heuristics gap" in (payload.get("notes") or "").lower()
+            assert "no surprises" not in (payload.get("notes") or "").lower()
+
     def test_no_anomalies_yields_empty_streams(self, tmp_path: Path) -> None:
         """Healthy campaign with full campaign.yaml + cache hits + no retries."""
         work_dir = tmp_path / "campaign"

--- a/tests/test_nous_stop.py
+++ b/tests/test_nous_stop.py
@@ -126,6 +126,31 @@ class TestCmdStop:
         captured = capsys.readouterr()
         assert "already present" in captured.out
 
+    def test_stop_message_announces_phase_boundary(
+        self, tmp_path: Path, capsys,
+    ) -> None:
+        """#208: the CLI's user-facing message must say 'phase boundary',
+        not 'iteration boundary' — STOP is honoured at every phase
+        transition post-#198, not only at iteration boundaries."""
+        from orchestrator.cli import _cmd_stop
+        from orchestrator.iteration import STOP_SENTINEL_NAME
+
+        work_dir = tmp_path / ".nous" / "exp1"
+        work_dir.mkdir(parents=True)
+        (work_dir / "state.json").write_text(json.dumps({
+            "phase": "DESIGN", "iteration": 1, "run_id": "exp1",
+        }))
+
+        _cmd_stop(self._argspace(str(work_dir)))
+        captured = capsys.readouterr()
+        assert "phase boundary" in captured.out, (
+            f"#208: stop message should announce phase boundary; got: {captured.out!r}"
+        )
+        # The legacy 'iteration boundary' phrasing should be gone.
+        assert "iteration boundary" not in captured.out, (
+            f"#208: legacy 'iteration boundary' phrasing leaked: {captured.out!r}"
+        )
+
     def test_stop_errors_on_missing_work_dir(
         self, tmp_path: Path, capsys,
     ) -> None:

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -155,6 +155,9 @@ class TestRealMethodologyThinTemplates:
             "nous_dir": "/path/to/nous",
             "repo_context": "(test)",
             "max_turns": "25",
+            # #212: rehearsal/real mode rendered into the design prompt.
+            "iteration_mode": "real",
+            "mode_guidance": "(real-mode guidance text)",
         }
 
     def _ctx_for_execute(self) -> dict[str, str]:

--- a/tests/test_sdk_dispatch.py
+++ b/tests/test_sdk_dispatch.py
@@ -21,7 +21,13 @@ import jsonschema
 import pytest
 import yaml
 
-from orchestrator.sdk_dispatch import SDKDispatcher, SDKResult, SDKTransientError
+from orchestrator.sdk_dispatch import (
+    SDKDispatcher,
+    SDKResult,
+    SDKTransientError,
+    aiter_with_silence_watchdog,
+    build_error_message,
+)
 
 
 SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "orchestrator" / "schemas"
@@ -420,3 +426,240 @@ class TestTeeEventToolNameExtraction:
         rows = [json.loads(l) for l in log.read_text().splitlines() if l]
         assert rows[0]["tool_name"] == "TopLevelTool"
 
+
+
+# ─── #205: live mid-turn silence watchdog ─────────────────────────────────
+
+
+class _ImmediateAsyncIter:
+    """An async iterator that yields a fixed list of values immediately."""
+
+    def __init__(self, values: list):
+        self._values = list(values)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._values:
+            raise StopAsyncIteration
+        return self._values.pop(0)
+
+
+class _StallingAsyncIter:
+    """An async iterator that yields one value, then stalls forever.
+
+    Used to simulate a model-side mid-turn hang. The watchdog under test
+    must abort the second ``__anext__`` after the configured threshold.
+    """
+
+    def __init__(self, first_value):
+        self._first = first_value
+        self._yielded = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._yielded:
+            self._yielded = True
+            return self._first
+        # Stall — wait far longer than any test threshold; the watchdog
+        # should cancel us before this completes.
+        import anyio
+        await anyio.sleep(3600)
+        raise StopAsyncIteration  # pragma: no cover — unreachable
+
+
+class TestSilenceWatchdog:
+    """#205: aiter_with_silence_watchdog raises SDKTransientError when the
+    underlying async iterator stalls longer than the configured threshold,
+    instead of blocking indefinitely. Pure asyncio test — no SDK imports."""
+
+    def test_passthrough_when_threshold_disabled(self):
+        """threshold=None means no watchdog: every value flows through."""
+        import anyio
+
+        async def _go():
+            collected = []
+            aiter = _ImmediateAsyncIter(["a", "b", "c"])
+            async for m in aiter_with_silence_watchdog(aiter, threshold=None):
+                collected.append(m)
+            return collected
+
+        assert anyio.run(_go) == ["a", "b", "c"]
+
+    def test_passthrough_when_threshold_zero(self):
+        """threshold=0 (or negative) also disables the watchdog."""
+        import anyio
+
+        async def _go():
+            collected = []
+            aiter = _ImmediateAsyncIter(["x", "y"])
+            async for m in aiter_with_silence_watchdog(aiter, threshold=0):
+                collected.append(m)
+            return collected
+
+        assert anyio.run(_go) == ["x", "y"]
+
+    def test_raises_transient_on_silence(self):
+        """When the iterator stalls past the threshold, the helper raises
+        SDKTransientError (not TimeoutError) so the dispatcher's existing
+        retry path catches it."""
+        import anyio
+
+        async def _go():
+            aiter = _StallingAsyncIter(first_value="hello")
+            collected = []
+            async for m in aiter_with_silence_watchdog(aiter, threshold=0.05):
+                collected.append(m)
+            return collected
+
+        with pytest.raises(SDKTransientError, match=r"silence between events"):
+            anyio.run(_go)
+
+    def test_no_raise_when_messages_arrive_within_threshold(self):
+        """If every message arrives within threshold, no transient is raised."""
+        import anyio
+
+        async def _go():
+            collected = []
+            aiter = _ImmediateAsyncIter([1, 2, 3])
+            async for m in aiter_with_silence_watchdog(aiter, threshold=5.0):
+                collected.append(m)
+            return collected
+
+        assert anyio.run(_go) == [1, 2, 3]
+
+
+class TestTurnSilenceThresholdWiring:
+    """#205: SDKDispatcher reads campaign.sdk_timeouts.turn_silence_threshold_seconds
+    and passes it through to the runner. The threshold defaults to the
+    post-mortem silence_threshold_seconds when unset."""
+
+    def test_default_threshold_matches_silence_threshold(self, tmp_path):
+        """Default behaviour: turn_silence_threshold == silence_threshold."""
+        runner = _ScriptedRunner([SDKResult(text="ok")])
+        campaign = _make_campaign(tmp_path)
+        # silence_threshold defaults to 600 in the dispatcher
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path, campaign=campaign, sdk_runner=runner,
+        )
+        dispatcher.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+        assert runner.calls[0]["turn_silence_threshold"] == 600.0
+
+    def test_explicit_threshold_passed_to_runner(self, tmp_path):
+        """campaign.sdk_timeouts.turn_silence_threshold_seconds = 30 → 30
+        flows to the runner."""
+        runner = _ScriptedRunner([SDKResult(text="ok")])
+        campaign = _make_campaign(tmp_path)
+        campaign.setdefault("sdk_timeouts", {})["turn_silence_threshold_seconds"] = 30
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path, campaign=campaign, sdk_runner=runner,
+        )
+        dispatcher.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+        assert runner.calls[0]["turn_silence_threshold"] == 30.0
+
+    def test_zero_disables_live_watchdog(self, tmp_path):
+        """Setting turn_silence_threshold_seconds=0 keeps the post-mortem
+        analyzer (silence_threshold_seconds) but disables the live watchdog."""
+        runner = _ScriptedRunner([SDKResult(text="ok")])
+        campaign = _make_campaign(tmp_path)
+        campaign.setdefault("sdk_timeouts", {})["turn_silence_threshold_seconds"] = 0
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path, campaign=campaign, sdk_runner=runner,
+        )
+        dispatcher.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+        assert runner.calls[0]["turn_silence_threshold"] == 0.0
+
+    def test_negative_threshold_rejected(self, tmp_path):
+        """Defensive: a negative threshold raises ValueError at init."""
+        campaign = _make_campaign(tmp_path)
+        campaign.setdefault("sdk_timeouts", {})["turn_silence_threshold_seconds"] = -1
+        with pytest.raises(ValueError, match=r"turn_silence_threshold_seconds"):
+            SDKDispatcher(
+                work_dir=tmp_path, campaign=campaign,
+                sdk_runner=_ScriptedRunner([]),
+            )
+
+
+# ─── #216: build_error_message synthesizes useful diagnostics ─────────────
+
+
+class _FakeResultMessage:
+    """Duck-typed stand-in for the real SDK ResultMessage."""
+
+    def __init__(self, **fields):
+        for k, v in fields.items():
+            setattr(self, k, v)
+
+
+class TestBuildErrorMessage:
+    """#216: build_error_message must never produce the literal string
+    'None' or '' when the SDK returns is_error=True. Operators reading
+    retry_log.jsonl after a failure should always have something to act on."""
+
+    def test_passes_through_substantive_result(self):
+        m = _FakeResultMessage(result="rate limit exceeded for tenant X")
+        assert build_error_message(m) == "rate limit exceeded for tenant X"
+
+    def test_none_result_falls_back_to_diagnostic(self):
+        """The friction-test failure: result=None produced 'None' in retry_log."""
+        m = _FakeResultMessage(
+            result=None,
+            stop_reason="end_turn",
+            num_turns=14,
+            duration_ms=125000,
+        )
+        msg = build_error_message(m, message_class_counts={
+            "AssistantMessage": 28, "UserMessage": 14, "ResultMessage": 1,
+        })
+        assert "None" not in msg or "no result text" in msg
+        assert "stop_reason=end_turn" in msg
+        assert "num_turns=14" in msg
+        assert "duration_ms=125000" in msg
+        assert "AssistantMessage=28" in msg
+
+    def test_empty_string_result_falls_back(self):
+        m = _FakeResultMessage(result="", stop_reason="max_turns_reached")
+        msg = build_error_message(m)
+        assert "stop_reason=max_turns_reached" in msg
+
+    def test_literal_none_string_treated_as_missing(self):
+        """If the SDK literally puts 'None' in the result, treat as missing
+        so the operator gets the diagnostic context, not a useless 'None'."""
+        m = _FakeResultMessage(result="None", stop_reason="end_turn")
+        msg = build_error_message(m)
+        assert "stop_reason=end_turn" in msg
+
+    def test_no_attributes_at_all_produces_actionable_pointer(self):
+        """Worst case: nothing useful on the message. The error must still
+        point the operator somewhere they can dig (executor_log.jsonl)."""
+        m = _FakeResultMessage(result=None)
+        msg = build_error_message(m, message_class_counts={})
+        assert "executor_log" in msg
+
+    def test_subtype_surfaces(self):
+        """Some failure paths populate ``subtype`` instead of ``stop_reason``."""
+        m = _FakeResultMessage(result="", subtype="error_during_execution")
+        msg = build_error_message(m)
+        assert "subtype=error_during_execution" in msg
+
+    def test_zero_num_turns_omitted(self):
+        """A num_turns=0 isn't useful; only positive counts are reported."""
+        m = _FakeResultMessage(result=None, num_turns=0, stop_reason="x")
+        msg = build_error_message(m)
+        assert "num_turns" not in msg
+        assert "stop_reason=x" in msg

--- a/tests/test_sdk_dispatch.py
+++ b/tests/test_sdk_dispatch.py
@@ -293,6 +293,57 @@ class TestMethodologyPreambleCached:
         assert "{{target_system}}" not in sp
         assert "{{" not in sp
 
+    def test_real_methodology_preamble_carries_new_methodology(
+            self, tmp_path: Path) -> None:
+        """#209/#210/#211: the real prompts/methodology/{design,execute_analyze}.md
+        files must carry the operational-handoff guidance into the
+        system_prompt. Without this regression test, an editor could
+        delete the Step 0 / experiment_spec / bundle_amendments sections
+        and only the methodology-prompt-only path would notice — fail
+        loudly here instead.
+        """
+        captured: list[dict] = []
+
+        def runner(**kwargs):
+            captured.append(kwargs)
+            return SDKResult(text="ok")
+
+        # Use the project's real prompts/methodology — no synthetic dir.
+        dispatcher = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_make_campaign(tmp_path),
+            sdk_runner=runner,
+        )
+        dispatcher.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
+            iteration=1,
+        )
+
+        assert len(captured) == 1
+        sp = captured[0]["system_prompt"] or ""
+
+        # #209: preflight_commands guidance must reach the agent
+        assert "preflight_commands" in sp, (
+            "#209: execute_analyze methodology references "
+            "experiment_spec.preflight_commands; this must be in the "
+            "system_prompt so EXECUTE_ANALYZE actually runs the build."
+        )
+        # #210: operational handoff fields (the structured per-call data
+        # the executor uses to avoid re-derivation in a fresh worktree)
+        assert "fanout_template" in sp, "#210: fanout_template guidance missing"
+        assert "classification_function" in sp, (
+            "#210: classification_function guidance missing"
+        )
+        assert "verified_parameters" in sp, (
+            "#210: verified_parameters guidance missing"
+        )
+        # #211: bundle_amendments.jsonl write protocol
+        assert "bundle_amendments.jsonl" in sp, (
+            "#211: bundle_amendments.jsonl write instructions must reach "
+            "the agent so silent parameter overrides can't happen."
+        )
+
     def test_two_calls_reuse_same_system_prompt(self, tmp_path):
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
@@ -531,61 +582,183 @@ class TestSilenceWatchdog:
 
         assert anyio.run(_go) == [1, 2, 3]
 
+    def test_silence_raise_closes_underlying_iterator(self):
+        """Resource hygiene: when the watchdog raises on silence, it
+        must aclose() the underlying SDK stream so its tasks/sockets
+        are released. Otherwise repeated transient retries leak
+        background work per attempt.
+        """
+        import anyio
 
-class TestTurnSilenceThresholdWiring:
-    """#205: SDKDispatcher reads campaign.sdk_timeouts.turn_silence_threshold_seconds
-    and passes it through to the runner. The threshold defaults to the
-    post-mortem silence_threshold_seconds when unset."""
+        class _StallingClosableGen:
+            """Async iterator that stalls forever; records aclose calls."""
+            def __init__(self):
+                self.aclose_called = False
 
-    def test_default_threshold_matches_silence_threshold(self, tmp_path):
-        """Default behaviour: turn_silence_threshold == silence_threshold."""
-        runner = _ScriptedRunner([SDKResult(text="ok")])
-        campaign = _make_campaign(tmp_path)
-        # silence_threshold defaults to 600 in the dispatcher
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                await anyio.sleep(3600)
+                raise StopAsyncIteration  # pragma: no cover
+
+            async def aclose(self):
+                self.aclose_called = True
+
+        aiter = _StallingClosableGen()
+
+        async def _go():
+            async for _ in aiter_with_silence_watchdog(aiter, threshold=0.05):
+                pass
+
+        with pytest.raises(SDKTransientError):
+            anyio.run(_go)
+        assert aiter.aclose_called, (
+            "aiter_with_silence_watchdog must call aclose() on the "
+            "underlying iterator when raising on silence — otherwise "
+            "the SDK stream's resources leak across retries."
+        )
+
+    def test_clean_completion_also_closes_iterator(self):
+        """Same hygiene contract: even on clean StopAsyncIteration, the
+        helper closes the underlying generator. That matches Python's
+        async-generator GC convention and ensures no path leaks."""
+        import anyio
+
+        class _ImmediateClosableGen:
+            def __init__(self, values):
+                self._values = list(values)
+                self.aclose_called = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._values:
+                    raise StopAsyncIteration
+                return self._values.pop(0)
+
+            async def aclose(self):
+                self.aclose_called = True
+
+        aiter = _ImmediateClosableGen([1, 2])
+
+        async def _go():
+            async for _ in aiter_with_silence_watchdog(aiter, threshold=None):
+                pass
+
+        anyio.run(_go)
+        assert aiter.aclose_called
+
+
+class TestTurnSilenceThresholdActuallyControlsBehavior:
+    """#205 (behavioral): the campaign-level threshold must actually drive
+    runtime behavior — a low threshold must turn a slow turn into a
+    transient retry, while a high threshold must let the same slow turn
+    complete cleanly. Asserts on disk artifacts and retry_log entries
+    (the dispatcher's actual outputs) instead of on internal kwargs.
+
+    Replaces an earlier ``runner.calls[0][...]`` test that asserted on
+    the kwarg shape — that's structural per CLAUDE.md tests/CLAUDE.md
+    ("Don't assert argv shape or internal control flow"). The behavioral
+    contract is: threshold value flows from campaign config to runner
+    behavior; we test that by making the runner's behavior depend on it.
+    """
+
+    @staticmethod
+    def _threshold_sensitive_runner(min_threshold: float):
+        """Runner that succeeds only when ``turn_silence_threshold`` is at
+        or above ``min_threshold``. Otherwise raises SDKTransientError —
+        the same shape a real watchdog would when triggered."""
+
+        def _runner(*, turn_silence_threshold=None, **_kwargs):
+            t = turn_silence_threshold
+            if t is None or t < min_threshold:
+                raise SDKTransientError(
+                    f"runner saw threshold={t!r} below cutoff {min_threshold}"
+                )
+            return SDKResult(text="threshold cleared", input_tokens=1, output_tokens=1)
+
+        return _runner
+
+    def test_high_default_threshold_clears_a_strict_runner(
+            self, tmp_path: Path) -> None:
+        """Default ``silence_threshold_seconds`` is 600. A runner that
+        requires ≥500 should see the high default and produce a clean
+        design log on disk."""
+        # No sdk_timeouts override — defaults flow through.
         dispatcher = SDKDispatcher(
-            work_dir=tmp_path, campaign=campaign, sdk_runner=runner,
+            work_dir=tmp_path,
+            campaign=_make_campaign(tmp_path),
+            sdk_runner=self._threshold_sensitive_runner(min_threshold=500.0),
+            max_retries=0,
         )
-        dispatcher.dispatch(
-            "planner", "design",
-            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
-            iteration=1,
-        )
-        assert runner.calls[0]["turn_silence_threshold"] == 600.0
+        out = tmp_path / "runs" / "iter-1" / "design_log.md"
+        dispatcher.dispatch("planner", "design", output_path=out, iteration=1)
 
-    def test_explicit_threshold_passed_to_runner(self, tmp_path):
-        """campaign.sdk_timeouts.turn_silence_threshold_seconds = 30 → 30
-        flows to the runner."""
-        runner = _ScriptedRunner([SDKResult(text="ok")])
+        # Behavioral: the output exists and contains the runner's text.
+        assert out.exists()
+        assert "threshold cleared" in out.read_text()
+        # No retry rows logged — the threshold was sufficient first try.
+        assert not (tmp_path / "retry_log.jsonl").exists() or \
+               (tmp_path / "retry_log.jsonl").read_text().strip() == ""
+
+    def test_low_explicit_threshold_makes_strict_runner_fail(
+            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Set ``turn_silence_threshold_seconds: 1`` — strict runner
+        rejects, dispatcher records the transient, retries are
+        exhausted, and a RuntimeError surfaces."""
+        monkeypatch.setattr("orchestrator.sdk_dispatch.time.sleep",
+                            lambda _s: None)
         campaign = _make_campaign(tmp_path)
-        campaign.setdefault("sdk_timeouts", {})["turn_silence_threshold_seconds"] = 30
+        campaign.setdefault("sdk_timeouts", {})["turn_silence_threshold_seconds"] = 1
         dispatcher = SDKDispatcher(
-            work_dir=tmp_path, campaign=campaign, sdk_runner=runner,
+            work_dir=tmp_path, campaign=campaign,
+            sdk_runner=self._threshold_sensitive_runner(min_threshold=500.0),
+            max_retries=0,
         )
-        dispatcher.dispatch(
-            "planner", "design",
-            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
-            iteration=1,
-        )
-        assert runner.calls[0]["turn_silence_threshold"] == 30.0
+        out = tmp_path / "runs" / "iter-1" / "design_log.md"
+        with pytest.raises(RuntimeError, match=r"still failing"):
+            dispatcher.dispatch("planner", "design", output_path=out, iteration=1)
 
-    def test_zero_disables_live_watchdog(self, tmp_path):
-        """Setting turn_silence_threshold_seconds=0 keeps the post-mortem
-        analyzer (silence_threshold_seconds) but disables the live watchdog."""
-        runner = _ScriptedRunner([SDKResult(text="ok")])
+        # Behavioral: the retry_log captured the runner's complaint.
+        retry_rows = _read_jsonl(tmp_path / "retry_log.jsonl")
+        assert retry_rows, "retry_log must record the transient"
+        assert any("threshold=1.0" in (r.get("error") or "") for r in retry_rows), (
+            "retry_log error text should include the threshold value the "
+            "runner observed — the wiring is what's under test."
+        )
+
+    def test_zero_threshold_propagates_so_runner_can_disable_watchdog(
+            self, tmp_path: Path) -> None:
+        """A runner that REQUIRES threshold=0 (e.g. opt-out path) should
+        succeed when the campaign sets ``turn_silence_threshold_seconds:
+        0``. This exercises the threshold==0 sentinel actually flowing,
+        not just being captured in kwargs."""
+
+        def _runner_needs_zero(*, turn_silence_threshold=None, **_kwargs):
+            if turn_silence_threshold != 0.0:
+                raise SDKTransientError(
+                    f"expected threshold=0.0 (watchdog disabled), got "
+                    f"{turn_silence_threshold!r}"
+                )
+            return SDKResult(text="watchdog disabled", input_tokens=1, output_tokens=1)
+
         campaign = _make_campaign(tmp_path)
         campaign.setdefault("sdk_timeouts", {})["turn_silence_threshold_seconds"] = 0
         dispatcher = SDKDispatcher(
-            work_dir=tmp_path, campaign=campaign, sdk_runner=runner,
+            work_dir=tmp_path, campaign=campaign,
+            sdk_runner=_runner_needs_zero, max_retries=0,
         )
-        dispatcher.dispatch(
-            "planner", "design",
-            output_path=tmp_path / "runs" / "iter-1" / "design_log.md",
-            iteration=1,
-        )
-        assert runner.calls[0]["turn_silence_threshold"] == 0.0
+        out = tmp_path / "runs" / "iter-1" / "design_log.md"
+        dispatcher.dispatch("planner", "design", output_path=out, iteration=1)
 
-    def test_negative_threshold_rejected(self, tmp_path):
-        """Defensive: a negative threshold raises ValueError at init."""
+        assert "watchdog disabled" in out.read_text()
+
+    def test_negative_threshold_rejected_at_init(self, tmp_path: Path) -> None:
+        """Defensive: a negative threshold raises ValueError at init,
+        before any campaign work runs. Behavioral: assert on the raised
+        exception, no runner needed."""
         campaign = _make_campaign(tmp_path)
         campaign.setdefault("sdk_timeouts", {})["turn_silence_threshold_seconds"] = -1
         with pytest.raises(ValueError, match=r"turn_silence_threshold_seconds"):
@@ -616,7 +789,16 @@ class TestBuildErrorMessage:
         assert build_error_message(m) == "rate limit exceeded for tenant X"
 
     def test_none_result_falls_back_to_diagnostic(self):
-        """The friction-test failure: result=None produced 'None' in retry_log."""
+        """The friction-test failure: result=None produced 'None' in retry_log.
+
+        The fix's contract is **structured**: every fallback message starts
+        with the canonical 'SDK reported is_error=True' prefix and embeds
+        each available diagnostic field as ``key=value``. The previous
+        assertion ``"None" not in msg or "no result text" in msg`` was
+        an over-tolerant disjunction that would still pass if the fix
+        regressed and reintroduced a literal "None" — exactly the bug
+        #216 was supposed to catch.
+        """
         m = _FakeResultMessage(
             result=None,
             stop_reason="end_turn",
@@ -626,11 +808,20 @@ class TestBuildErrorMessage:
         msg = build_error_message(m, message_class_counts={
             "AssistantMessage": 28, "UserMessage": 14, "ResultMessage": 1,
         })
-        assert "None" not in msg or "no result text" in msg
+        # Positive-only: the fallback message starts with the canonical
+        # prefix and includes every captured field as key=value.
+        assert msg.startswith("SDK reported is_error=True"), (
+            f"#216: fallback diagnostic must start with the canonical "
+            f"prefix; got: {msg!r}"
+        )
         assert "stop_reason=end_turn" in msg
         assert "num_turns=14" in msg
         assert "duration_ms=125000" in msg
         assert "AssistantMessage=28" in msg
+        # The literal string "None" must NOT appear as a result-text
+        # surrogate (the very bug #216 fixes).
+        assert ": None" not in msg
+        assert "= None" not in msg
 
     def test_empty_string_result_falls_back(self):
         m = _FakeResultMessage(result="", stop_reason="max_turns_reached")
@@ -663,3 +854,26 @@ class TestBuildErrorMessage:
         msg = build_error_message(m)
         assert "num_turns" not in msg
         assert "stop_reason=x" in msg
+
+
+class TestSDKResultInvariant:
+    """SDKResult.__post_init__ enforces ``is_error=True`` requires a
+    non-empty error_message — locks the contract ``build_error_message``
+    is written to maintain. A regression that returns ``SDKResult(
+    is_error=True, error_message="")`` is now caught at construction
+    time, not later when retry_log records ``error: ""``."""
+
+    def test_clean_result_constructs(self):
+        SDKResult(text="ok")  # no exception
+
+    def test_explicit_error_with_message_constructs(self):
+        SDKResult(text="", is_error=True, error_message="rate limit hit")
+
+    def test_error_with_empty_message_rejected(self):
+        with pytest.raises(ValueError, match=r"is_error=True.*requires"):
+            SDKResult(text="", is_error=True, error_message="")
+
+    def test_error_with_whitespace_message_rejected(self):
+        """Whitespace-only is no more useful than empty."""
+        with pytest.raises(ValueError, match=r"is_error=True.*requires"):
+            SDKResult(text="", is_error=True, error_message="   ")

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -258,3 +258,203 @@ class TestFormatWatchPanel:
         snap = StatusSnapshot(run_id="r1", phase="DESIGN", iteration=1)
         out = format_watch_panel(snap)
         assert "no events" in out.lower() or "(no events" in out
+
+
+# ─── #207: Last tool walks back through events for nearest tool_name ──────
+
+
+class TestLastToolWalkback:
+    """#207: when the very-latest event has no `tool_name` (a SystemMessage,
+    TaskNotificationMessage, or pure ThinkingBlock), `nous status` used to
+    show `Last tool: ?` even though a Bash/Read happened seconds before.
+    The reader now walks backward through recent events to surface the
+    nearest tool-bearing event."""
+
+    def test_walkback_finds_tool_when_tail_is_systemmessage(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="EXECUTE_ANALYZE", iteration=1)
+        # Sequence: Bash event, then a stretch of system/notification events
+        # (no tool_name on any of them).
+        events = [
+            {"type": "AssistantMessage", "ts": 100.0, "tool_name": "Bash"},
+            {"type": "AssistantMessage", "ts": 110.0},  # ThinkingBlock-shape
+            {"type": "SystemMessage", "ts": 120.0},
+            {"type": "TaskNotificationMessage", "ts": 130.0},
+            {"type": "UserMessage", "ts": 140.0},
+        ]
+        _write_log(wd, 1, events, mtime=140.0)
+
+        snap = read_status_snapshot(wd, now=145.0)
+        assert snap.last_tool_name == "Bash", (
+            "#207: walkback must surface the nearest tool_name even when "
+            "the tail of the log has no tool-bearing events."
+        )
+
+    def test_walkback_returns_none_when_no_tool_events(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="DESIGN", iteration=1)
+        events = [
+            {"type": "SystemMessage", "ts": 100.0},
+            {"type": "UserMessage", "ts": 110.0},
+        ]
+        _write_log(wd, 1, events, mtime=110.0)
+
+        snap = read_status_snapshot(wd, now=115.0)
+        assert snap.last_tool_name is None
+
+    def test_walkback_picks_most_recent_tool(self, tmp_path: Path) -> None:
+        """When multiple tool events exist, the most recent wins."""
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="DESIGN", iteration=1)
+        events = [
+            {"type": "AssistantMessage", "ts": 100.0, "tool_name": "Read"},
+            {"type": "AssistantMessage", "ts": 110.0, "tool_name": "Bash"},
+            {"type": "AssistantMessage", "ts": 120.0, "tool_name": "Write"},
+            {"type": "SystemMessage", "ts": 130.0},
+        ]
+        _write_log(wd, 1, events, mtime=130.0)
+
+        snap = read_status_snapshot(wd, now=135.0)
+        assert snap.last_tool_name == "Write"
+
+    def test_one_liner_uses_walkback(self, tmp_path: Path) -> None:
+        """`nous status --line` shows `last=Bash` from walkback even when
+        the tail of the log has no tool_name."""
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="EXECUTE_ANALYZE", iteration=1)
+        events = [
+            {"type": "AssistantMessage", "ts": 100.0, "tool_name": "Bash"},
+            {"type": "TaskNotificationMessage", "ts": 110.0},
+        ]
+        _write_log(wd, 1, events, mtime=110.0)
+
+        snap = read_status_snapshot(wd, now=115.0)
+        line = format_one_liner(snap)
+        assert "last=Bash" in line, (
+            f"#207: --line should show last=Bash from walkback; got: {line!r}"
+        )
+
+    def test_watch_panel_uses_walkback(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="EXECUTE_ANALYZE", iteration=1)
+        events = [
+            {"type": "AssistantMessage", "ts": 100.0, "tool_name": "Read"},
+            {"type": "SystemMessage", "ts": 110.0},
+        ]
+        _write_log(wd, 1, events, mtime=110.0)
+
+        snap = read_status_snapshot(wd, now=115.0)
+        panel = format_watch_panel(snap)
+        assert "Last tool:  Read" in panel, (
+            f"#207: full status panel must show 'Last tool: Read' from "
+            f"walkback; got:\n{panel}"
+        )
+
+
+# ─── #217: failed iterations counted separately from clean completions ────
+
+
+def _write_ledger_with_rows(work_dir: Path, rows: list[dict]) -> None:
+    """Write ledger.json with explicit row contents (not the simple count helper)."""
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / "ledger.json").write_text(json.dumps({"iterations": rows}))
+
+
+class TestFailedIterationCounter:
+    """#217: clean completions and failures are tracked separately so the
+    status display can distinguish a botched run from a clean refute."""
+
+    def test_clean_completion_counts_as_completed(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="DESIGN", iteration=2)
+        _write_ledger_with_rows(wd, [
+            {"iteration": 1, "h_main_result": "CONFIRMED"},
+        ])
+        snap = read_status_snapshot(wd, now=100.0)
+        assert snap.completed_iterations == 1
+        assert snap.failed_iterations == 0
+
+    def test_failed_row_counts_as_failed_not_completed(
+            self, tmp_path: Path) -> None:
+        """A row with status='FAILED' (the shape append_failed_row writes)
+        is a failure, not a completion."""
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="DESIGN", iteration=2)
+        _write_ledger_with_rows(wd, [
+            {"iteration": 1, "status": "FAILED",
+             "error": "SDK returned error after 1 attempt(s): None"},
+        ])
+        snap = read_status_snapshot(wd, now=100.0)
+        assert snap.completed_iterations == 0, (
+            "#217: a FAILED row must NOT be counted as a clean completion."
+        )
+        assert snap.failed_iterations == 1
+
+    def test_mixed_rows_counted_separately(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="DESIGN", iteration=4)
+        _write_ledger_with_rows(wd, [
+            {"iteration": 1, "h_main_result": "CONFIRMED"},
+            {"iteration": 2, "h_main_result": "REFUTED"},
+            {"iteration": 3, "status": "FAILED", "error": "boom"},
+        ])
+        snap = read_status_snapshot(wd, now=100.0)
+        # Both CONFIRMED and REFUTED count as completions (clean science),
+        # only the FAILED row is a failure.
+        assert snap.completed_iterations == 2
+        assert snap.failed_iterations == 1
+
+    def test_one_liner_shows_failure_count_when_present(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="DESIGN", iteration=2)
+        _write_ledger_with_rows(wd, [
+            {"iteration": 1, "status": "FAILED", "error": "x"},
+        ])
+        snap = read_status_snapshot(wd, now=100.0)
+        line = format_one_liner(snap)
+        assert "1 failed" in line, (
+            f"#217: --line should show '... / 1 failed'; got: {line!r}"
+        )
+
+    def test_one_liner_omits_failure_segment_when_zero(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="DESIGN", iteration=2)
+        _write_ledger_with_rows(wd, [
+            {"iteration": 1, "h_main_result": "CONFIRMED"},
+        ])
+        snap = read_status_snapshot(wd, now=100.0)
+        line = format_one_liner(snap)
+        assert "failed" not in line, (
+            f"#217: --line should not surface 'failed' when zero; got: {line!r}"
+        )
+
+    def test_watch_panel_shows_failed_line_when_present(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="REPORT", iteration=2)
+        _write_ledger_with_rows(wd, [
+            {"iteration": 1, "status": "FAILED",
+             "error": "SDK error mid-execute"},
+        ])
+        snap = read_status_snapshot(wd, now=100.0)
+        panel = format_watch_panel(snap)
+        assert "Failed:     1 iteration" in panel, (
+            f"#217: watch panel should show 'Failed: 1 iteration'; got:\n{panel}"
+        )
+
+    def test_watch_panel_omits_failed_line_when_zero(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="DESIGN", iteration=1)
+        _write_ledger_with_rows(wd, [
+            {"iteration": 1, "h_main_result": "CONFIRMED"},
+        ])
+        snap = read_status_snapshot(wd, now=100.0)
+        panel = format_watch_panel(snap)
+        assert "Failed:" not in panel, (
+            f"#217: watch panel should NOT show 'Failed:' when zero; got:\n{panel}"
+        )

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -458,3 +458,37 @@ class TestFailedIterationCounter:
         assert "Failed:" not in panel, (
             f"#217: watch panel should NOT show 'Failed:' when zero; got:\n{panel}"
         )
+
+
+class TestWalkbackCapBoundary:
+    """Walkback bound must hold so a 50k-event log doesn't dominate the
+    cost of ``nous status``. The cap is _TOOL_WALKBACK_LIMIT (200)."""
+
+    def test_returns_none_when_tool_event_outside_cap(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="EXECUTE_ANALYZE", iteration=1)
+        # 1 oldest tool event + 250 newer tool-less events (well beyond cap)
+        events = [{"type": "AssistantMessage", "ts": 100.0, "tool_name": "Bash"}]
+        for i in range(250):
+            events.append({"type": "SystemMessage", "ts": 200.0 + i})
+        _write_log(wd, 1, events, mtime=600.0)
+
+        snap = read_status_snapshot(wd, now=605.0)
+        assert snap.last_tool_name is None, (
+            "walkback cap must hold: 250 tool-less events past the old "
+            "Bash event should mean Bash is past the 200-event bound."
+        )
+
+    def test_finds_tool_event_just_inside_cap(self, tmp_path: Path) -> None:
+        """At exactly 199 tool-less events newer than the Bash, the
+        Bash is the 200th-newest event — just inside the cap."""
+        wd = tmp_path / "campaign"
+        _write_state(wd, run_id="r1", phase="EXECUTE_ANALYZE", iteration=1)
+        events = [{"type": "AssistantMessage", "ts": 100.0, "tool_name": "Bash"}]
+        for i in range(199):
+            events.append({"type": "SystemMessage", "ts": 200.0 + i})
+        _write_log(wd, 1, events, mtime=600.0)
+
+        snap = read_status_snapshot(wd, now=605.0)
+        assert snap.last_tool_name == "Bash"


### PR DESCRIPTION
## Summary

Lands **all twelve friction sub-issues** from the post-#204 paper-burst rerun (tracker **#213**) so the next rerun has a fully cleared friction surface — supporting both *surgical rehearsal iterations* and *full iterations that don't fail*.

Closes: **#205**, **#206**, **#207**, **#208**, **#209**, **#210**, **#211**, **#212** (v1), **#214**, **#215**, **#216**, **#217**.

The work splits into three coherent themes called out in the tracker:

1. **Watchdog / observability** — #205 (mid-turn watchdog), #207 (status walkback), #215 (meta_findings reads retry_log), #216 (rich diagnostic context), #217 (failed-vs-completed distinction). The next failure is now self-diagnosing instead of leaving operators with `error: "None"` and `Last tool: ?`.
2. **Search-orientation discipline** — #214 (REPORT reads partial results + retry_log + amendments), #212 (rehearsal mode), #206 (validator stops rejecting CLAUDE.md-prescribed fields), #208 (CLI message reflects #198 reality). Rehearsal is now the structured first iteration of any campaign; the report extractor can no longer dismiss 80% data as "no data."
3. **Operational handoff** — #209 (preflight_commands), #210 (fanout_template + classification_function + verified_parameters in bundle), #211 (bundle_amendments.jsonl drift record). DESIGN's verified work survives the fresh worktree of EXECUTE_ANALYZE; silent parameter overrides leave a permanent forensic trail.

## What's in v1 of rehearsal mode (#212)

- Campaign YAML grows `iterations: [...]` with per-entry `mode: rehearsal | real`.
- DESIGN methodology reads the resolved mode and renders mode-specific guidance: rehearsal iterations focus on **apparatus check** + **feasibility check**, use **ONE seed**, emit **`brief_amendments.md`**; real iterations run the full bundle.
- Defaults to `real` for missing/unknown config (backward-compat).
- **Same model for both modes** — haiku swap is a v2 lever (false-positive risk from haiku's blind spots is the unobvious cost; full design discussion in `docs/plans/rehearsal-mode.md` — uncommitted, available on request).

Operator usage:

```yaml
research_question: ...
iterations:
  - mode: rehearsal     # iter-1: surgical scope; emits brief_amendments.md
  - mode: real          # iter-2: full bundle, reads iter-1's amendments
```

## What's in the operational handoff cluster (#209/#210/#211)

DESIGN can now pin operational decisions in `bundle.experiment_spec` so EXECUTE_ANALYZE doesn't pay the token cost of re-deriving them in a fresh worktree:

```yaml
experiment_spec:
  preflight_commands:                # #209 — build steps that don't survive the worktree
    - "go build -o blis main.go"
  fanout_template:                   # #210 — exact GNU-parallel template, quoting verified
    "cat /tmp/args.txt | parallel -j $N './blis run {} > {}.log 2>&1'"
  classification_function:           # #210 — when per-result tagging isn't obvious
    "lambda r: 'adv' if r['num_prefill_tokens'] > 4096 else 'coop'"
  verified_parameters:               # #210 — DESIGN-verified, treat as canonical
    total_kv_blocks: 1200
    horizon_us: 300000000
```

When EXECUTE_ANALYZE smoke-testing reveals a parameter must change, it appends to `runs/iter-N/inputs/bundle_amendments.jsonl` (#211):

```jsonl
{"parameter": "total_kv_blocks", "prescribed_value": 1100, "actual_value": 1200, "reason": "smoke produced dropped_unservable=120"}
```

REPORT reads both `experiment_spec` and `bundle_amendments.jsonl` so the report describes the *executed* parameters, not the *prescribed* ones.

## Test plan

- [x] **+75 new tests, 1074 passed, 1 skipped, 0 regressions** (`pytest tests/`)
  - `test_complexity_tier`: +5 (metadata location accepted, reader fallback, gate panel) — #206
  - `test_nous_stop`: +1 (CLI message says "phase boundary") — #208
  - `test_sdk_dispatch`: +9 watchdog + +7 `build_error_message` — #205, #216
  - `test_meta_findings`: +3 (single `sdk_silence` row → ask; "heuristics gap" replaces "no surprises") — #215
  - `test_llm_dispatch`: +10 (results_summary, retry_log_summary, REPORT context) — #214
  - `test_iteration_mode` (new): +18 (resolver, guidance text, schema, design-prompt rendering) — #212
  - `test_status`: +5 walkback + +7 failed-iter counter — #207, #217
  - `test_experiment_spec` (new): +12 (schema for experiment_spec, bundle_amendments helper, REPORT context) — #209, #210, #211
  - `test_prompt_loader`: tiny ctx fix to surface new design placeholders.
- [x] All tests are behavioral and use existing seam-injected fakes per CLAUDE.md ("no live LLM calls in tests"). The watchdog logic and bundle-amendments rendering are pulled into pure-Python helpers specifically so they're testable without `claude_agent_sdk`.
- [ ] Re-run paper-burst against this PR's nous to verify the friction surfaced in #213 doesn't replay (next session). Expected outcome: rehearsal iter-1 produces a `brief_amendments.md` highlighting any campaign-spec friction; real iter-2 runs cleanly with `bundle_amendments.jsonl` recording any parameter overrides; even on failure, the report acknowledges partial data and the meta_findings emits actionable nous_asks.

## Files changed

```
 25 files changed, 2030 insertions(+), 33 deletions(-)
```

- `orchestrator/`: cli.py, complexity_tier.py, llm_dispatch.py, meta_findings.py, sdk_dispatch.py, status.py, schemas/{bundle,campaign}.schema.yaml; new modules `iteration_mode.py`
- `prompts/methodology/`: design.md, execute_analyze.md, report.md
- `tests/`: +`test_iteration_mode.py`, +`test_experiment_spec.py`, modifications to test_complexity_tier, test_nous_stop, test_sdk_dispatch, test_meta_findings, test_llm_dispatch, test_status, test_prompt_loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)
