### PR TITLE
fix(methodology): close all 5 subissues of tracker #225 (post-#218 follow-up)

### DIFF
--- a/orchestrator/iteration_mode.py
+++ b/orchestrator/iteration_mode.py
@@ -81,10 +81,15 @@ scientific completeness. Two distinct goals — score them separately:
 If you find any campaign-spec or brief inconsistencies (paths the
 validator rejects, broken argv quoting, wall-time claims that don't
 match reality, single-tenant probes when the target requires multi-
-tenant, etc.), write them to ``runs/iter-N/brief_amendments.md`` —
-one entry per finding, with file path + suggested change. The next
-``real`` iteration will read this; future runs of the same campaign
-will benefit indefinitely.
+tenant, etc.), write them to
+``runs/iter-N/inputs/brief_amendments.jsonl`` as one structured JSON
+object per line. Required fields: ``id`` (pattern ``BA-N``),
+``brief_section``, ``problem``, ``fix``, ``priority`` (one of
+``BLOCKING``, ``HIGH``, ``MEDIUM``, ``LOW``, ``INFO``). Optional
+``evidence``, ``impact``. Schema:
+``orchestrator/schemas/brief_amendments.schema.json``. The promote
+gate, the REPORT extractor, and the future ``apply-amendments`` CLI
+all read this structured form.
 
 **Do NOT:**
 - Author full multi-arm bundles. Keep arms minimal.
@@ -132,13 +137,13 @@ def mode_guidance_for(mode: Mode) -> str:
 # entire economic argument for #212.
 
 EXECUTE_REHEARSAL_GUIDANCE = """\
-This iteration is in **REHEARSAL** mode (#212). The DESIGN agent's
-bundle declares the full experimental design (so iter-2 / future runs
-can run it untouched). YOUR JOB this iter:
+This iteration is in **REHEARSAL** mode. The DESIGN agent's bundle
+declares the full experimental design (so iter-2 / future runs can
+run it untouched). YOUR JOB this iter:
 
 1. **Honor the rehearsal scope.** If the bundle's
-   ``experiment_spec.rehearsal_subset`` is populated (#222), execute
-   ONLY that subset (typically: 1 seed × the contrast-pair arms).
+   ``experiment_spec.rehearsal_subset`` is populated, execute ONLY
+   that subset (typically: 1 seed × the contrast-pair arms).
    Do NOT fan out the full ``experiment_spec`` — that's iter-2's job.
    If ``rehearsal_subset`` is missing, default to: first canonical
    seed + ``h-main`` and ``h-control-negative`` arms only.
@@ -148,7 +153,7 @@ can run it untouched). YOUR JOB this iter:
    analysis script fails or returns null where data is present,
    fix the script (or surface the issue) before iter-2 runs.
 
-3. **Append per-policy timing observations** (#226). During the
+3. **Append per-policy timing observations.** During the
    feasibility / contrast-pair runs, measure wall-clock per policy.
    Record into ``experiment_spec.timing_observations``:
    ``expected_wall_time_seconds_per_policy: { ea-wfq: 25, wfq: 23, ... }``
@@ -156,7 +161,7 @@ can run it untouched). YOUR JOB this iter:
    (~3× the slowest observed policy + buffer). iter-2's watchdog
    reads these to calibrate.
 
-4. **Emit ``brief_amendments.jsonl``** (post-#223 structured form) at
+4. **Emit ``brief_amendments.jsonl``** at
    ``runs/iter-N/inputs/brief_amendments.jsonl`` if you find any
    campaign-spec friction (workload params, timing claims, missing
    flags, etc.). One JSON object per line; required fields: ``id``
@@ -164,7 +169,7 @@ can run it untouched). YOUR JOB this iter:
    ``priority`` (BLOCKING / HIGH / MEDIUM / LOW / INFO). Optional
    ``evidence``, ``impact``.
 
-5. **Append to ``bundle_amendments.jsonl``** (#211) when you override
+5. **Append to ``bundle_amendments.jsonl``** when you override
    any parameter from ``experiment_spec.verified_parameters``.
 
 6. **Write findings.json with ``mode: rehearsal``** in the outcome,
@@ -180,15 +185,22 @@ can run it untouched). YOUR JOB this iter:
 """
 
 EXECUTE_REAL_GUIDANCE = """\
-This iteration is in **REAL** mode (#212). Run the full experiment_spec
-at the bundle's prescribed scope: all arms, full seed list. If a prior
-``rehearsal`` iter emitted ``brief_amendments.jsonl``, read it before
-launching the experiment — if any ``priority: BLOCKING`` amendments
-exist that haven't been applied to the brief, halt with a
-``failure_note.md`` (promotion-gate logic, #224). Otherwise run the
-full bundle, write ``findings.json`` with ``mode: real`` and a CONFIRMED /
-REFUTED / NULL status per arm, and append ``bundle_amendments.jsonl``
-(#211) for any parameter overrides observed during execution.
+This iteration is in **REAL** mode. Run the full experiment_spec at
+the bundle's prescribed scope: all arms, full seed list.
+
+If a prior ``rehearsal`` iter emitted ``brief_amendments.jsonl``, read
+it BEFORE launching the experiment. Any ``priority: BLOCKING``
+amendments encode constraints iter-2 must respect (e.g., a workload
+parameter the rehearsal verified is required for the experiment to
+engage the mechanism). Apply each BLOCKING amendment to your run
+configuration and proceed; if you cannot apply one, write a
+``failure_note.md`` describing why and STOP — the campaign should
+revise the brief before continuing.
+
+Write ``findings.json`` with ``mode: real`` and a CONFIRMED / REFUTED
+/ NULL status per arm. Append ``bundle_amendments.jsonl`` for any
+parameter overrides observed during execution (silent drift breaks
+reproducibility).
 """
 
 

--- a/orchestrator/iteration_mode.py
+++ b/orchestrator/iteration_mode.py
@@ -105,7 +105,7 @@ re-discover the same friction.
 
 
 def mode_guidance_for(mode: Mode) -> str:
-    """Return the prompt block that guides the agent for ``mode``.
+    """Return the DESIGN-phase prompt block that guides the agent for ``mode``.
 
     Raises ``ValueError`` on an unknown mode value. Silently defaulting
     to REAL_GUIDANCE was the prior behavior; that's the more dangerous
@@ -116,6 +116,92 @@ def mode_guidance_for(mode: Mode) -> str:
         return REHEARSAL_GUIDANCE
     if mode == "real":
         return REAL_GUIDANCE
+    raise ValueError(
+        f"unknown iteration mode {mode!r}; expected one of {VALID_MODES}"
+    )
+
+
+# ─── Execute-phase mode guidance (#221) ──────────────────────────────────
+#
+# The DESIGN agent's mode_guidance shaped how it scope-shrunk probes /
+# bundle authoring. EXECUTE_ANALYZE needs its OWN mode-aware guidance
+# so it doesn't fan out the bundle at full scope when iter is rehearsal.
+# Without this, post-#212 paper-burst reruns observed the DESIGN agent
+# honoring rehearsal scope while EXECUTE_ANALYZE dutifully ran the full
+# 50-arm experiment anyway — defeating the cost asymmetry that was the
+# entire economic argument for #212.
+
+EXECUTE_REHEARSAL_GUIDANCE = """\
+This iteration is in **REHEARSAL** mode (#212). The DESIGN agent's
+bundle declares the full experimental design (so iter-2 / future runs
+can run it untouched). YOUR JOB this iter:
+
+1. **Honor the rehearsal scope.** If the bundle's
+   ``experiment_spec.rehearsal_subset`` is populated (#222), execute
+   ONLY that subset (typically: 1 seed × the contrast-pair arms).
+   Do NOT fan out the full ``experiment_spec`` — that's iter-2's job.
+   If ``rehearsal_subset`` is missing, default to: first canonical
+   seed + ``h-main`` and ``h-control-negative`` arms only.
+
+2. **Validate the analysis pipeline.** Schema-pass at least one
+   result through the analysis_summary.json computation. If the
+   analysis script fails or returns null where data is present,
+   fix the script (or surface the issue) before iter-2 runs.
+
+3. **Append per-policy timing observations** (#226). During the
+   feasibility / contrast-pair runs, measure wall-clock per policy.
+   Record into ``experiment_spec.timing_observations``:
+   ``expected_wall_time_seconds_per_policy: { ea-wfq: 25, wfq: 23, ... }``
+   and a derived ``recommended_turn_silence_threshold_seconds``
+   (~3× the slowest observed policy + buffer). iter-2's watchdog
+   reads these to calibrate.
+
+4. **Emit ``brief_amendments.jsonl``** (post-#223 structured form) at
+   ``runs/iter-N/inputs/brief_amendments.jsonl`` if you find any
+   campaign-spec friction (workload params, timing claims, missing
+   flags, etc.). One JSON object per line; required fields: ``id``
+   (pattern ``BA-N``), ``brief_section``, ``problem``, ``fix``,
+   ``priority`` (BLOCKING / HIGH / MEDIUM / LOW / INFO). Optional
+   ``evidence``, ``impact``.
+
+5. **Append to ``bundle_amendments.jsonl``** (#211) when you override
+   any parameter from ``experiment_spec.verified_parameters``.
+
+6. **Write findings.json with ``mode: rehearsal``** in the outcome,
+   noting that scientific claims are deferred to iter-2. The
+   ``experiment_valid: true`` flag means "the apparatus works" —
+   not "the hypothesis is confirmed/refuted."
+
+**Do NOT:**
+- Fan out the full bundle's seeds × policies grid.
+- Mark h-main as CONFIRMED / REFUTED based on rehearsal data.
+- Skip writing ``brief_amendments.jsonl`` if you discovered
+  campaign-spec friction.
+"""
+
+EXECUTE_REAL_GUIDANCE = """\
+This iteration is in **REAL** mode (#212). Run the full experiment_spec
+at the bundle's prescribed scope: all arms, full seed list. If a prior
+``rehearsal`` iter emitted ``brief_amendments.jsonl``, read it before
+launching the experiment — if any ``priority: BLOCKING`` amendments
+exist that haven't been applied to the brief, halt with a
+``failure_note.md`` (promotion-gate logic, #224). Otherwise run the
+full bundle, write ``findings.json`` with ``mode: real`` and a CONFIRMED /
+REFUTED / NULL status per arm, and append ``bundle_amendments.jsonl``
+(#211) for any parameter overrides observed during execution.
+"""
+
+
+def execute_mode_guidance_for(mode: Mode) -> str:
+    """Return the EXECUTE_ANALYZE-phase prompt block for ``mode`` (#221).
+
+    Distinct from ``mode_guidance_for`` (which targets the DESIGN agent).
+    Raises ``ValueError`` on unknown modes for the same fail-loud reason.
+    """
+    if mode == "rehearsal":
+        return EXECUTE_REHEARSAL_GUIDANCE
+    if mode == "real":
+        return EXECUTE_REAL_GUIDANCE
     raise ValueError(
         f"unknown iteration mode {mode!r}; expected one of {VALID_MODES}"
     )

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -140,14 +140,17 @@ def _format_brief_amendments_summary(work_dir: Path) -> str:
     Each amendment is a JSON object with required fields
     ``id, brief_section, problem, fix, priority``. Optional
     ``evidence``, ``impact``. The schema lives at
-    ``orchestrator/schemas/brief_amendments.schema.json``.
+    ``orchestrator/schemas/brief_amendments.schema.json`` and is
+    enforced by the agent that *writes* the file (per methodology) —
+    this renderer JSON-decodes each row and surfaces a count of
+    lines that failed to parse so the operator sees corruption,
+    but does not itself re-validate against the schema.
 
-    Walks ``runs/iter-*/inputs/brief_amendments.jsonl``, schema-validates
-    rows individually (skipping malformed with a visible warning), and
-    renders a per-iter listing grouped by priority. The REPORT extractor
-    can use this to: (a) cite which amendments shaped the iteration's
-    findings, (b) flag which BLOCKING amendments still need applying
-    to the upstream brief (the cross-run learning loop).
+    Walks ``runs/iter-*/inputs/brief_amendments.jsonl`` and renders a
+    per-iter listing grouped by priority. The REPORT extractor can use
+    this to: (a) cite which amendments shaped the iteration's findings,
+    (b) flag which BLOCKING amendments still need applying to the
+    upstream brief (the cross-run learning loop).
     """
     runs_dir = work_dir / "runs"
     if not runs_dir.is_dir():

--- a/orchestrator/llm_dispatch.py
+++ b/orchestrator/llm_dispatch.py
@@ -133,6 +133,91 @@ def _format_results_summary(work_dir: Path) -> str:
     return "\n".join(lines)
 
 
+def _format_brief_amendments_summary(work_dir: Path) -> str:
+    """#223: surface structured ``brief_amendments.jsonl`` entries to
+    the REPORT extractor.
+
+    Each amendment is a JSON object with required fields
+    ``id, brief_section, problem, fix, priority``. Optional
+    ``evidence``, ``impact``. The schema lives at
+    ``orchestrator/schemas/brief_amendments.schema.json``.
+
+    Walks ``runs/iter-*/inputs/brief_amendments.jsonl``, schema-validates
+    rows individually (skipping malformed with a visible warning), and
+    renders a per-iter listing grouped by priority. The REPORT extractor
+    can use this to: (a) cite which amendments shaped the iteration's
+    findings, (b) flag which BLOCKING amendments still need applying
+    to the upstream brief (the cross-run learning loop).
+    """
+    runs_dir = work_dir / "runs"
+    if not runs_dir.is_dir():
+        return "(no iteration directories — no brief amendments to report.)"
+    iter_dirs = sorted(
+        (d for d in runs_dir.iterdir()
+         if d.is_dir() and d.name.startswith("iter-")),
+        key=lambda d: d.name,
+    )
+    sections: list[str] = []
+    total = 0
+    for iter_dir in iter_dirs:
+        log = iter_dir / "inputs" / "brief_amendments.jsonl"
+        if not log.exists():
+            continue
+        try:
+            text = log.read_text()
+        except OSError as exc:
+            sections.append(
+                f"- {iter_dir.name}: brief_amendments.jsonl unreadable "
+                f"({type(exc).__name__})"
+            )
+            continue
+        rows: list[dict] = []
+        skipped_malformed = 0
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                skipped_malformed += 1
+        if not rows and skipped_malformed == 0:
+            continue
+        # Group by priority for at-a-glance triage. BLOCKING first, then
+        # HIGH / MEDIUM / LOW / INFO. Unknown priorities sort last.
+        priority_order = {
+            "BLOCKING": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "INFO": 4,
+        }
+        rows_sorted = sorted(
+            rows,
+            key=lambda r: priority_order.get(
+                str(r.get("priority", "")).upper(), 99
+            ),
+        )
+        header = f"- {iter_dir.name}: {len(rows)} amendment(s)"
+        if skipped_malformed:
+            header += f" + {skipped_malformed} malformed line(s) skipped"
+        sections.append(header)
+        total += len(rows)
+        cap = 20
+        for r in rows_sorted[:cap]:
+            aid = r.get("id", "?")
+            prio = r.get("priority", "?")
+            section = r.get("brief_section", "?")
+            problem = r.get("problem", "")
+            sections.append(
+                f"  - [{prio}] {aid} (target: {section}) — "
+                + (problem[:160] + "..." if len(problem) > 160 else problem)
+            )
+        if len(rows_sorted) > cap:
+            sections.append(f"  - ... and {len(rows_sorted) - cap} more")
+    if not sections:
+        return (
+            "(no brief_amendments.jsonl entries — the campaign brief was "
+            "consistent with the agent's runs; no amendments queued.)"
+        )
+    return "\n".join(sections)
+
+
 def _format_bundle_amendments_summary(work_dir: Path) -> str:
     """#211: surface bundle_amendments.jsonl entries to the REPORT extractor.
 
@@ -594,6 +679,19 @@ class LLMDispatcher:
                     "No design handoff available — explore the system directly."
                 )
 
+            # #221: per-iteration mode signal in EXECUTE_ANALYZE too. The
+            # post-#212 paper-burst rerun observed the DESIGN agent
+            # honoring rehearsal scope-shrink while EXECUTE_ANALYZE
+            # dutifully fanned out the full bundle anyway — because the
+            # mode signal only flowed to DESIGN. Rendering it in execute
+            # too closes that gap.
+            from orchestrator.iteration_mode import (
+                iteration_mode_for, execute_mode_guidance_for,
+            )
+            mode = iteration_mode_for(self.campaign, iteration)
+            ctx["iteration_mode"] = mode
+            ctx["mode_guidance"] = execute_mode_guidance_for(mode)
+
         if perspective is not None:
             ctx["perspective_name"] = perspective
 
@@ -655,6 +753,14 @@ class LLMDispatcher:
             # different values.
             ctx["bundle_amendments_summary"] = (
                 _format_bundle_amendments_summary(self.work_dir)
+            )
+            # #223: structured brief_amendments — propagate to REPORT
+            # so the extractor can cite which amendments shaped the
+            # iteration's findings AND surface BLOCKING amendments
+            # that haven't been applied to the upstream brief yet
+            # (cross-run learning loop).
+            ctx["brief_amendments_summary"] = (
+                _format_brief_amendments_summary(self.work_dir)
             )
 
         return ctx

--- a/orchestrator/promote_gate.py
+++ b/orchestrator/promote_gate.py
@@ -1,0 +1,200 @@
+"""Deterministic promotion-gate decision logic (#224 v1).
+
+After an iteration completes, the engine needs a decision: promote to
+the next iteration, revise (halt for operator action), or abort. Today
+(post-#218) the engine has no such decision point — iterations run
+linearly with no protection against (a) BLOCKING brief_amendments
+that haven't been applied to the upstream brief, or (b) feasibility
+failures that mean further iterations on this regime are wasted.
+
+This module is the v1 decision-function. The caller — engine
+state-machine integration is deferred to v2 — passes a work_dir +
+iteration index and gets a structured decision back. Pure Python, no
+LLM, no I/O beyond reading on-disk artifacts. Heuristics over
+``findings.json``, ``brief_amendments.jsonl`` (#223), and
+``applied_amendments.jsonl`` (the future apply-amendments CLI's
+provenance log).
+
+**v1 scope:**
+
+- Function returns a structured dict; engine integration is the v2
+  concern. This lets the decision logic be tested in isolation
+  before any state-machine changes land.
+- Decision rule:
+   1. ``findings.json`` missing OR ``experiment_valid: false`` → ``abort``
+   2. Any unapplied amendment with ``priority: "BLOCKING"`` → ``revise``
+   3. else → ``promote``
+- Auto-approve interaction (the ``summarize-gate`` LLM-driven override)
+  is out of v1 scope. The deterministic decision is the source of
+  truth; auto-approve in v2 just rubber-stamps it.
+
+Per CLAUDE.md test discipline (no live LLM calls): this module is pure
+Python and trivially testable with synthesized inputs.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+
+Decision = Literal["promote", "revise", "abort"]
+
+VALID_DECISIONS: tuple[Decision, ...] = ("promote", "revise", "abort")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    """Read a JSONL file; skip malformed lines silently."""
+    if not path.exists():
+        return []
+    rows: list[dict] = []
+    try:
+        text = path.read_text()
+    except OSError:
+        return []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+def _read_json(path: Path) -> object | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def evaluate_promote_gate(
+    work_dir: Path,
+    iteration: int,
+) -> dict:
+    """Decide whether to promote, revise, or abort after iteration N.
+
+    Returns a structured dict: ``{decision, reasoning, blocking_amendments,
+    applied_amendments, feasibility_check}``.
+
+    Decision rule (deterministic; pure Python):
+        1. ``runs/iter-N/findings.json`` missing → ``abort``
+           ("no apparatus output to evaluate; iteration didn't reach
+           the analysis phase").
+        2. ``findings.experiment_valid == false`` → ``abort``
+           ("the apparatus failed; no scientific signal").
+        3. Any ``brief_amendments.jsonl`` row with ``priority:
+           BLOCKING`` whose ``id`` is NOT in
+           ``<work_dir>/applied_amendments.jsonl`` → ``revise``
+           ("blocking amendment must be applied to the brief before
+           iter-(N+1) can produce valid data").
+        4. Otherwise → ``promote``.
+
+    Engine integration (v2): the engine calls this between iterations
+    and acts on ``decision``: ``promote`` → start iter-(N+1),
+    ``revise`` → halt with ``CampaignStopped("revise")`` so the operator
+    can run ``nous brief apply-amendments``, ``abort`` → halt with
+    ``CampaignStopped("abort")``.
+    """
+    work_dir = Path(work_dir)
+    iter_dir = work_dir / "runs" / f"iter-{iteration}"
+
+    # 1+2. Findings.json gate.
+    findings = _read_json(iter_dir / "findings.json")
+    if not isinstance(findings, dict):
+        return _decision(
+            "abort",
+            reasoning=(
+                f"runs/iter-{iteration}/findings.json missing or "
+                f"unreadable; the iteration did not reach the analysis "
+                f"phase (or analysis failed before writing findings). "
+                f"Cannot promote without a scientific outcome."
+            ),
+            blocking=[],
+            applied=[],
+            feasibility=False,
+        )
+    if findings.get("experiment_valid") is False:
+        return _decision(
+            "abort",
+            reasoning=(
+                f"runs/iter-{iteration}/findings.json reports "
+                f"experiment_valid=false; the apparatus failed. "
+                f"Iter-{iteration + 1} won't fix this — operator must "
+                f"revise the campaign before any further iteration."
+            ),
+            blocking=[],
+            applied=[],
+            feasibility=False,
+        )
+
+    # 3. Brief-amendments gate.
+    amendments = _read_jsonl(iter_dir / "inputs" / "brief_amendments.jsonl")
+    applied_rows = _read_jsonl(work_dir / "applied_amendments.jsonl")
+    applied_ids = {
+        str(r.get("id"))
+        for r in applied_rows
+        if isinstance(r, dict) and r.get("id")
+    }
+    blocking_unapplied = [
+        a for a in amendments
+        if isinstance(a, dict)
+        and a.get("priority") == "BLOCKING"
+        and a.get("id") not in applied_ids
+    ]
+    if blocking_unapplied:
+        ids = ", ".join(
+            str(a.get("id", "?")) for a in blocking_unapplied[:5]
+        )
+        if len(blocking_unapplied) > 5:
+            ids += f", ... and {len(blocking_unapplied) - 5} more"
+        return _decision(
+            "revise",
+            reasoning=(
+                f"{len(blocking_unapplied)} BLOCKING brief_amendment(s) "
+                f"({ids}) have not been applied to the upstream brief. "
+                f"Iter-{iteration + 1} would re-discover or re-trip "
+                f"these issues. Run `nous brief apply-amendments` (post-#223 "
+                f"v2) or apply manually, then resume."
+            ),
+            blocking=[str(a.get("id", "?")) for a in blocking_unapplied],
+            applied=sorted(applied_ids),
+            feasibility=True,
+        )
+
+    # 4. Default → promote.
+    return _decision(
+        "promote",
+        reasoning=(
+            f"iter-{iteration} produced valid findings and no BLOCKING "
+            f"brief_amendments are pending. Iter-{iteration + 1} can "
+            f"proceed."
+        ),
+        blocking=[],
+        applied=sorted(applied_ids),
+        feasibility=True,
+    )
+
+
+def _decision(
+    decision: Decision,
+    *,
+    reasoning: str,
+    blocking: list[str],
+    applied: list[str],
+    feasibility: bool,
+) -> dict:
+    """Build the result dict in the canonical shape."""
+    return {
+        "decision": decision,
+        "reasoning": reasoning,
+        "blocking_amendments": blocking,
+        "applied_amendments": applied,
+        "feasibility_check": {
+            "passed": feasibility,
+        },
+    }

--- a/orchestrator/promote_gate.py
+++ b/orchestrator/promote_gate.py
@@ -43,15 +43,23 @@ Decision = Literal["promote", "revise", "abort"]
 VALID_DECISIONS: tuple[Decision, ...] = ("promote", "revise", "abort")
 
 
-def _read_jsonl(path: Path) -> list[dict]:
-    """Read a JSONL file; skip malformed lines silently."""
+def _read_jsonl_with_skips(path: Path) -> tuple[list[dict], int]:
+    """Read a JSONL file. Returns ``(valid_rows, malformed_count)``.
+
+    Malformed-line counts are surfaced (not silently dropped) because
+    the gate makes BLOCKING decisions on these files: a corrupt line
+    that was meant to be a BLOCKING amendment must not silently
+    register as "no BLOCKING amendments" and let the campaign promote
+    to its next iteration.
+    """
     if not path.exists():
-        return []
-    rows: list[dict] = []
+        return [], 0
     try:
         text = path.read_text()
     except OSError:
-        return []
+        return [], 0
+    rows: list[dict] = []
+    malformed = 0
     for line in text.splitlines():
         line = line.strip()
         if not line:
@@ -59,7 +67,16 @@ def _read_jsonl(path: Path) -> list[dict]:
         try:
             rows.append(json.loads(line))
         except json.JSONDecodeError:
-            continue
+            malformed += 1
+    return rows, malformed
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    """Backward-compat thin wrapper. Drops the malformed count for
+    callers that don't need it (today: ``applied_amendments.jsonl``,
+    where the cost of a corrupted apply log is symmetric — false
+    negatives + false positives both possible)."""
+    rows, _ = _read_jsonl_with_skips(path)
     return rows
 
 
@@ -92,12 +109,26 @@ def evaluate_promote_gate(
            ``<work_dir>/applied_amendments.jsonl`` → ``revise``
            ("blocking amendment must be applied to the brief before
            iter-(N+1) can produce valid data").
+        3b. Any malformed line(s) in ``brief_amendments.jsonl`` →
+           ``revise`` (cannot rule out a hidden BLOCKING entry;
+           asymmetric-risk choice).
         4. Otherwise → ``promote``.
+
+    **Scoping (v1):** the gate reads only iter-N's
+    ``brief_amendments.jsonl``, NOT amendments from earlier iters. Per
+    the schema, ``id`` (e.g. ``BA-1``) is "stable within this iter's
+    amendments" — *not globally unique*. So an iter-1 BLOCKING
+    amendment that the operator never applied will NOT be re-flagged
+    when this function is called for iter-2 (iter-2's gate looks at
+    iter-2's amendments only). The cross-iter "still-pending" view is
+    deferred to v2 (apply-amendments CLI + composite IDs); for v1,
+    callers MUST run the gate after EVERY iter that emits any
+    BLOCKING amendment, not just the last one.
 
     Engine integration (v2): the engine calls this between iterations
     and acts on ``decision``: ``promote`` → start iter-(N+1),
     ``revise`` → halt with ``CampaignStopped("revise")`` so the operator
-    can run ``nous brief apply-amendments``, ``abort`` → halt with
+    can apply amendments, ``abort`` → halt with
     ``CampaignStopped("abort")``.
     """
     work_dir = Path(work_dir)
@@ -132,8 +163,14 @@ def evaluate_promote_gate(
             feasibility=False,
         )
 
-    # 3. Brief-amendments gate.
-    amendments = _read_jsonl(iter_dir / "inputs" / "brief_amendments.jsonl")
+    # 3. Brief-amendments gate. Counts malformed lines separately —
+    # a corrupted line could have been a BLOCKING amendment, and
+    # silently letting it disappear past the gate is exactly the
+    # asymmetric-risk failure (false promote >> false revise) we
+    # want to avoid.
+    amendments, malformed = _read_jsonl_with_skips(
+        iter_dir / "inputs" / "brief_amendments.jsonl",
+    )
     applied_rows = _read_jsonl(work_dir / "applied_amendments.jsonl")
     applied_ids = {
         str(r.get("id"))
@@ -158,12 +195,34 @@ def evaluate_promote_gate(
                 f"{len(blocking_unapplied)} BLOCKING brief_amendment(s) "
                 f"({ids}) have not been applied to the upstream brief. "
                 f"Iter-{iteration + 1} would re-discover or re-trip "
-                f"these issues. Run `nous brief apply-amendments` (post-#223 "
-                f"v2) or apply manually, then resume."
+                f"these issues. Apply the amendments manually (or wait "
+                f"for `nous brief apply-amendments`), then resume."
             ),
             blocking=[str(a.get("id", "?")) for a in blocking_unapplied],
             applied=sorted(applied_ids),
             feasibility=True,
+            malformed_lines=malformed,
+        )
+
+    # 3b. Malformed-line safety: if the amendments file had any
+    # unparseable lines, we cannot rule out a hidden BLOCKING entry.
+    # Asymmetric risk: false revise costs an operator a few minutes
+    # of inspection; false promote past corruption can waste an
+    # iteration's tokens. Choose revise.
+    if malformed > 0:
+        return _decision(
+            "revise",
+            reasoning=(
+                f"{malformed} malformed line(s) in "
+                f"runs/iter-{iteration}/inputs/brief_amendments.jsonl "
+                f"could not be parsed. We cannot rule out a hidden "
+                f"BLOCKING amendment among them. Inspect the file and "
+                f"fix the malformed lines before iter-{iteration + 1}."
+            ),
+            blocking=[],
+            applied=sorted(applied_ids),
+            feasibility=True,
+            malformed_lines=malformed,
         )
 
     # 4. Default → promote.
@@ -177,6 +236,7 @@ def evaluate_promote_gate(
         blocking=[],
         applied=sorted(applied_ids),
         feasibility=True,
+        malformed_lines=0,
     )
 
 
@@ -187,8 +247,8 @@ def _decision(
     blocking: list[str],
     applied: list[str],
     feasibility: bool,
+    malformed_lines: int = 0,
 ) -> dict:
-    """Build the result dict in the canonical shape."""
     return {
         "decision": decision,
         "reasoning": reasoning,
@@ -197,4 +257,5 @@ def _decision(
         "feasibility_check": {
             "passed": feasibility,
         },
+        "malformed_amendment_lines": malformed_lines,
     }

--- a/orchestrator/schemas/brief_amendments.schema.json
+++ b/orchestrator/schemas/brief_amendments.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/schemas/brief_amendments.schema.json",
+  "title": "Brief Amendment",
+  "description": "One structured amendment to a campaign brief. Stored as one JSON object per line in `runs/iter-N/inputs/brief_amendments.jsonl`. The structured form (post-#223) replaces the prior free-form markdown so amendments can be programmatically parsed, applied to briefs, and propagated across campaign runs without re-discovery.",
+  "type": "object",
+  "required": ["id", "brief_section", "problem", "fix", "priority"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^BA-[0-9]+$",
+      "description": "Stable identifier within this iter's amendments (e.g. 'BA-1', 'BA-2'). Numbers are 1-indexed and unique within an iter."
+    },
+    "brief_section": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The brief location the amendment targets, e.g. '.nous/paper-burst-brief.md §ITER-1' or 'paper-conventions.md §parallel-execution'. Must be specific enough that an apply-amendments tool can locate the section."
+    },
+    "problem": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Plain-English description of what the brief got wrong, missing, or unclear. The 'why-it-matters' explanation."
+    },
+    "evidence": {
+      "type": "string",
+      "description": "Observed behavior that demonstrates the problem (e.g. 'dropped_unservable=61, adversary completed=0' or a quoted error message). Optional but strongly recommended."
+    },
+    "fix": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Specific edit instruction. Should be concrete enough that an operator (or a future apply-amendments CLI, post-#223 v2) can mechanically apply it: 'Add --max-model-len 0 to all main-experiment BLIS commands' is good; 'fix the model length issue' is not."
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["BLOCKING", "HIGH", "MEDIUM", "LOW", "INFO"],
+      "description": "How urgently this needs applying before iter-2 / next campaign run. BLOCKING means iter-2 will produce invalid data without this fix; HIGH/MEDIUM are quality concerns; LOW is polish; INFO is observation. Per #224, BLOCKING amendments not yet applied trigger the promotion gate's 'revise' decision."
+    },
+    "impact": {
+      "type": "string",
+      "description": "What happens if the brief is NOT amended. Optional. E.g. 'iter-2 produces ground_truth_held=false trivially because adversary requests are all dropped'."
+    }
+  }
+}

--- a/orchestrator/schemas/bundle.schema.yaml
+++ b/orchestrator/schemas/bundle.schema.yaml
@@ -141,6 +141,85 @@ properties:
           system, e.g. ``{total_kv_blocks: 1200}``. EXECUTE_ANALYZE
           treats them as canonical; deviations require an entry in
           ``bundle_amendments.jsonl`` (#211).
+      rehearsal_subset:
+        # #222: structured rehearsal scope. When iteration_mode ==
+        # "rehearsal" AND this field is populated, EXECUTE_ANALYZE
+        # executes ONLY this subset (not the full experiment_spec).
+        # Without this field, the rehearsal agent has to infer scope
+        # from prose methodology — which the post-#212 paper-burst
+        # rerun showed is unreliable (the agent fanned out the full
+        # 50-arm bundle anyway).
+        type: object
+        additionalProperties: false
+        description: >
+          Subset of the full experiment to execute in rehearsal mode (#222).
+          DESIGN populates this; EXECUTE_ANALYZE in rehearsal mode runs
+          ONLY this subset. iter-2 (real mode) ignores this field and
+          runs the full experiment_spec.
+        properties:
+          seeds:
+            type: array
+            items: { type: integer }
+            minItems: 1
+            description: >
+              Subset of canonical seeds to execute in rehearsal.
+              Typically the first canonical seed only.
+          arms:
+            type: array
+            items: { type: string, minLength: 1 }
+            minItems: 1
+            description: >
+              Subset of arm IDs to execute in rehearsal — typically
+              the contrast pair (h-main + the most direct control).
+          extra_validation_only:
+            type: boolean
+            description: >
+              When true, rehearsal does NOT make scientific claims —
+              ``findings.json`` is marked ``mode: rehearsal`` regardless
+              of confirmed/refuted status. Iter-2 makes the canonical
+              scientific call.
+      timing_observations:
+        # #226: structured per-policy timing data captured during
+        # rehearsal feasibility probes. Fields are SCHEMA-LOCKED here
+        # (vs verified_parameters which is open by design — that's a
+        # knob namespace; this is a measurement record). Iter-2's
+        # SDKDispatcher reads ``recommended_turn_silence_threshold_seconds``
+        # to calibrate the live watchdog (#205).
+        type: object
+        additionalProperties: false
+        description: >
+          Per-policy wall-time observations from rehearsal feasibility
+          probes (#226). Used by the engine to calibrate iter-2's
+          watchdog thresholds and by the brief_amendments machinery
+          to surface recurring slow-policy patterns across runs.
+        properties:
+          expected_wall_time_seconds_per_policy:
+            type: object
+            description: >
+              Map of policy name → observed wall-time seconds. Recorded
+              during the rehearsal feasibility probe at one canonical
+              seed. EXECUTE_ANALYZE's per-arm timeout (when the runner
+              supports one) and the watchdog threshold derive from this.
+            additionalProperties:
+              type: number
+              minimum: 0
+          recommended_turn_silence_threshold_seconds:
+            type: number
+            minimum: 0
+            description: >
+              Suggested override for ``campaign.sdk_timeouts.turn_silence_threshold_seconds``
+              for iter-2 / real iters. Computed by the rehearsal agent
+              as roughly 3× the slowest policy observed, with buffer.
+              ``SDKDispatcher`` reads this in preference to the
+              campaign-level default.
+          observation_method:
+            type: string
+            minLength: 1
+            description: >
+              How the observations were collected (e.g. "feasibility
+              probe at seed=42, horizon=120s, single arm per policy").
+              Helps iter-2 / future runs interpret the numbers
+              correctly.
 
   arms:
     type: array

--- a/orchestrator/sdk_dispatch.py
+++ b/orchestrator/sdk_dispatch.py
@@ -620,13 +620,16 @@ class SDKDispatcher(CLIDispatcher):
 
     def _bundle_recommended_turn_silence_threshold(
             self, iteration: int) -> float | None:
-        """#226: read the rehearsal-recorded watchdog threshold override
-        from ``bundle.experiment_spec.timing_observations.recommended_turn_silence_threshold_seconds``
-        for the iter immediately PRIOR to the current one (the rehearsal
-        iter, when present).
+        """Read the rehearsal-recorded watchdog threshold override from the
+        prior iter's bundle.experiment_spec.timing_observations.
 
-        Returns None if the bundle / field doesn't exist or is malformed.
-        Pure file reader — no LLM, no I/O beyond a single read.
+        Returns ``None`` for: iter-1 (no prior bundle), missing bundle file,
+        unparseable YAML, or absent/malformed
+        ``recommended_turn_silence_threshold_seconds``. On parse failures
+        (corrupt YAML, missing PyYAML), logs a warning so operators see
+        why the override didn't apply — silently falling back to the
+        campaign default would be the silent-failure pattern PR #218
+        was specifically meant to kill.
         """
         if iteration < 2:
             return None
@@ -634,10 +637,26 @@ class SDKDispatcher(CLIDispatcher):
         bundle_path = prior_iter_dir / "bundle.yaml"
         if not bundle_path.exists():
             return None
+        # Import yaml outside the try/except: an ImportError here is
+        # an environmental defect that should propagate, not a
+        # silent fallback to the campaign default.
+        import yaml as _yaml
         try:
-            import yaml as _yaml
-            data = _yaml.safe_load(bundle_path.read_text())
-        except (OSError, Exception):  # noqa: BLE001
+            text = bundle_path.read_text()
+            data = _yaml.safe_load(text)
+        except OSError as exc:
+            logger.warning(
+                "iter-%d bundle unreadable; skipping timing-override "
+                "(%s: %s)",
+                iteration - 1, type(exc).__name__, exc,
+            )
+            return None
+        except _yaml.YAMLError as exc:
+            logger.warning(
+                "iter-%d bundle YAML invalid; skipping timing-override "
+                "(falling back to campaign default %.0fs): %s",
+                iteration - 1, self._turn_silence_threshold, exc,
+            )
             return None
         if not isinstance(data, dict):
             return None

--- a/orchestrator/sdk_dispatch.py
+++ b/orchestrator/sdk_dispatch.py
@@ -618,6 +618,44 @@ class SDKDispatcher(CLIDispatcher):
                 summary["max_gap_seconds"], self._silence_threshold,
             )
 
+    def _bundle_recommended_turn_silence_threshold(
+            self, iteration: int) -> float | None:
+        """#226: read the rehearsal-recorded watchdog threshold override
+        from ``bundle.experiment_spec.timing_observations.recommended_turn_silence_threshold_seconds``
+        for the iter immediately PRIOR to the current one (the rehearsal
+        iter, when present).
+
+        Returns None if the bundle / field doesn't exist or is malformed.
+        Pure file reader — no LLM, no I/O beyond a single read.
+        """
+        if iteration < 2:
+            return None
+        prior_iter_dir = self.work_dir / "runs" / f"iter-{iteration - 1}"
+        bundle_path = prior_iter_dir / "bundle.yaml"
+        if not bundle_path.exists():
+            return None
+        try:
+            import yaml as _yaml
+            data = _yaml.safe_load(bundle_path.read_text())
+        except (OSError, Exception):  # noqa: BLE001
+            return None
+        if not isinstance(data, dict):
+            return None
+        spec = data.get("experiment_spec") or {}
+        if not isinstance(spec, dict):
+            return None
+        timing = spec.get("timing_observations") or {}
+        if not isinstance(timing, dict):
+            return None
+        val = timing.get("recommended_turn_silence_threshold_seconds")
+        try:
+            v = float(val) if val is not None else None
+        except (TypeError, ValueError):
+            return None
+        if v is None or v < 0:
+            return None
+        return v
+
     def dispatch(  # type: ignore[override]
         self, role: str, phase: str, *, output_path, iteration: int,
         perspective=None, h_main_result="CONFIRMED",
@@ -631,6 +669,18 @@ class SDKDispatcher(CLIDispatcher):
         inputs_dir = self.work_dir / "runs" / f"iter-{iteration}" / "inputs"
         inputs_dir.mkdir(parents=True, exist_ok=True)
         self._event_log_path = inputs_dir / "executor_log.jsonl"
+        # #226: per-iter watchdog threshold override. Resolution chain:
+        # bundle.experiment_spec.timing_observations.recommended_turn_silence_threshold_seconds
+        # > campaign.sdk_timeouts.turn_silence_threshold_seconds (set in
+        # __init__) > 600s default. Resolve here so the runner sees the
+        # right value for THIS iter; reset after to avoid leaking state
+        # to subsequent dispatches in long-running campaigns.
+        original_threshold = self._turn_silence_threshold
+        bundle_override = self._bundle_recommended_turn_silence_threshold(
+            iteration,
+        )
+        if bundle_override is not None:
+            self._turn_silence_threshold = bundle_override
         try:
             super().dispatch(
                 role, phase,
@@ -638,6 +688,7 @@ class SDKDispatcher(CLIDispatcher):
                 perspective=perspective, h_main_result=h_main_result,
             )
         finally:
+            self._turn_silence_threshold = original_threshold
             # #201: post-turn silence diagnostic. Read the streaming log
             # we just produced and surface excessive event gaps to
             # retry_log.jsonl. Best-effort — never raise from the finally.

--- a/prompts/methodology/design.md
+++ b/prompts/methodology/design.md
@@ -196,6 +196,25 @@ Now design a hypothesis bundle based on what you actually observed and verified:
      the executor a plain-Python expression that labels each row.
    - `verified_parameters`: parameters you confirmed work for this
      target (e.g. `{total_kv_blocks: 1200}`). Treat as canonical.
+   - `rehearsal_subset` *(populate when iteration_mode == rehearsal — #222)*:
+     declarative scope for what iter-1 (rehearsal) should execute.
+     Required sub-fields when present: `seeds: [int]` (typically the
+     first canonical seed only), `arms: [str]` (typically the
+     contrast pair: h-main + the most direct control). Optional
+     `extra_validation_only: bool` (when true, findings.json marked
+     `mode: rehearsal` regardless of confirmed/refuted). The full
+     experiment_spec stays at full scope so iter-2 inherits it
+     untouched.
+   - `timing_observations` *(populate when iteration_mode == rehearsal — #226)*:
+     per-policy wall-time observations from feasibility probes.
+     Required sub-fields: `expected_wall_time_seconds_per_policy: { policy: number }`
+     and `recommended_turn_silence_threshold_seconds: number` (~3×
+     the slowest observed policy + buffer). iter-2's
+     `SDKDispatcher` reads `recommended_turn_silence_threshold_seconds`
+     to calibrate the live watchdog (#205). Without these
+     measurements, the watchdog uses the campaign's global default,
+     which is a one-size-fits-all that doesn't catch a runaway
+     `wfq` while tolerating a slow `externality-credit`.
 
 4. Each arm must have:
    - `type`: One of h-main, h-ablation, h-super-additivity, h-control-negative, h-robustness, h-dose-response, h-tradeoff.

--- a/prompts/methodology/execute_analyze.md
+++ b/prompts/methodology/execute_analyze.md
@@ -11,6 +11,12 @@ Your job has FIVE phases — all in one session with full context:
 
 You have {{max_turns}} turns. Use them.
 
+## Iteration mode
+
+This iteration's mode is: **{{iteration_mode}}**
+
+{{mode_guidance}}
+
 ## Target System
 
 - **Name:** {{target_system}}
@@ -80,6 +86,16 @@ operational handoff from DESIGN. Specifically:
 - **`experiment_spec.verified_parameters`** (#210): treat as canonical.
   If smoke / validation reveals a parameter must change, see "Bundle
   amendments" in Step 1 below — don't override silently.
+- **`experiment_spec.rehearsal_subset`** *(when iteration_mode == "rehearsal")* (#222):
+  declarative scope override. Run ONLY the seeds × arms in this
+  subset; do NOT fan out the full experiment. iter-2 (real mode)
+  ignores this field and runs the full spec.
+- **`experiment_spec.timing_observations`** *(when populated by a prior
+  rehearsal iter)* (#226): use the per-policy wall-time observations
+  to set per-arm timeouts in the fan-out (e.g. `parallel --timeout`).
+  The engine has already read
+  `recommended_turn_silence_threshold_seconds` and applied it to the
+  watchdog — you don't need to reconfigure that yourself.
 
 ### Step 1: Build the system
 Use the build command from the designer handoff (or

--- a/prompts/methodology/execute_analyze_thin.md
+++ b/prompts/methodology/execute_analyze_thin.md
@@ -5,6 +5,12 @@
 > structure, fast-fail rules, prediction-error taxonomy, and principle-update
 > protocol.
 
+## Iteration mode
+
+This iteration's mode is: **{{iteration_mode}}**
+
+{{mode_guidance}}
+
 ## Active principles
 {{active_principles}}
 

--- a/prompts/methodology/report.md
+++ b/prompts/methodology/report.md
@@ -24,6 +24,10 @@ You are writing the final report for a Nous research campaign.
 
 {{bundle_amendments_summary}}
 
+## Brief amendments (campaign-spec friction surfaced; cross-run propagation)
+
+{{brief_amendments_summary}}
+
 ## Instructions
 
 Write a concise research report in markdown answering the research question. Structure:

--- a/tests/test_experiment_spec.py
+++ b/tests/test_experiment_spec.py
@@ -313,3 +313,434 @@ class TestReportContextIncludesAmendments:
         )
         assert "1200" in all_prompt
         assert "1100" in all_prompt
+
+
+# ─── #222: rehearsal_subset structured field ─────────────────────────────
+
+
+class TestRehearsalSubsetSchema:
+    """#222: bundle.experiment_spec.rehearsal_subset declares iter-1's
+    execution scope. The post-#212 paper-burst rerun showed that
+    methodology prose alone doesn't scope-shrink reliably; this is the
+    structured backup."""
+
+    def test_rehearsal_subset_validates(self):
+        b = _make_bundle(experiment_spec={
+            "rehearsal_subset": {
+                "seeds": [42],
+                "arms": ["h-main", "h-control-negative"],
+                "extra_validation_only": True,
+            },
+        })
+        jsonschema.validate(b, _load_bundle_schema())
+
+    def test_rehearsal_subset_minimal(self):
+        """``seeds`` and ``arms`` are the only meaningful fields;
+        extra_validation_only defaults to false (omitted)."""
+        b = _make_bundle(experiment_spec={
+            "rehearsal_subset": {
+                "seeds": [42],
+                "arms": ["h-main"],
+            },
+        })
+        jsonschema.validate(b, _load_bundle_schema())
+
+    def test_rehearsal_subset_unknown_field_rejected(self):
+        b = _make_bundle(experiment_spec={
+            "rehearsal_subset": {
+                "seeds": [42],
+                "arms": ["h-main"],
+                "unknown_field": "x",
+            },
+        })
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(b, _load_bundle_schema())
+
+    def test_rehearsal_subset_empty_arms_rejected(self):
+        b = _make_bundle(experiment_spec={
+            "rehearsal_subset": {
+                "seeds": [42],
+                "arms": [],   # minItems: 1
+            },
+        })
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(b, _load_bundle_schema())
+
+
+# ─── #226: timing_observations + watchdog override ────────────────────────
+
+
+class TestTimingObservationsSchema:
+    """#226: timing_observations records per-policy wall-time observations
+    from rehearsal feasibility probes. iter-2's SDKDispatcher reads
+    `recommended_turn_silence_threshold_seconds` to calibrate the
+    watchdog."""
+
+    def test_timing_observations_validates(self):
+        b = _make_bundle(experiment_spec={
+            "timing_observations": {
+                "expected_wall_time_seconds_per_policy": {
+                    "ea-wfq": 25.0,
+                    "wfq": 23.0,
+                    "drf": 28.0,
+                    "externality-credit": 95.0,
+                    "none": 22.0,
+                },
+                "recommended_turn_silence_threshold_seconds": 360.0,
+                "observation_method":
+                    "feasibility probe at seed=42, single arm per policy",
+            },
+        })
+        jsonschema.validate(b, _load_bundle_schema())
+
+    def test_timing_observations_unknown_field_rejected(self):
+        b = _make_bundle(experiment_spec={
+            "timing_observations": {
+                "expected_wall_time_seconds_per_policy": {"ea-wfq": 25},
+                "recommended_turn_silence_threshold_seconds": 360,
+                "another_typo_field": "x",
+            },
+        })
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(b, _load_bundle_schema())
+
+    def test_negative_threshold_rejected(self):
+        b = _make_bundle(experiment_spec={
+            "timing_observations": {
+                "recommended_turn_silence_threshold_seconds": -1,
+            },
+        })
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(b, _load_bundle_schema())
+
+
+def _campaign_with_default_threshold(repo: Path | None = None) -> dict:
+    """Campaign with the default sdk_timeouts (silence + turn = 600s)."""
+    target = {
+        "name": "TestSys", "description": "test",
+        "observable_metrics": ["m"], "controllable_knobs": ["k"],
+    }
+    if repo is not None:
+        target["repo_path"] = str(repo)
+    return {
+        "research_question": "?",
+        "target_system": target,
+        "prompts": {"methodology_layer": "prompts/methodology",
+                    "domain_adapter_layer": None},
+    }
+
+
+class TestWatchdogReadsBundleOverride:
+    """#226: ``SDKDispatcher.dispatch`` should resolve the watchdog
+    threshold per-iter from the prior iter's bundle.experiment_spec.
+    timing_observations.recommended_turn_silence_threshold_seconds —
+    falling back to the campaign-level default (or factory default)
+    when the bundle doesn't carry one. Tests the resolver as a pure
+    function (no SDK needed) AND the dispatcher's per-call override.
+    """
+
+    def test_resolver_reads_recommended_threshold(self, tmp_path: Path) -> None:
+        from orchestrator.sdk_dispatch import SDKDispatcher
+        # Pre-write iter-1 bundle with timing_observations
+        (tmp_path / "runs" / "iter-1").mkdir(parents=True)
+        bundle = _make_bundle(experiment_spec={
+            "timing_observations": {
+                "recommended_turn_silence_threshold_seconds": 360.0,
+            },
+        })
+        (tmp_path / "runs" / "iter-1" / "bundle.yaml").write_text(
+            yaml.safe_dump(bundle),
+        )
+        d = SDKDispatcher(
+            work_dir=tmp_path, campaign=_campaign_with_default_threshold(tmp_path),
+            sdk_runner=lambda **_: None,  # never called
+        )
+        # Asking about iter-2 → reads iter-1's bundle.
+        v = d._bundle_recommended_turn_silence_threshold(2)
+        assert v == 360.0
+
+    def test_resolver_returns_none_for_iter_1(self, tmp_path: Path) -> None:
+        """No prior iter exists for iter-1 → nothing to read."""
+        from orchestrator.sdk_dispatch import SDKDispatcher
+        d = SDKDispatcher(
+            work_dir=tmp_path, campaign=_campaign_with_default_threshold(tmp_path),
+            sdk_runner=lambda **_: None,
+        )
+        assert d._bundle_recommended_turn_silence_threshold(1) is None
+
+    def test_resolver_returns_none_when_field_missing(self, tmp_path: Path) -> None:
+        """Bundle exists but has no timing_observations.recommended."""
+        from orchestrator.sdk_dispatch import SDKDispatcher
+        (tmp_path / "runs" / "iter-1").mkdir(parents=True)
+        # No timing_observations → falls through to None
+        bundle = _make_bundle(experiment_spec={
+            "verified_parameters": {"x": 1},
+        })
+        (tmp_path / "runs" / "iter-1" / "bundle.yaml").write_text(
+            yaml.safe_dump(bundle),
+        )
+        d = SDKDispatcher(
+            work_dir=tmp_path, campaign=_campaign_with_default_threshold(tmp_path),
+            sdk_runner=lambda **_: None,
+        )
+        assert d._bundle_recommended_turn_silence_threshold(2) is None
+
+    def test_dispatch_applies_bundle_override_then_restores(
+            self, tmp_path: Path) -> None:
+        """Behavioral: with an iter-1 bundle that recommends 100s, an
+        iter-2 dispatch sees the 100s threshold flow to the runner.
+        After the dispatch, the dispatcher's stored threshold returns
+        to its campaign default — no leak into subsequent calls.
+        """
+        from orchestrator.sdk_dispatch import SDKDispatcher, SDKResult
+        # iter-1 bundle: recommends 100s
+        (tmp_path / "runs" / "iter-1").mkdir(parents=True)
+        b1 = _make_bundle(experiment_spec={
+            "timing_observations": {
+                "recommended_turn_silence_threshold_seconds": 100.0,
+            },
+        })
+        (tmp_path / "runs" / "iter-1" / "bundle.yaml").write_text(
+            yaml.safe_dump(b1),
+        )
+        # iter-2 needs a problem.md / handoff.md for the LLMDispatcher
+        # path — but SDKDispatcher just needs an output path.
+        (tmp_path / "runs" / "iter-2").mkdir(parents=True)
+
+        thresholds_seen: list[float | None] = []
+
+        def runner(*, turn_silence_threshold=None, **_):
+            thresholds_seen.append(turn_silence_threshold)
+            return SDKResult(text="ok", input_tokens=1, output_tokens=1)
+
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign_with_default_threshold(tmp_path),
+            sdk_runner=runner,
+            max_retries=0,
+        )
+        default_threshold = d._turn_silence_threshold  # campaign default
+
+        # iter-2 dispatch: should see the bundle override (100.0)
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-2" / "design_log.md",
+            iteration=2,
+        )
+        assert thresholds_seen == [100.0], (
+            f"#226: iter-2 runner should see bundle override 100.0; "
+            f"got {thresholds_seen!r}"
+        )
+        # Post-dispatch: dispatcher's stored threshold restored to default.
+        assert d._turn_silence_threshold == default_threshold, (
+            "#226: bundle override must NOT leak past the dispatch — "
+            "next dispatch with no bundle override should see the "
+            "campaign default again."
+        )
+
+    def test_dispatch_uses_campaign_default_when_no_bundle_override(
+            self, tmp_path: Path) -> None:
+        """When the prior iter's bundle has no timing_observations,
+        the campaign-level default is used unchanged."""
+        from orchestrator.sdk_dispatch import SDKDispatcher, SDKResult
+        (tmp_path / "runs" / "iter-1").mkdir(parents=True)
+        b1 = _make_bundle()  # no experiment_spec at all
+        (tmp_path / "runs" / "iter-1" / "bundle.yaml").write_text(
+            yaml.safe_dump(b1),
+        )
+        (tmp_path / "runs" / "iter-2").mkdir(parents=True)
+
+        thresholds_seen: list[float | None] = []
+
+        def runner(*, turn_silence_threshold=None, **_):
+            thresholds_seen.append(turn_silence_threshold)
+            return SDKResult(text="ok", input_tokens=1, output_tokens=1)
+
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign_with_default_threshold(tmp_path),
+            sdk_runner=runner,
+            max_retries=0,
+        )
+        d.dispatch(
+            "planner", "design",
+            output_path=tmp_path / "runs" / "iter-2" / "design_log.md",
+            iteration=2,
+        )
+        # No bundle override → fall back to campaign default (600s).
+        assert thresholds_seen == [600.0]
+
+
+# ─── #223 v1: structured brief_amendments.jsonl schema + REPORT renderer ─
+
+
+def _load_brief_amendments_schema() -> dict:
+    return json.loads(
+        (SCHEMAS_DIR / "brief_amendments.schema.json").read_text()
+    )
+
+
+class TestBriefAmendmentsSchema:
+    """#223: structured brief_amendments.jsonl entries replace the prior
+    free-form markdown so they can be programmatically parsed, applied,
+    and propagated across campaign runs."""
+
+    def _valid_amendment(self, **overrides) -> dict:
+        a = {
+            "id": "BA-1",
+            "brief_section": "paper-burst-brief.md §ITER-1",
+            "problem": "Probe command produces schema-invalid output",
+            "fix": "Replace probe command with workload-spec version",
+            "priority": "HIGH",
+        }
+        a.update(overrides)
+        return a
+
+    def test_minimal_amendment_validates(self):
+        jsonschema.validate(self._valid_amendment(),
+                            _load_brief_amendments_schema())
+
+    def test_full_amendment_with_optional_fields_validates(self):
+        a = self._valid_amendment(
+            evidence="dropped_unservable=61, adversary completed=0",
+            impact="iter-2 produces ground_truth_held=false trivially",
+        )
+        jsonschema.validate(a, _load_brief_amendments_schema())
+
+    def test_id_pattern_enforced(self):
+        for bad in ["1", "BA-", "BA-foo", "BA1", "ba-1"]:
+            a = self._valid_amendment(id=bad)
+            with pytest.raises(jsonschema.ValidationError):
+                jsonschema.validate(a, _load_brief_amendments_schema())
+
+    def test_priority_enum_enforced(self):
+        for bad in ["URGENT", "blocking", "P0", "high", ""]:
+            a = self._valid_amendment(priority=bad)
+            with pytest.raises(jsonschema.ValidationError):
+                jsonschema.validate(a, _load_brief_amendments_schema())
+
+    def test_required_fields(self):
+        for missing in ["id", "brief_section", "problem", "fix", "priority"]:
+            a = self._valid_amendment()
+            del a[missing]
+            with pytest.raises(jsonschema.ValidationError):
+                jsonschema.validate(a, _load_brief_amendments_schema())
+
+    def test_unknown_field_rejected(self):
+        a = self._valid_amendment(severity="high")  # typo for priority
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(a, _load_brief_amendments_schema())
+
+
+from orchestrator.llm_dispatch import _format_brief_amendments_summary
+
+
+class TestFormatBriefAmendmentsSummary:
+    """The REPORT-context renderer produces a human/agent-readable
+    summary grouped by priority."""
+
+    def test_no_iter_dirs_returns_marker(self, tmp_path: Path) -> None:
+        out = _format_brief_amendments_summary(tmp_path / "campaign")
+        assert "no iteration directories" in out.lower()
+
+    def test_no_amendments_returns_clean_marker(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        (wd / "runs" / "iter-1" / "inputs").mkdir(parents=True)
+        out = _format_brief_amendments_summary(wd)
+        assert "no brief_amendments" in out.lower()
+
+    def test_renders_amendments_grouped_by_priority(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        inputs = wd / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        rows = [
+            {"id": "BA-1", "brief_section": "x §a", "problem": "low-pri thing",
+             "fix": "fix-x", "priority": "LOW"},
+            {"id": "BA-2", "brief_section": "x §b", "problem": "blocking gotcha",
+             "fix": "fix-y", "priority": "BLOCKING"},
+            {"id": "BA-3", "brief_section": "x §c", "problem": "medium concern",
+             "fix": "fix-z", "priority": "MEDIUM"},
+        ]
+        (inputs / "brief_amendments.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n"
+        )
+        out = _format_brief_amendments_summary(wd)
+        assert "iter-1" in out
+        assert "3 amendment(s)" in out
+        # BLOCKING comes first (priority sort)
+        blocking_idx = out.find("BA-2")
+        low_idx = out.find("BA-1")
+        medium_idx = out.find("BA-3")
+        assert blocking_idx > 0 and low_idx > 0 and medium_idx > 0
+        assert blocking_idx < medium_idx < low_idx, (
+            "#223: amendments must be sorted BLOCKING > HIGH > MEDIUM > "
+            "LOW > INFO so operators see the most urgent first."
+        )
+
+    def test_malformed_lines_surfaced(self, tmp_path: Path) -> None:
+        """Malformed JSON lines are skipped but the count is surfaced —
+        the operator must know corruption happened (mirroring the
+        post-#218 bundle_amendments helper pattern)."""
+        wd = tmp_path / "campaign"
+        inputs = wd / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        (inputs / "brief_amendments.jsonl").write_text(
+            json.dumps({"id": "BA-1", "brief_section": "x", "problem": "p",
+                        "fix": "f", "priority": "HIGH"}) + "\n"
+            + "not valid json {\n"
+            + "{garbage\n"
+        )
+        out = _format_brief_amendments_summary(wd)
+        assert "BA-1" in out
+        assert "malformed" in out.lower()
+        assert "2 malformed" in out
+
+
+class TestReportContextIncludesBriefAmendments:
+    """#223: the REPORT extractor's prompt includes the brief_amendments
+    summary so the report can describe what spec friction the campaign
+    surfaced — not just narrate the experiment outcome."""
+
+    def test_brief_amendments_appear_in_extractor_prompt(
+            self, tmp_path: Path,
+            monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        # Pre-create artifacts the report extractor reads.
+        results = tmp_path / "runs" / "iter-1" / "results"
+        results.mkdir(parents=True)
+        (results / "h-main_seed42.json").write_text("{}")
+        inputs = tmp_path / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        (inputs / "brief_amendments.jsonl").write_text(json.dumps({
+            "id": "BA-1",
+            "brief_section": "paper-burst-brief.md §ITER-1",
+            "problem": "missing --max-model-len 0 flag",
+            "fix": "Add --max-model-len 0 to all main BLIS commands",
+            "priority": "BLOCKING",
+        }) + "\n")
+        (tmp_path / "ledger.json").write_text(json.dumps({"iterations": []}))
+        (tmp_path / "principles.json").write_text(json.dumps({"principles": []}))
+
+        d = LLMDispatcher(
+            work_dir=tmp_path,
+            campaign=_make_campaign(),
+            completion_fn=_make_completion(["# stub report"]),
+        )
+        d.dispatch(
+            "extractor", "report",
+            output_path=tmp_path / "report.md",
+            iteration=0,
+        )
+
+        all_prompt = ""
+        for call in d._completion.call_log:  # type: ignore[attr-defined]
+            for msg in call.get("messages", []):
+                all_prompt += msg.get("content", "") + "\n"
+
+        assert "BA-1" in all_prompt, (
+            "#223: REPORT extractor must see the structured "
+            "brief_amendments — that's the cross-run-learning surface."
+        )
+        assert "BLOCKING" in all_prompt
+        assert "max-model-len" in all_prompt

--- a/tests/test_experiment_spec.py
+++ b/tests/test_experiment_spec.py
@@ -538,6 +538,59 @@ class TestWatchdogReadsBundleOverride:
             "campaign default again."
         )
 
+    def test_dispatch_restores_threshold_when_runner_raises(
+            self, tmp_path: Path,
+            monkeypatch: pytest.MonkeyPatch) -> None:
+        """#226 + post-PR-#227-review: the override-and-restore must
+        survive a runner failure. If a regression moved the restore
+        line out of ``finally``, this test catches it: dispatch() raises,
+        but the dispatcher's stored threshold is still the campaign
+        default — no leak into subsequent dispatches.
+        """
+        from orchestrator.sdk_dispatch import SDKDispatcher, SDKTransientError
+        monkeypatch.setattr(
+            "orchestrator.sdk_dispatch.time.sleep", lambda _s: None,
+        )
+        # iter-1 bundle: recommends 100s
+        (tmp_path / "runs" / "iter-1").mkdir(parents=True)
+        b1 = _make_bundle(experiment_spec={
+            "timing_observations": {
+                "recommended_turn_silence_threshold_seconds": 100.0,
+            },
+        })
+        (tmp_path / "runs" / "iter-1" / "bundle.yaml").write_text(
+            yaml.safe_dump(b1),
+        )
+        (tmp_path / "runs" / "iter-2").mkdir(parents=True)
+
+        def runner(**_):
+            raise SDKTransientError("simulated runner failure")
+
+        d = SDKDispatcher(
+            work_dir=tmp_path,
+            campaign=_campaign_with_default_threshold(tmp_path),
+            sdk_runner=runner,
+            max_retries=0,
+        )
+        default_threshold = d._turn_silence_threshold
+
+        with pytest.raises(RuntimeError):
+            d.dispatch(
+                "planner", "design",
+                output_path=tmp_path / "runs" / "iter-2" / "design_log.md",
+                iteration=2,
+            )
+
+        # Critical: post-failure, dispatcher's stored threshold MUST be
+        # the campaign default — not the iter-1 override that was
+        # applied transiently.
+        assert d._turn_silence_threshold == default_threshold, (
+            "post-PR-#227-review: try/finally must restore "
+            "_turn_silence_threshold even when super().dispatch raises. "
+            "A regression here would leak the override into all "
+            "subsequent iterations of a long-running campaign."
+        )
+
     def test_dispatch_uses_campaign_default_when_no_bundle_override(
             self, tmp_path: Path) -> None:
         """When the prior iter's bundle has no timing_observations,
@@ -744,3 +797,106 @@ class TestReportContextIncludesBriefAmendments:
         )
         assert "BLOCKING" in all_prompt
         assert "max-model-len" in all_prompt
+
+
+# ─── End-to-end coupling across #221+#222+#223+#224 ────────────────────────
+
+
+from orchestrator.iteration_mode import iteration_mode_for, execute_mode_guidance_for
+from orchestrator.promote_gate import evaluate_promote_gate
+
+
+class TestEndToEndIntegration:
+    """Post-PR-#227-review: a single test that exercises the chain
+    #221 (mode signal flows to EXECUTE) → #222 (rehearsal_subset is the
+    structural scope) → #223 (BLOCKING brief_amendment is written by
+    rehearsal) → #224 (gate decides revise based on it).
+
+    If any link in the chain breaks (mode resolver bug, schema drift,
+    field-name typo, gate logic regression), this test catches it
+    even though each per-feature test still passes."""
+
+    def test_rehearsal_emits_blocking_amendment_then_gate_revises(
+            self, tmp_path: Path) -> None:
+        # 1. Campaign declares iter-1 rehearsal, iter-2 real (#212).
+        c = _make_campaign()
+        c["iterations"] = [{"mode": "rehearsal"}, {"mode": "real"}]
+
+        # 2. Mode resolver returns "rehearsal" for iter-1 (#212).
+        assert iteration_mode_for(c, 1) == "rehearsal"
+        assert iteration_mode_for(c, 2) == "real"
+
+        # 3. Execute-phase guidance for rehearsal mentions
+        # rehearsal_subset (#221 → #222 link).
+        guidance = execute_mode_guidance_for("rehearsal")
+        assert "rehearsal_subset" in guidance, (
+            "#221 → #222 link broken: execute-phase rehearsal guidance "
+            "must reference rehearsal_subset (the structural scope)."
+        )
+        # And mentions the brief_amendments.jsonl path (#221 → #223 link).
+        assert "brief_amendments.jsonl" in guidance
+        assert "BLOCKING" in guidance
+
+        # 4. DESIGN agent emits a bundle with rehearsal_subset (#222).
+        # Schema-validate to confirm the structural field is honored.
+        bundle = _make_bundle(experiment_spec={
+            "rehearsal_subset": {
+                "seeds": [42],
+                "arms": ["h-main", "h-control-negative"],
+                "extra_validation_only": True,
+            },
+        })
+        jsonschema.validate(bundle, _load_bundle_schema())
+
+        # 5. Rehearsal iter-1 emits a BLOCKING brief_amendment (#223
+        # structured form). Schema-validate the amendment row.
+        iter1 = tmp_path / "runs" / "iter-1"
+        inputs = iter1 / "inputs"
+        inputs.mkdir(parents=True)
+        amendment = {
+            "id": "BA-1",
+            "brief_section": "paper-burst-brief.md §ITER-1",
+            "problem": "Probe command produces schema-invalid output",
+            "fix": "Replace probe command with workload-spec version",
+            "priority": "BLOCKING",
+        }
+        jsonschema.validate(amendment, _load_brief_amendments_schema())
+        (inputs / "brief_amendments.jsonl").write_text(
+            json.dumps(amendment) + "\n"
+        )
+        # Plus a successful findings.json so the gate passes its
+        # apparatus check.
+        (iter1 / "findings.json").write_text(json.dumps({
+            "iteration": 1,
+            "bundle_ref": "runs/iter-1/bundle.yaml",
+            "experiment_valid": True,
+            "arms": [{
+                "arm_type": "h-main",
+                "predicted": "stub", "observed": "stub",
+                "status": "CONFIRMED", "error_type": None,
+                "diagnostic_note": "stub",
+            }],
+        }))
+
+        # 6. Promote gate (#224) decides revise — because BA-1 is
+        # BLOCKING and applied_amendments.jsonl is empty.
+        result = evaluate_promote_gate(tmp_path, 1)
+        assert result["decision"] == "revise", (
+            "#224 link broken: gate must emit revise when a BLOCKING "
+            f"amendment is unapplied. Got {result!r}"
+        )
+        assert "BA-1" in result["blocking_amendments"]
+        # Reasoning string is operator-actionable.
+        assert "BA-1" in result["reasoning"]
+
+        # 7. Operator applies BA-1 → applied_amendments.jsonl populated
+        # → gate now promotes. (In v2 this is a CLI; in v1 it's manual.)
+        (tmp_path / "applied_amendments.jsonl").write_text(
+            json.dumps({"id": "BA-1"}) + "\n"
+        )
+        result_after = evaluate_promote_gate(tmp_path, 1)
+        assert result_after["decision"] == "promote", (
+            "#224 link: once the BLOCKING amendment is in "
+            "applied_amendments.jsonl, the gate should promote."
+        )
+        assert "BA-1" in result_after["applied_amendments"]

--- a/tests/test_iteration_mode.py
+++ b/tests/test_iteration_mode.py
@@ -294,3 +294,194 @@ class TestDesignPromptIncludesMode:
         # No unfilled placeholders leaked.
         assert "{{mode_guidance}}" not in prompt_text
         assert "{{iteration_mode}}" not in prompt_text
+
+
+# ─── #221: execute-phase mode guidance ───────────────────────────────────
+
+
+from orchestrator.iteration_mode import (
+    EXECUTE_REHEARSAL_GUIDANCE,
+    EXECUTE_REAL_GUIDANCE,
+    execute_mode_guidance_for,
+)
+
+
+def _valid_execute_analyze_response() -> str:
+    """Schema-passing stub for executor/execute-analyze so the
+    dispatcher's parse path doesn't crash — lets prompt-content
+    assertions run. Mirrors the shape from tests/test_llm_dispatch.py.
+    """
+    payload = {
+        "plan": {
+            "metadata": {"iteration": 1, "bundle_ref": "runs/iter-1/bundle.yaml"},
+            "arms": [{"arm_id": "h-main",
+                      "conditions": [{"name": "baseline",
+                                      "cmd": "echo test"}]}],
+        },
+        "findings": {
+            "iteration": 1,
+            "bundle_ref": "runs/iter-1/bundle.yaml",
+            "experiment_valid": True,
+            "arms": [{
+                "arm_type": "h-main",
+                "predicted": "stub",
+                "observed": "stub",
+                "status": "CONFIRMED",
+                "error_type": None,
+                "diagnostic_note": "stub",
+            }],
+        },
+        "principle_updates": [],
+    }
+    return "```json\n" + json.dumps(payload) + "\n```"
+
+
+class TestExecuteModeGuidance:
+    """#221: execute_mode_guidance_for returns phase-appropriate text
+    distinct from mode_guidance_for. Rehearsal-mode execute guidance
+    must instruct the agent to honor rehearsal_subset, NOT fan out
+    the full bundle."""
+
+    def test_rehearsal_mentions_rehearsal_subset_and_scope(self):
+        text = execute_mode_guidance_for("rehearsal")
+        assert text == EXECUTE_REHEARSAL_GUIDANCE
+        # Critical scope-shrink instructions
+        assert "rehearsal_subset" in text, (
+            "#221: rehearsal-mode execute guidance must mention the "
+            "rehearsal_subset bundle field — that's the structural "
+            "scope-shrink mechanism."
+        )
+        assert "Do NOT fan out the full" in text, (
+            "#221: rehearsal-mode execute guidance must imperative-forbid "
+            "full fan-out (the post-#212 paper-burst rerun observed the "
+            "agent fanning out the full bundle anyway because it had "
+            "no signal not to)."
+        )
+        # Cross-reference to companion mechanisms:
+        assert "brief_amendments.jsonl" in text  # #223
+        assert "bundle_amendments.jsonl" in text  # #211
+        assert "timing_observations" in text  # #226
+
+    def test_real_mentions_full_scope_and_promotion_gate(self):
+        text = execute_mode_guidance_for("real")
+        assert text == EXECUTE_REAL_GUIDANCE
+        assert "full" in text.lower()
+        # Promotion-gate intent (#224): real iter respects BLOCKING amendments.
+        assert "BLOCKING" in text
+        assert "brief_amendments" in text
+
+    def test_unknown_mode_raises_value_error(self):
+        """Same fail-loud discipline as design-phase mode_guidance_for."""
+        with pytest.raises(ValueError, match=r"unknown iteration mode"):
+            execute_mode_guidance_for("turbo")  # type: ignore[arg-type]
+
+    def test_design_and_execute_guidance_are_distinct(self):
+        """Sanity: the two helpers return different strings (otherwise
+        the whole #221 split is moot — DESIGN and EXECUTE would be
+        getting the same prompt block)."""
+        assert mode_guidance_for("rehearsal") != execute_mode_guidance_for("rehearsal")
+        assert mode_guidance_for("real") != execute_mode_guidance_for("real")
+
+
+class TestExecuteAnalyzeContextIncludesMode:
+    """#221: the EXECUTE_ANALYZE-phase context populates iteration_mode +
+    mode_guidance with execute-phase text. Tests at the ``_build_context``
+    seam (the dispatcher's actual contract for prompt content) rather
+    than driving the full dispatch+parse+validate pipeline — keeps the
+    test focused on what #221 actually changes."""
+
+    def _build_executor_ctx(self, tmp_path: Path,
+                            campaign: dict,
+                            monkeypatch: pytest.MonkeyPatch) -> dict:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        # Pre-create the DESIGN artifacts the executor's context-builder
+        # reads (bundle.yaml, problem.md, campaign-level handoff.md).
+        iter1 = tmp_path / "runs" / "iter-1"
+        iter1.mkdir(parents=True)
+        (iter1 / "bundle.yaml").write_text(yaml.safe_dump({
+            "metadata": {"iteration": 1, "family": "test",
+                         "research_question": "?"},
+            "arms": [{"type": "h-main", "prediction": "p", "mechanism": "m",
+                      "diagnostic": "d"}],
+        }))
+        (iter1 / "problem.md").write_text("## problem\nbrief\n")
+        (tmp_path / "handoff.md").write_text("## prior handoff\n")
+
+        d = LLMDispatcher(
+            work_dir=tmp_path, campaign=campaign,
+            completion_fn=_make_completion(["unused"]),
+        )
+        return d._build_context("executor", "execute-analyze",
+                                iteration=1, perspective=None)
+
+    def test_rehearsal_ctx_carries_execute_rehearsal_guidance(
+            self, tmp_path: Path,
+            monkeypatch: pytest.MonkeyPatch) -> None:
+        c = _make_campaign(iterations=[{"mode": "rehearsal"},
+                                       {"mode": "real"}])
+        ctx = self._build_executor_ctx(tmp_path, c, monkeypatch)
+
+        assert ctx["iteration_mode"] == "rehearsal", (
+            f"#221: iter-1 (rehearsal) ctx must carry mode; got {ctx['iteration_mode']!r}"
+        )
+        guidance = ctx["mode_guidance"]
+        assert "rehearsal_subset" in guidance, (
+            "#221: execute-phase rehearsal guidance must mention "
+            "rehearsal_subset (scope-shrink mechanism)."
+        )
+        assert "Do NOT fan out" in guidance, (
+            "#221: rehearsal guidance must imperative-forbid full fan-out."
+        )
+        # Companion mechanisms cross-referenced:
+        assert "brief_amendments.jsonl" in guidance
+        assert "timing_observations" in guidance
+
+    def test_real_ctx_carries_execute_real_guidance(
+            self, tmp_path: Path,
+            monkeypatch: pytest.MonkeyPatch) -> None:
+        c = _make_campaign()  # no iterations block → real default
+        ctx = self._build_executor_ctx(tmp_path, c, monkeypatch)
+
+        assert ctx["iteration_mode"] == "real"
+        guidance = ctx["mode_guidance"]
+        # Real-mode guidance must mention BLOCKING amendment handling
+        # (the promotion-gate intent) and full scope.
+        assert "BLOCKING" in guidance
+        assert "full" in guidance.lower()
+        # Rehearsal-specific scope language should NOT be foregrounded.
+        assert "Do NOT fan out" not in guidance
+
+    def test_executor_ctx_distinct_from_design_ctx(
+            self, tmp_path: Path,
+            monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sanity: design-phase and execute-phase ctx populate
+        mode_guidance with DIFFERENT text, not the same string."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        c = _make_campaign(iterations=[{"mode": "rehearsal"}])
+        d = LLMDispatcher(
+            work_dir=tmp_path, campaign=c,
+            completion_fn=_make_completion(["unused"]),
+        )
+        # Pre-create iter dir
+        (tmp_path / "runs" / "iter-1").mkdir(parents=True)
+
+        design_ctx = d._build_context("planner", "design",
+                                      iteration=1, perspective=None)
+
+        # And execute ctx (with prerequisite artifacts)
+        iter1 = tmp_path / "runs" / "iter-1"
+        (iter1 / "bundle.yaml").write_text(yaml.safe_dump({
+            "metadata": {"iteration": 1, "family": "test",
+                         "research_question": "?"},
+            "arms": [{"type": "h-main", "prediction": "p", "mechanism": "m",
+                      "diagnostic": "d"}],
+        }))
+        (iter1 / "problem.md").write_text("brief")
+        (tmp_path / "handoff.md").write_text("handoff")
+        execute_ctx = d._build_context("executor", "execute-analyze",
+                                       iteration=1, perspective=None)
+
+        assert design_ctx["mode_guidance"] != execute_ctx["mode_guidance"], (
+            "#221: design-phase and execute-phase mode_guidance must "
+            "differ — otherwise the whole phase-aware split is moot."
+        )

--- a/tests/test_promote_gate.py
+++ b/tests/test_promote_gate.py
@@ -1,0 +1,222 @@
+"""Tests for #224 v1: deterministic promote_gate decision logic.
+
+Pure-Python tests with synthesized inputs. No LLM, no SDK. Each test
+sets up the relevant on-disk artifacts (findings.json,
+brief_amendments.jsonl, applied_amendments.jsonl) for a given iteration
+and asserts the decision dict.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orchestrator.promote_gate import (
+    VALID_DECISIONS,
+    evaluate_promote_gate,
+)
+
+
+def _write_findings(iter_dir: Path, *, valid: bool = True) -> None:
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    (iter_dir / "findings.json").write_text(json.dumps({
+        "iteration": 1,
+        "bundle_ref": "runs/iter-1/bundle.yaml",
+        "experiment_valid": valid,
+        "arms": [
+            {"arm_type": "h-main",
+             "predicted": "p", "observed": "o", "status": "CONFIRMED",
+             "error_type": None, "diagnostic_note": "n"},
+        ],
+    }))
+
+
+def _write_amendments(iter_dir: Path, rows: list[dict]) -> None:
+    inputs = iter_dir / "inputs"
+    inputs.mkdir(parents=True, exist_ok=True)
+    (inputs / "brief_amendments.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n"
+    )
+
+
+def _write_applied(work_dir: Path, ids: list[str]) -> None:
+    (work_dir / "applied_amendments.jsonl").write_text(
+        "\n".join(json.dumps({"id": i}) for i in ids) + "\n"
+    )
+
+
+# ─── promote: clean iter, no blockers ─────────────────────────────────────
+
+
+class TestPromote:
+    def test_clean_findings_no_amendments(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "promote"
+        assert result["blocking_amendments"] == []
+        assert result["feasibility_check"]["passed"] is True
+
+    def test_clean_findings_with_non_blocking_amendments(
+            self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        _write_amendments(wd / "runs" / "iter-1", [
+            {"id": "BA-1", "brief_section": "x", "problem": "p",
+             "fix": "f", "priority": "HIGH"},
+            {"id": "BA-2", "brief_section": "y", "problem": "p",
+             "fix": "f", "priority": "MEDIUM"},
+        ])
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "promote"
+        assert result["blocking_amendments"] == []
+
+    def test_blocking_amendment_already_applied(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        _write_amendments(wd / "runs" / "iter-1", [
+            {"id": "BA-1", "brief_section": "x", "problem": "p",
+             "fix": "f", "priority": "BLOCKING"},
+        ])
+        _write_applied(wd, ["BA-1"])
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "promote"
+        assert "BA-1" in result["applied_amendments"]
+
+
+# ─── revise: BLOCKING amendments not yet applied ──────────────────────────
+
+
+class TestRevise:
+    def test_one_blocking_unapplied(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        _write_amendments(wd / "runs" / "iter-1", [
+            {"id": "BA-2", "brief_section": "x", "problem": "p",
+             "fix": "f", "priority": "BLOCKING"},
+        ])
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "revise"
+        assert result["blocking_amendments"] == ["BA-2"]
+        assert "BA-2" in result["reasoning"]
+
+    def test_multiple_blocking_some_applied(self, tmp_path: Path) -> None:
+        """Mixed state: 3 BLOCKING amendments, 1 applied → still revise
+        because 2 remain."""
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        _write_amendments(wd / "runs" / "iter-1", [
+            {"id": "BA-1", "brief_section": "x", "problem": "p",
+             "fix": "f", "priority": "BLOCKING"},
+            {"id": "BA-2", "brief_section": "x", "problem": "p",
+             "fix": "f", "priority": "BLOCKING"},
+            {"id": "BA-3", "brief_section": "x", "problem": "p",
+             "fix": "f", "priority": "BLOCKING"},
+        ])
+        _write_applied(wd, ["BA-1"])
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "revise"
+        assert sorted(result["blocking_amendments"]) == ["BA-2", "BA-3"]
+
+
+# ─── abort: apparatus failure ─────────────────────────────────────────────
+
+
+class TestAbort:
+    def test_findings_missing(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        # No findings.json
+        (wd / "runs" / "iter-1").mkdir(parents=True)
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "abort"
+        assert "findings.json" in result["reasoning"]
+        assert result["feasibility_check"]["passed"] is False
+
+    def test_findings_invalid(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=False)
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "abort"
+        assert "experiment_valid=false" in result["reasoning"]
+        assert result["feasibility_check"]["passed"] is False
+
+    def test_findings_missing_takes_priority_over_amendments(
+            self, tmp_path: Path) -> None:
+        """When findings is missing, decision is abort regardless of
+        amendments — there's no point reviewing amendments for an
+        iter that didn't produce data."""
+        wd = tmp_path / "campaign"
+        (wd / "runs" / "iter-1").mkdir(parents=True)
+        _write_amendments(wd / "runs" / "iter-1", [
+            {"id": "BA-1", "brief_section": "x", "problem": "p",
+             "fix": "f", "priority": "BLOCKING"},
+        ])
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "abort"
+
+
+# ─── shape contracts ──────────────────────────────────────────────────────
+
+
+class TestResultShape:
+    def test_decision_in_valid_set(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] in VALID_DECISIONS
+
+    def test_required_keys(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        result = evaluate_promote_gate(wd, 1)
+        for k in ("decision", "reasoning", "blocking_amendments",
+                  "applied_amendments", "feasibility_check"):
+            assert k in result, f"missing key {k} in result"
+        assert "passed" in result["feasibility_check"]
+
+    def test_reasoning_is_human_readable(self, tmp_path: Path) -> None:
+        """Smoke test that reasoning text is non-empty and references
+        the iteration — operators reading the JSON output can act
+        without parsing internal flags."""
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        result = evaluate_promote_gate(wd, 1)
+        assert "iter-1" in result["reasoning"]
+        assert len(result["reasoning"]) > 30
+
+
+# ─── degenerate inputs ────────────────────────────────────────────────────
+
+
+class TestDegenerate:
+    def test_no_iter_dir(self, tmp_path: Path) -> None:
+        """No runs/iter-N dir at all → abort (treat same as missing findings)."""
+        wd = tmp_path / "campaign"
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "abort"
+
+    def test_malformed_findings_treated_as_missing(self, tmp_path: Path) -> None:
+        wd = tmp_path / "campaign"
+        iter_dir = wd / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        (iter_dir / "findings.json").write_text("not json {")
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "abort"
+
+    def test_malformed_amendments_skipped_silently(self, tmp_path: Path) -> None:
+        """A malformed line in brief_amendments.jsonl should not crash
+        the gate — it skips the bad row and proceeds (matching the
+        helper-renderer convention from #223)."""
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        inputs = wd / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        (inputs / "brief_amendments.jsonl").write_text(
+            json.dumps({"id": "BA-1", "brief_section": "x", "problem": "p",
+                        "fix": "f", "priority": "HIGH"}) + "\n"
+            + "not valid json {\n"
+        )
+        # Only valid row was HIGH (not BLOCKING), so → promote
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "promote"

--- a/tests/test_promote_gate.py
+++ b/tests/test_promote_gate.py
@@ -171,9 +171,11 @@ class TestResultShape:
         _write_findings(wd / "runs" / "iter-1", valid=True)
         result = evaluate_promote_gate(wd, 1)
         for k in ("decision", "reasoning", "blocking_amendments",
-                  "applied_amendments", "feasibility_check"):
+                  "applied_amendments", "feasibility_check",
+                  "malformed_amendment_lines"):
             assert k in result, f"missing key {k} in result"
         assert "passed" in result["feasibility_check"]
+        assert isinstance(result["malformed_amendment_lines"], int)
 
     def test_reasoning_is_human_readable(self, tmp_path: Path) -> None:
         """Smoke test that reasoning text is non-empty and references
@@ -204,10 +206,11 @@ class TestDegenerate:
         result = evaluate_promote_gate(wd, 1)
         assert result["decision"] == "abort"
 
-    def test_malformed_amendments_skipped_silently(self, tmp_path: Path) -> None:
-        """A malformed line in brief_amendments.jsonl should not crash
-        the gate — it skips the bad row and proceeds (matching the
-        helper-renderer convention from #223)."""
+    def test_malformed_amendments_downgrade_to_revise(self, tmp_path: Path) -> None:
+        """A malformed line in brief_amendments.jsonl could have been a
+        BLOCKING amendment — silently letting it through risks a false
+        promote. Asymmetric-risk: we choose revise instead, surfacing
+        the malformed_amendment_lines count for operator inspection."""
         wd = tmp_path / "campaign"
         _write_findings(wd / "runs" / "iter-1", valid=True)
         inputs = wd / "runs" / "iter-1" / "inputs"
@@ -217,6 +220,39 @@ class TestDegenerate:
                         "fix": "f", "priority": "HIGH"}) + "\n"
             + "not valid json {\n"
         )
-        # Only valid row was HIGH (not BLOCKING), so → promote
+        # The valid row is HIGH (no BLOCKING) but the malformed line
+        # could have been anything — we cannot rule out a hidden
+        # BLOCKING. Decision: revise.
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "revise", (
+            f"asymmetric-risk: malformed amendment lines should "
+            f"trigger revise, not silent promote. Got {result!r}"
+        )
+        assert result["malformed_amendment_lines"] == 1
+        assert "malformed" in result["reasoning"].lower()
+
+    def test_clean_amendments_no_malformed_lines(self, tmp_path: Path) -> None:
+        """Sanity: no malformed lines → malformed_amendment_lines is 0."""
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
         result = evaluate_promote_gate(wd, 1)
         assert result["decision"] == "promote"
+        assert result["malformed_amendment_lines"] == 0
+
+    def test_blocking_takes_priority_over_malformed(self, tmp_path: Path) -> None:
+        """When both a BLOCKING amendment AND a malformed line exist,
+        the BLOCKING-amendment decision wins (still revise — but the
+        reasoning should cite the BLOCKING IDs first)."""
+        wd = tmp_path / "campaign"
+        _write_findings(wd / "runs" / "iter-1", valid=True)
+        inputs = wd / "runs" / "iter-1" / "inputs"
+        inputs.mkdir(parents=True)
+        (inputs / "brief_amendments.jsonl").write_text(
+            json.dumps({"id": "BA-1", "brief_section": "x", "problem": "p",
+                        "fix": "f", "priority": "BLOCKING"}) + "\n"
+            + "garbage {\n"
+        )
+        result = evaluate_promote_gate(wd, 1)
+        assert result["decision"] == "revise"
+        assert "BA-1" in result["blocking_amendments"]
+        assert result["malformed_amendment_lines"] == 1

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -169,6 +169,9 @@ class TestRealMethodologyThinTemplates:
             "iter_dir": "/tmp/iter-2",
             "observable_metrics": "throughput, latency",
             "controllable_knobs": "batch_size, scheduling",
+            # #221: rehearsal/real mode rendered into the execute prompt.
+            "iteration_mode": "real",
+            "mode_guidance": "(real-mode execute guidance)",
         }
 
     def test_design_thin_renders_and_is_smaller_than_full(self, tmp_path):


### PR DESCRIPTION
## Summary

Lands **v1 scope of all five subissues** of tracker #225 (methodology improvements) as a single PR. Each subissue has a concrete, testable fix that closes a gap revealed by the post-#218 paper-burst rerun (2026-05-27).

Closes: **#221**, **#222**, **#223** (v1), **#224** (v1), **#226**.

The five subissues cluster into three themes:

1. **Mode discipline carries through to EXECUTE_ANALYZE** (#221, #222) — rehearsal/real signal flows to *both* agent phases, and the rehearsal scope is structurally enforced via a new `experiment_spec.rehearsal_subset` field. Without these, the DESIGN agent's scope-shrink (#212) was getting silently ignored by the EXECUTE_ANALYZE agent.
2. **Cross-run knowledge propagation** (#223 v1, #226) — `brief_amendments.jsonl` is now structured (schema-validated, per-priority); `bundle.experiment_spec.timing_observations` records per-policy wall-time observations and the engine reads `recommended_turn_silence_threshold_seconds` to calibrate the watchdog for iter-2. Recurring frictions (e.g. `externality-credit` is slower than the rest) become structural data instead of folklore.
3. **Decision primitive** (#224 v1) — `promote_gate.evaluate_promote_gate(work_dir, iteration)` returns a structured `{decision, reasoning, blocking_amendments, applied_amendments, feasibility_check}` dict. Engine state-machine integration is deferred to v2; this PR lands the decision logic in isolation so it can be tested without any engine surface area.

## Per-subissue scope

### #221 — `iteration_mode` + `execute_mode_guidance` in EXECUTE_ANALYZE prompt

Adds `execute_mode_guidance_for(mode)` to `orchestrator/iteration_mode.py` (returning rehearsal-vs-real text *distinct* from the design-phase helper — verified by an explicit test). Plumbs `iteration_mode` + `mode_guidance` through `_build_context` for `phase == "execute-analyze"`. Both `execute_analyze.md` and `execute_analyze_thin.md` get the placeholders. Tests assert the rehearsal-mode prompt explicitly forbids full fan-out and references `rehearsal_subset` (the structural mechanism #222 adds).

### #222 — `experiment_spec.rehearsal_subset` structured field

`bundle.schema.yaml` gains a `rehearsal_subset` block under `experiment_spec` with `seeds`, `arms`, `extra_validation_only` — `additionalProperties: false` so typo'd fields fail loudly. DESIGN methodology updated to instruct populating it when `iteration_mode == "rehearsal"`. EXECUTE_ANALYZE methodology updated to honor it.

### #223 v1 — Structured `brief_amendments.jsonl` schema + REPORT renderer

New `orchestrator/schemas/brief_amendments.schema.json`: required `id` (pattern `^BA-[0-9]+$`), `brief_section`, `problem`, `fix`, `priority` (`BLOCKING|HIGH|MEDIUM|LOW|INFO` enum). Optional `evidence`, `impact`. Helper `_format_brief_amendments_summary` renders into REPORT context grouped by priority (BLOCKING first). Malformed lines surfaced loudly, not silently skipped. `report.md` template carries the new placeholder. **CLI `nous brief apply-amendments` deferred to v2** — this PR lands the schema + renderer; agent-friendly tools to apply amendments to upstream briefs come next.

### #224 v1 — Deterministic `promote_gate.evaluate_promote_gate` function

New `orchestrator/promote_gate.py`. Decision rule:
1. `findings.json` missing OR `experiment_valid: false` → `abort`
2. Any unapplied BLOCKING amendment → `revise` (lists which IDs)
3. else → `promote`

Pure Python — no LLM, no SDK, no I/O beyond reading on-disk artifacts. **Engine state-machine integration deferred to v2** — this PR lands the decision-function so it can be tested independently before any engine state changes. Auto-approve interaction (LLM-driven override) is a v2 concern.

### #226 — `experiment_spec.timing_observations` + watchdog override

`bundle.schema.yaml` gains a sibling `timing_observations` block (separate from the open-knob `verified_parameters` namespace) with `expected_wall_time_seconds_per_policy` and `recommended_turn_silence_threshold_seconds`. `SDKDispatcher.dispatch` reads the prior iter's bundle for the recommended threshold and applies it as a per-call override; restores the campaign-level default after. Resolution chain: `bundle override > campaign default > factory default (600s)`.

The recurring `externality-credit` slowness across three paper-burst reruns is exactly the case this fix is designed for: rehearsal observes the slow policy, records the observation, iter-2's watchdog calibrates accordingly.

## Test plan

- [x] **+44 new tests, 1133 passed, 1 skipped, 0 regressions** (`pytest tests/`)
  - `test_iteration_mode`: +7 (`execute_mode_guidance_for` shape + `_build_context` integration covering both template paths)
  - `test_experiment_spec`: +28 (schema validation for `rehearsal_subset` + `timing_observations` + `brief_amendments.schema.json`; behavioral test for `SDKDispatcher` reading bundle override; renderer test for grouped-by-priority output)
  - `test_promote_gate` (new file): +14 (promote / revise / abort branches; result-shape contract; degenerate inputs)
- [x] All tests are behavioral and use existing seam-injected fakes per CLAUDE.md ("no live LLM calls in tests"). Promote-gate logic is pure-Python; bundle/schema reads use real on-disk JSON.
- [ ] Re-run paper-burst (now amended for canonical `burst-tokenwfq` reproduction at 8192/800/120s) against this PR's nous to verify the methodology improvements work end-to-end. **Deferred to after-merge** — operator will sync and reinstall first.

## Out of scope (deferred to v2)

| Subissue | v1 scope (this PR) | v2 work deferred |
|---|---|---|
| #223 | structured schema + REPORT renderer | `nous brief apply-amendments` CLI for cross-run propagation |
| #224 | deterministic decision function | engine state-machine integration; auto-approve LLM summarizer |

These deferrals are explicit; the v2 work is captured in tracker #225 itself for follow-up.

## Compaction safety

This PR was developed across a long session that risked compaction. The full implementation plan, memory entries, and recovery instructions are at:
- `docs/plans/methodology-improvements-pr.md` (in this PR)
- `~/.claude/projects/<project>/memory/project_methodology_pr_in_flight.md` (operator's local memory)

A future Claude resuming work post-compaction can read these to pick up where this PR left off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
