### PR TITLE
fix(isolation): close all 4 subissues of tracker #228 (worktree, resume, persistence)

### DIFF
--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -48,6 +48,46 @@ class IterationOutcome(str, Enum):
 
 TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
 SCHEMAS_DIR = Path(__file__).resolve().parent / "schemas"
+
+
+def _declared_code_change_paths(bundle_path: Path) -> set[str]:
+    """Read ``bundle.yaml`` and return every ``arms[].code_changes[].file``
+    relative path declared on any arm. Returns an empty set if the file
+    is missing, unparseable, or declares no ``code_changes`` (#230)."""
+    if not bundle_path.exists():
+        return set()
+    try:
+        bundle = yaml.safe_load(bundle_path.read_text()) or {}
+    except yaml.YAMLError:
+        return set()
+    arms = bundle.get("arms") or []
+    declared: set[str] = set()
+    for arm in arms:
+        if not isinstance(arm, dict):
+            continue
+        for change in arm.get("code_changes") or []:
+            if isinstance(change, dict) and isinstance(change.get("file"), str):
+                declared.add(change["file"])
+    return declared
+
+
+def _record_undeclared_writes_in_findings(
+    findings_path: Path,
+    undeclared: list[str],
+) -> None:
+    """Merge ``worktree_uncommitted_writes`` into ``findings.json`` (#230).
+
+    No-op if findings.json is missing or unparseable — the schema
+    validator downstream will already complain and we don't want to
+    block worktree cleanup on a malformed findings artifact."""
+    if not undeclared or not findings_path.exists():
+        return
+    try:
+        findings = json.loads(findings_path.read_text())
+    except json.JSONDecodeError:
+        return
+    findings["worktree_uncommitted_writes"] = sorted(set(undeclared))
+    atomic_write(findings_path, json.dumps(findings, indent=2) + "\n")
 DEFAULTS_PATH = Path(__file__).resolve().parent / "defaults.yaml"
 _ARM_TYPE_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -960,8 +1000,9 @@ def run_iteration(
                 create_experiment_worktree,
                 remove_experiment_worktree,
             )
+            extras = campaign.get("target_system", {}).get("worktree_extras") or []
             experiment_dir, experiment_id = create_experiment_worktree(
-                Path(repo_path), iteration,
+                Path(repo_path), iteration, extras=extras,
             )
             (iter_dir / ".experiment_id").write_text(experiment_id)
             print(f"  Experiment worktree: {experiment_dir}")
@@ -1031,6 +1072,24 @@ def run_iteration(
                 "Executor artifacts failed post-check validation: %s",
                 result["errors"],
             )
+        # #230: surface undeclared writes that would be lost when the
+        # worktree is removed below. Persist into findings.json so the
+        # design agent on iter-N+1 can see what to declare in
+        # ``code_changes``. Tripwire only — never blocks cleanup.
+        if repo_path and experiment_dir is not None:
+            from orchestrator.worktree import detect_undeclared_writes
+            declared = _declared_code_change_paths(iter_dir / "bundle.yaml")
+            undeclared = detect_undeclared_writes(experiment_dir, declared)
+            if undeclared:
+                logger.warning(
+                    "Executor wrote %d files in the experiment worktree "
+                    "without declaring them in bundle.arms[].code_changes; "
+                    "they will be lost on cleanup: %s",
+                    len(undeclared), undeclared[:20],
+                )
+                _record_undeclared_writes_in_findings(
+                    iter_dir / "findings.json", undeclared,
+                )
         # Clean up worktree only on success
         if repo_path and experiment_id:
             remove_experiment_worktree(Path(repo_path), experiment_id)

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -52,13 +52,31 @@ SCHEMAS_DIR = Path(__file__).resolve().parent / "schemas"
 
 def _declared_code_change_paths(bundle_path: Path) -> set[str]:
     """Read ``bundle.yaml`` and return every ``arms[].code_changes[].file``
-    relative path declared on any arm. Returns an empty set if the file
-    is missing, unparseable, or declares no ``code_changes`` (#230)."""
+    declared on any arm (#230).
+
+    Returns the set of declared file paths verbatim — paths are NOT
+    normalized. If the bundle declares an absolute path or a ``./``-
+    prefixed path, it won't match the relative paths that
+    ``detect_undeclared_writes`` reports; that mismatch is the bundle
+    author's responsibility (the bundle schema already constrains
+    ``file`` shape).
+
+    Returns an empty set when the bundle is missing or declares no
+    ``code_changes``. A YAML parse failure is logged at ERROR (the
+    bundle is a system boundary; corruption is operator-actionable)
+    and an empty set returned so cleanup proceeds.
+    """
     if not bundle_path.exists():
         return set()
     try:
         bundle = yaml.safe_load(bundle_path.read_text()) or {}
-    except yaml.YAMLError:
+    except yaml.YAMLError as exc:
+        logger.error(
+            "_declared_code_change_paths: bundle.yaml parse failed at %s "
+            "(%s); treating as if no code_changes were declared. Every "
+            "executor write will be flagged as undeclared until this is fixed.",
+            bundle_path, exc,
+        )
         return set()
     arms = bundle.get("arms") or []
     declared: set[str] = set()
@@ -77,17 +95,50 @@ def _record_undeclared_writes_in_findings(
 ) -> None:
     """Merge ``worktree_uncommitted_writes`` into ``findings.json`` (#230).
 
-    No-op if findings.json is missing or unparseable — the schema
-    validator downstream will already complain and we don't want to
-    block worktree cleanup on a malformed findings artifact."""
+    No-op if findings.json is missing — the cleanup may be running in
+    the execute-incomplete branch where findings was never produced
+    (the caller surfaces the data via retry_log there instead).
+
+    A JSONDecodeError on the existing findings is logged at ERROR
+    (corrupted findings is operator-actionable) and the function
+    returns without writing — modifying a corrupt JSON file would
+    only make recovery harder.
+    """
     if not undeclared or not findings_path.exists():
         return
     try:
         findings = json.loads(findings_path.read_text())
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        logger.error(
+            "_record_undeclared_writes_in_findings: findings.json at %s "
+            "is not valid JSON (%s); the undeclared-writes list will not "
+            "be persisted. Undeclared paths: %s",
+            findings_path, exc, undeclared,
+        )
         return
     findings["worktree_uncommitted_writes"] = sorted(set(undeclared))
     atomic_write(findings_path, json.dumps(findings, indent=2) + "\n")
+
+
+def _detect_undeclared_writes_for_iter(
+    iter_dir: Path,
+    experiment_dir: Path,
+) -> list[str]:
+    """Detect undeclared writes in ``experiment_dir`` and log a WARNING
+    if any are found (#230). Returns the list so the caller can decide
+    where to persist it (findings.json on success, retry_log on
+    incomplete). Pure tripwire — never raises, never blocks cleanup."""
+    from orchestrator.worktree import detect_undeclared_writes
+    declared = _declared_code_change_paths(iter_dir / "bundle.yaml")
+    undeclared = detect_undeclared_writes(experiment_dir, declared)
+    if undeclared:
+        logger.warning(
+            "Executor wrote %d files in the experiment worktree "
+            "without declaring them in bundle.arms[].code_changes; "
+            "they will be lost on cleanup: %s",
+            len(undeclared), undeclared[:20],
+        )
+    return undeclared
 DEFAULTS_PATH = Path(__file__).resolve().parent / "defaults.yaml"
 _ARM_TYPE_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -1048,6 +1099,14 @@ def run_iteration(
         # "X not found" from validate_execution.
         missing = _missing_execute_artifacts(iter_dir)
         if missing:
+            # #230: even on incomplete, the executor may have written
+            # partial code into the worktree — exactly the case where
+            # undeclared writes matter most. Capture before cleanup.
+            incomplete_undeclared: list[str] = []
+            if repo_path and experiment_id and experiment_dir is not None:
+                incomplete_undeclared = _detect_undeclared_writes_for_iter(
+                    iter_dir, experiment_dir,
+                )
             from orchestrator.metrics import log_retry_event
             log_retry_event(work_dir / "llm_metrics.jsonl", {
                 "iteration": iteration,
@@ -1055,6 +1114,7 @@ def run_iteration(
                 "failure_type": "execute_incomplete",
                 "missing_artifacts": missing,
                 "max_turns": _max_turns_for("execute_analyze"),
+                "undeclared_writes": incomplete_undeclared,
             })
             # Clean up the experiment worktree so a re-run isn't blocked.
             if repo_path and experiment_id:
@@ -1076,17 +1136,11 @@ def run_iteration(
         # worktree is removed below. Persist into findings.json so the
         # design agent on iter-N+1 can see what to declare in
         # ``code_changes``. Tripwire only — never blocks cleanup.
-        if repo_path and experiment_dir is not None:
-            from orchestrator.worktree import detect_undeclared_writes
-            declared = _declared_code_change_paths(iter_dir / "bundle.yaml")
-            undeclared = detect_undeclared_writes(experiment_dir, declared)
+        if repo_path and experiment_id and experiment_dir is not None:
+            undeclared = _detect_undeclared_writes_for_iter(
+                iter_dir, experiment_dir,
+            )
             if undeclared:
-                logger.warning(
-                    "Executor wrote %d files in the experiment worktree "
-                    "without declaring them in bundle.arms[].code_changes; "
-                    "they will be lost on cleanup: %s",
-                    len(undeclared), undeclared[:20],
-                )
                 _record_undeclared_writes_in_findings(
                     iter_dir / "findings.json", undeclared,
                 )

--- a/orchestrator/prompt_loader.py
+++ b/orchestrator/prompt_loader.py
@@ -60,9 +60,21 @@ class PromptLoader:
 
         remaining = _PLACEHOLDER_RE.findall(text)
         if remaining:
+            missing = sorted(set(remaining))
+            # #232: forensic logging on the resume-time placeholder bug.
+            # The error message names the missing placeholders; we add
+            # what keys WERE present in the context so the next
+            # occurrence produces evidence pointing at the actual cause
+            # (phase string mismatch, stale loader, resume-path field
+            # uninitialized, ...).
+            logger.error(
+                "prompt render failed: template=%s resolved_path=%s "
+                "missing_placeholders=%s context_keys=%s",
+                template_name, path, missing, sorted(context.keys()),
+            )
             raise ValueError(
                 f"Unreplaced placeholders in {template_name}.md: "
-                f"{', '.join(sorted(set(remaining)))}"
+                f"{', '.join(missing)}"
             )
 
         logger.debug("Loaded prompt %s (%d chars)", template_name, len(text))

--- a/orchestrator/schemas/campaign.schema.yaml
+++ b/orchestrator/schemas/campaign.schema.yaml
@@ -84,6 +84,23 @@ properties:
         type: ["string", "null"]
         minLength: 1
         description: "Path to target system git repo. Used by CLIDispatcher for code-access agents. If set, experiments run in isolated worktrees."
+      worktree_extras:
+        type: array
+        items:
+          type: string
+          minLength: 1
+        uniqueItems: true
+        description: >
+          Paths (relative to repo_path) to symlink into each experiment
+          worktree on creation (#229). Use this for gitignored assets
+          the executor needs from main — virtualenvs, pre-fetched data
+          dirs, prior-iteration outputs, build artifacts. Without this
+          mechanism, executors discover that the worktree is missing
+          their tooling and `cd` back to the parent repo, silently
+          breaking isolation. Each entry must be a relative path that
+          resolves under repo_path; absolute paths and ``..`` traversal
+          are rejected at worktree creation. Source must exist in main
+          at the time of worktree creation.
 
   models:
     type: object

--- a/orchestrator/schemas/findings.schema.json
+++ b/orchestrator/schemas/findings.schema.json
@@ -24,6 +24,12 @@
       "minimum": 0,
       "maximum": 100,
       "description": "Percentage of total effect from single dominant component, if detected."
+    },
+    "worktree_uncommitted_writes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true,
+      "description": "#230 — paths the executor wrote inside the experiment worktree without declaring them in the bundle's `code_changes`. Surfaced just before worktree cleanup; logged at WARNING. Empty array (or absent) means the executor declared everything it wrote, or wrote nothing untracked. The orchestrator does not block cleanup on undeclared writes — this is a tripwire, not a gate."
     }
   },
   "$defs": {

--- a/orchestrator/worktree.py
+++ b/orchestrator/worktree.py
@@ -17,7 +17,7 @@ import subprocess
 import time
 import uuid
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +26,27 @@ _EXPERIMENTS_DIRNAME = ".nous-experiments"
 _DEFAULT_ORPHAN_AGE_SECONDS = 60 * 60  # 1 hour
 
 
-def create_experiment_worktree(repo_path: Path, iteration: int) -> tuple[Path, str]:
+def create_experiment_worktree(
+    repo_path: Path,
+    iteration: int,
+    *,
+    extras: Sequence[str] | None = None,
+) -> tuple[Path, str]:
     """Create a git worktree for running an experiment in isolation.
+
+    Args:
+        repo_path: Target repo root.
+        iteration: 1-based iteration index. Used to name the experiment.
+        extras: Paths (relative to ``repo_path``) to symlink into the
+            worktree. Each entry is symlinked as ``<worktree>/<entry>``
+            pointing at ``<repo_path>/<entry>`` (#229). Use this for
+            gitignored deps the executor needs from main — venvs, large
+            data dirs, prior-iteration outputs — so the executor doesn't
+            have to ``cd`` to the parent repo and silently break
+            isolation. Each path must be relative and resolve under
+            ``repo_path``; absolute paths and ``..`` traversal are
+            rejected. Source must exist; missing source raises
+            ``FileNotFoundError``.
 
     Returns:
         Tuple of (worktree_path, experiment_id).
@@ -50,7 +69,129 @@ def create_experiment_worktree(repo_path: Path, iteration: int) -> tuple[Path, s
         text=True,
     )
     logger.info("Created experiment worktree: %s (branch: %s)", worktree_dir, branch_name)
+
+    if extras:
+        try:
+            _link_worktree_extras(repo_path, worktree_dir, extras)
+        except BaseException:
+            # If symlinking fails (bad extras config), don't leak the
+            # half-built worktree + branch — clean up before re-raising.
+            remove_experiment_worktree(repo_path, experiment_id)
+            raise
+
     return worktree_dir, experiment_id
+
+
+def _link_worktree_extras(
+    repo_path: Path,
+    worktree_dir: Path,
+    extras: Sequence[str],
+) -> None:
+    """Symlink each entry in ``extras`` from ``repo_path`` into ``worktree_dir``.
+
+    Each entry must be a relative path (no leading ``/``, no ``..``
+    traversal that escapes ``repo_path``). The source path must exist in
+    ``repo_path``. Parent directories under the worktree are created as
+    needed.
+
+    If a path under the worktree already exists at the target location
+    (typically because the entry refers to a tracked path that the
+    worktree checkout already populated), the existing path is left
+    untouched and a warning is logged — do not silently overwrite the
+    real checkout with a symlink.
+    """
+    for entry in extras:
+        if not entry or os.path.isabs(entry):
+            raise ValueError(
+                f"worktree_extras entries must be non-empty relative paths; "
+                f"got {entry!r}"
+            )
+        source = (repo_path / entry).resolve()
+        try:
+            source.relative_to(repo_path.resolve())
+        except ValueError as exc:
+            raise ValueError(
+                f"worktree_extras entry {entry!r} resolves outside repo_path "
+                f"({repo_path}); refusing to symlink across the repo boundary."
+            ) from exc
+        if not source.exists():
+            raise FileNotFoundError(
+                f"worktree_extras source not found: {source} "
+                f"(declared as {entry!r} in target_system.worktree_extras)"
+            )
+
+        link_path = worktree_dir / entry
+        if link_path.exists() or link_path.is_symlink():
+            logger.warning(
+                "worktree_extras: %s already present in worktree; leaving "
+                "the existing path untouched (entry was %r)",
+                link_path, entry,
+            )
+            continue
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+        os.symlink(source, link_path)
+        logger.info("worktree_extras: linked %s -> %s", link_path, source)
+
+
+def detect_undeclared_writes(
+    worktree_path: Path,
+    declared_paths: set[str] | None = None,
+) -> list[str]:
+    """Return paths in ``worktree_path`` that the executor wrote without
+    declaring them via the bundle's ``code_changes`` (#230).
+
+    Parses ``git -C <worktree_path> status --porcelain`` and reports
+    every untracked file (``??``) and modified-tracked file (``M``) that
+    is not already covered by ``declared_paths``. Each returned path is
+    relative to ``worktree_path``.
+
+    Symlinks (typically created by ``worktree_extras``, #229) are
+    excluded — they're orchestrator-managed inputs, not undeclared
+    executor writes.
+
+    The intent is to surface silent loss of work: an executor that
+    writes a Python module via the ``Write`` tool but forgets to add a
+    ``code_changes`` entry will lose the file when the worktree is
+    cleaned up. Reporting it loudly turns the silent loss into an
+    auditable trail.
+    """
+    declared_paths = declared_paths or set()
+    worktree_path = Path(worktree_path)
+
+    if not worktree_path.exists():
+        return []
+
+    result = subprocess.run(
+        ["git", "-C", str(worktree_path), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        # Worktree may have been removed already, or git is unhappy —
+        # don't make cleanup fail because diagnostics failed.
+        logger.debug(
+            "git status --porcelain on %s exited %s: %s",
+            worktree_path, result.returncode, result.stderr.strip(),
+        )
+        return []
+
+    undeclared: list[str] = []
+    for line in result.stdout.splitlines():
+        if len(line) < 4:
+            continue
+        # Porcelain v1 prefix: 2 status chars + space + path.
+        status = line[:2]
+        path = line[3:].strip()
+        if not (status.startswith("??") or "M" in status):
+            continue
+        if path in declared_paths:
+            continue
+        full = worktree_path / path
+        if full.is_symlink():
+            continue
+        undeclared.append(path)
+    return undeclared
 
 
 def remove_experiment_worktree(repo_path: Path, experiment_id: str) -> None:

--- a/orchestrator/worktree.py
+++ b/orchestrator/worktree.py
@@ -73,9 +73,12 @@ def create_experiment_worktree(
     if extras:
         try:
             _link_worktree_extras(repo_path, worktree_dir, extras)
-        except BaseException:
+        except Exception:
             # If symlinking fails (bad extras config), don't leak the
             # half-built worktree + branch — clean up before re-raising.
+            # Scoped to ``Exception`` so a Ctrl-C (KeyboardInterrupt)
+            # during setup aborts fast instead of triggering a `git
+            # worktree remove` subprocess that may itself stall.
             remove_experiment_worktree(repo_path, experiment_id)
             raise
 
@@ -89,16 +92,24 @@ def _link_worktree_extras(
 ) -> None:
     """Symlink each entry in ``extras`` from ``repo_path`` into ``worktree_dir``.
 
-    Each entry must be a relative path (no leading ``/``, no ``..``
-    traversal that escapes ``repo_path``). The source path must exist in
-    ``repo_path``. Parent directories under the worktree are created as
-    needed.
+    Validation order:
 
-    If a path under the worktree already exists at the target location
-    (typically because the entry refers to a tracked path that the
-    worktree checkout already populated), the existing path is left
-    untouched and a warning is logged — do not silently overwrite the
-    real checkout with a symlink.
+    1. Each entry must be a non-empty relative path (no leading ``/``).
+    2. Resolved source must lie under ``repo_path`` — ``..`` traversal
+       is permitted *syntactically* but rejected if the resolved path
+       escapes the repo boundary.
+    3. Source must exist in ``repo_path``.
+    4. If the target path already exists in the worktree (typically a
+       tracked path the checkout populated), the existing file is left
+       untouched. This is logged at WARNING with the entry name so
+       operators can spot a misconfigured extras list — declaring a
+       tracked path as an extra is almost always a mistake (the agent
+       reads main's working tree instead of main's HEAD).
+
+    On failure mid-loop, prior symlinks created in this call are NOT
+    rolled back here — the caller's ``except Exception`` in
+    ``create_experiment_worktree`` (which calls
+    ``remove_experiment_worktree``) sweeps the whole worktree.
     """
     for entry in extras:
         if not entry or os.path.isabs(entry):
@@ -122,10 +133,17 @@ def _link_worktree_extras(
 
         link_path = worktree_dir / entry
         if link_path.exists() or link_path.is_symlink():
+            # Loud warning, not silent — the executor will see main's
+            # tracked content here instead of the symlinked target,
+            # which subverts the campaign author's intent.
             logger.warning(
-                "worktree_extras: %s already present in worktree; leaving "
-                "the existing path untouched (entry was %r)",
-                link_path, entry,
+                "worktree_extras: %r collides with an existing path in "
+                "the worktree (%s) — leaving it untouched. This usually "
+                "means the entry refers to a tracked path; tracked paths "
+                "should NOT be declared as extras (they're already in "
+                "the worktree checkout). Drop %r from worktree_extras "
+                "or rename the source.",
+                entry, link_path, entry,
             )
             continue
         link_path.parent.mkdir(parents=True, exist_ok=True)
@@ -133,17 +151,47 @@ def _link_worktree_extras(
         logger.info("worktree_extras: linked %s -> %s", link_path, source)
 
 
+# Porcelain v1 status codes that indicate the executor produced or
+# changed file content the bundle didn't declare. ``M`` = modified, ``A``
+# = added (staged), ``R`` = renamed, ``C`` = copied, ``T`` = typechange.
+# ``D`` (deleted) is intentionally NOT here: removing a tracked file
+# isn't a "write," and surfacing it would turn ``git rm`` between arms
+# into noise. Untracked is signalled by the special ``??`` prefix and
+# handled separately in the parser.
+_PORCELAIN_WRITE_CODES = frozenset({"M", "A", "R", "C", "T"})
+
+
+def _parse_porcelain_line(line: str) -> tuple[str, str, str] | None:
+    """Parse one ``git status --porcelain`` v1 line.
+
+    Returns ``(index_status, worktree_status, path)`` or ``None`` for
+    blank/short lines. For renames and copies (``R``, ``C``), the
+    porcelain format is ``XY orig -> new``; this returns the *new*
+    path so the caller treats the destination as the relevant write.
+    """
+    if len(line) < 4:
+        return None
+    index_st, worktree_st = line[0], line[1]
+    rest = line[3:]
+    if " -> " in rest:
+        rest = rest.split(" -> ", 1)[1]
+    return index_st, worktree_st, rest.strip()
+
+
 def detect_undeclared_writes(
     worktree_path: Path,
     declared_paths: set[str] | None = None,
 ) -> list[str]:
-    """Return paths in ``worktree_path`` that the executor wrote without
+    """Return paths the executor wrote in ``worktree_path`` without
     declaring them via the bundle's ``code_changes`` (#230).
 
     Parses ``git -C <worktree_path> status --porcelain`` and reports
-    every untracked file (``??``) and modified-tracked file (``M``) that
-    is not already covered by ``declared_paths``. Each returned path is
-    relative to ``worktree_path``.
+    every porcelain line whose status indicates a write — untracked
+    (``??``), modified (``M``), staged-add (``A``), renamed (``R``),
+    copied (``C``), or typechanged (``T``) — in either the index or
+    the worktree column. Deletions (``D``) are not surfaced (see
+    ``_PORCELAIN_WRITE_CODES``). Each returned path is relative to
+    ``worktree_path``; for renames, the destination path is reported.
 
     Symlinks (typically created by ``worktree_extras``, #229) are
     excluded — they're orchestrator-managed inputs, not undeclared
@@ -154,6 +202,12 @@ def detect_undeclared_writes(
     ``code_changes`` entry will lose the file when the worktree is
     cleaned up. Reporting it loudly turns the silent loss into an
     auditable trail.
+
+    Returns an empty list when ``worktree_path`` is missing or when
+    ``git status`` itself fails — the cleanup path must not break on
+    diagnostics. Failures are logged at WARNING with returncode +
+    stderr, so an empty return on a real git failure is loud, not
+    silent.
     """
     declared_paths = declared_paths or set()
     worktree_path = Path(worktree_path)
@@ -168,22 +222,30 @@ def detect_undeclared_writes(
         check=False,
     )
     if result.returncode != 0:
-        # Worktree may have been removed already, or git is unhappy —
-        # don't make cleanup fail because diagnostics failed.
-        logger.debug(
-            "git status --porcelain on %s exited %s: %s",
+        # Diagnostic failure — we still must not block cleanup, but the
+        # whole point of this function is "turn silent loss into an
+        # auditable trail," so log loudly rather than at DEBUG.
+        logger.warning(
+            "detect_undeclared_writes: git status failed for %s "
+            "(returncode=%s); returning empty list. stderr=%s",
             worktree_path, result.returncode, result.stderr.strip(),
         )
         return []
 
     undeclared: list[str] = []
     for line in result.stdout.splitlines():
-        if len(line) < 4:
+        parsed = _parse_porcelain_line(line)
+        if parsed is None:
             continue
-        # Porcelain v1 prefix: 2 status chars + space + path.
-        status = line[:2]
-        path = line[3:].strip()
-        if not (status.startswith("??") or "M" in status):
+        index_st, worktree_st, path = parsed
+        # Untracked is the special ``??`` prefix.
+        if index_st == "?" and worktree_st == "?":
+            relevant = True
+        else:
+            relevant = bool(
+                _PORCELAIN_WRITE_CODES & {index_st, worktree_st}
+            )
+        if not relevant:
             continue
         if path in declared_paths:
             continue

--- a/prompts/methodology/execute_analyze.md
+++ b/prompts/methodology/execute_analyze.md
@@ -2,6 +2,14 @@ You are a scientific executor for the Nous hypothesis-driven experimentation fra
 
 You have **shell access**. You are running inside an isolated git worktree of the target system. You own this worktree — reset it yourself with `git checkout -- .` between conditions.
 
+## Worktree discipline (#228)
+
+Your `cwd` is an experiment worktree forked from the target repo's main branch. It contains the tracked source tree plus any symlinks the orchestrator created from `target_system.worktree_extras` (#229) — typically virtualenvs, prefetched data dirs, prior-iteration outputs, build artifacts.
+
+- **Stay in your worktree.** Do not `cd` to the parent repo to "use the real venv" or "read prior-iter results from main." Reference parent assets via the `worktree_extras` symlinks. They appear as ordinary paths inside the worktree and resolve to main automatically.
+- **Reference parent assets through symlinks, not absolute paths into main.** If `worktree_extras` includes `.nous/<campaign>`, read prior-iter files at `.nous/<campaign>/runs/iter-{N-1}/...` (relative — resolves through the symlink), NOT `/Users/<user>/.../<repo>/.nous/<campaign>/...`. Absolute paths into main work today by accident; they break under harness-managed isolation (#123).
+- **Code you write must be declared.** Any new file you create in the worktree must appear in your bundle arm's `code_changes[]` to survive cleanup. Files you don't declare get listed in `findings.worktree_uncommitted_writes` (#230) and lost when the worktree is removed. If you write code outside the worktree (e.g., into a `worktree_extras`-symlinked parent dir), that code persists by virtue of living in main — but think twice before doing it; you're outside the experiment's isolation.
+
 Your job has FIVE phases — all in one session with full context:
 1. **Prepare** — build, create patches, validate ALL commands
 2. **Execute** — run all conditions across seeds, capture results

--- a/prompts/methodology/execute_analyze_thin.md
+++ b/prompts/methodology/execute_analyze_thin.md
@@ -11,6 +11,15 @@ This iteration's mode is: **{{iteration_mode}}**
 
 {{mode_guidance}}
 
+## Worktree discipline (#228)
+
+Your `cwd` is an experiment worktree, not the target repo. Stay in it.
+Parent-repo assets (venvs, data dirs, prior-iter outputs) appear as
+symlinks declared in `target_system.worktree_extras` (#229) — reference
+them via relative paths, never `cd` to the parent repo. Any file you
+write that isn't in a bundle arm's `code_changes[]` gets listed in
+`findings.worktree_uncommitted_writes` and lost on cleanup (#230).
+
 ## Active principles
 {{active_principles}}
 

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -1,4 +1,5 @@
 """Tests for the prompt template loader."""
+import logging
 from pathlib import Path
 
 import pytest
@@ -195,3 +196,101 @@ class TestRealMethodologyThinTemplates:
         out = loader.load("execute_analyze", self._ctx_for_execute())
         assert "CLAUDE.md" in out
         assert "BLIS" in out
+
+
+class TestWorktreeDisciplineGuidance:
+    """#231 — both shipped EXECUTE_ANALYZE templates must carry the
+    "Worktree discipline" guidance so the executor knows to stay in the
+    worktree, reference parent assets via ``worktree_extras`` symlinks,
+    and declare any new files via ``code_changes``.
+    """
+
+    REAL_PROMPTS_DIR = (
+        Path(__file__).resolve().parent.parent / "prompts" / "methodology"
+    )
+
+    def test_full_template_carries_discipline_section(self):
+        text = (self.REAL_PROMPTS_DIR / "execute_analyze.md").read_text()
+        assert "Worktree discipline" in text
+        assert "worktree_extras" in text
+        assert "Do not `cd` to the parent repo" in text
+        # Persistence rule must be present so executors don't lose work.
+        assert "code_changes" in text
+
+    def test_thin_template_carries_discipline_section(self):
+        text = (self.REAL_PROMPTS_DIR / "execute_analyze_thin.md").read_text()
+        assert "Worktree discipline" in text
+        assert "worktree_extras" in text
+        assert "code_changes" in text
+
+    def test_thin_template_renders_with_existing_context(self, tmp_path):
+        # The new section adds prose only — no new placeholders. Confirm
+        # the existing dispatcher context still renders the template
+        # without unreplaced-placeholder errors.
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("...")
+        loader = PromptLoader(self.REAL_PROMPTS_DIR, claude_md_at=claude_md)
+        ctx = {
+            "iteration": "2",
+            "target_system": "BLIS",
+            "system_description": "Inference simulator.",
+            "active_principles": "p1.",
+            "iter_dir": "/tmp/iter-2",
+            "observable_metrics": "throughput",
+            "controllable_knobs": "batch_size",
+            "iteration_mode": "real",
+            "mode_guidance": "(guidance)",
+        }
+        out = loader.load("execute_analyze", ctx)
+        assert "Worktree discipline" in out
+
+
+class TestPlaceholderDiagnosticLogging:
+    """#232 — when prompt rendering fails on unreplaced placeholders,
+    the loader must emit a forensic log line listing both the missing
+    placeholders AND the keys that were present in the context. The
+    cross-account-signal-pooling campaign hit a non-deterministic
+    `Unreplaced placeholders: iteration_mode, mode_guidance` on iter-2;
+    the error message named what was missing, but operators had no way
+    to tell whether the keys were absent or just spelled wrong.
+
+    This issue does NOT fix the underlying bug — only ships diagnostics
+    so the next occurrence produces actionable evidence.
+    """
+
+    def test_logs_missing_placeholders_and_context_keys(self, prompts_dir, caplog):
+        _write_template(
+            prompts_dir,
+            "execute_analyze",
+            "mode={{iteration_mode}}\nguide={{mode_guidance}}\nrest={{iter_dir}}",
+        )
+        loader = PromptLoader(prompts_dir)
+        # Mimic the resume-bug shape: context has *some* keys but is
+        # missing iteration_mode + mode_guidance.
+        partial_context = {"iter_dir": "/tmp/iter-2", "target_system": "X"}
+
+        with caplog.at_level(logging.ERROR, logger="orchestrator.prompt_loader"):
+            with pytest.raises(ValueError, match="iteration_mode, mode_guidance"):
+                loader.load("execute_analyze", partial_context)
+
+        # The forensic log line must carry the two new fields.
+        record = next(
+            (r for r in caplog.records if r.levelname == "ERROR"
+             and "prompt render failed" in r.getMessage()),
+            None,
+        )
+        assert record is not None, "expected ERROR-level diagnostic log line"
+        msg = record.getMessage()
+        assert "missing_placeholders=['iteration_mode', 'mode_guidance']" in msg
+        assert "context_keys=['iter_dir', 'target_system']" in msg
+        assert "template=execute_analyze" in msg
+
+    def test_no_log_on_successful_render(self, prompts_dir, caplog):
+        _write_template(prompts_dir, "ok", "Hello {{name}}!")
+        loader = PromptLoader(prompts_dir)
+        with caplog.at_level(logging.ERROR, logger="orchestrator.prompt_loader"):
+            loader.load("ok", {"name": "Nous"})
+        assert not [
+            r for r in caplog.records
+            if "prompt render failed" in r.getMessage()
+        ]

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -210,11 +210,12 @@ class TestWorktreeDisciplineGuidance:
     )
 
     def test_full_template_carries_discipline_section(self):
+        # Structural anchors only — match the *concepts* the section
+        # must convey, not the exact prose. Editorial tweaks to the
+        # surrounding language must not break this test.
         text = (self.REAL_PROMPTS_DIR / "execute_analyze.md").read_text()
         assert "Worktree discipline" in text
         assert "worktree_extras" in text
-        assert "Do not `cd` to the parent repo" in text
-        # Persistence rule must be present so executors don't lose work.
         assert "code_changes" in text
 
     def test_thin_template_carries_discipline_section(self):
@@ -273,7 +274,11 @@ class TestPlaceholderDiagnosticLogging:
             with pytest.raises(ValueError, match="iteration_mode, mode_guidance"):
                 loader.load("execute_analyze", partial_context)
 
-        # The forensic log line must carry the two new fields.
+        # The forensic log line must carry the two new fields. Match by
+        # substring (not exact list-repr) so a future format swap (e.g.
+        # comma-joined values, JSON, structured logging) doesn't break
+        # the diagnostic intent — what matters is that a human reading
+        # the log can see the missing names AND the present names.
         record = next(
             (r for r in caplog.records if r.levelname == "ERROR"
              and "prompt render failed" in r.getMessage()),
@@ -281,8 +286,12 @@ class TestPlaceholderDiagnosticLogging:
         )
         assert record is not None, "expected ERROR-level diagnostic log line"
         msg = record.getMessage()
-        assert "missing_placeholders=['iteration_mode', 'mode_guidance']" in msg
-        assert "context_keys=['iter_dir', 'target_system']" in msg
+        assert "missing_placeholders=" in msg
+        assert "iteration_mode" in msg
+        assert "mode_guidance" in msg
+        assert "context_keys=" in msg
+        assert "iter_dir" in msg
+        assert "target_system" in msg
         assert "template=execute_analyze" in msg
 
     def test_no_log_on_successful_render(self, prompts_dir, caplog):

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -316,6 +316,95 @@ class TestDetectUndeclaredWrites:
         finally:
             remove_experiment_worktree(temp_git_repo, experiment_id)
 
+    def test_modify_then_stage_flagged(self, temp_git_repo):
+        # Porcelain code "MM": modified-staged-AND-modified-unstaged.
+        # The earlier substring filter (`"M" in status`) caught this by
+        # accident; the new explicit-status filter must continue to.
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            (worktree_dir / "README.md").write_text("# Once\n")
+            subprocess.run(
+                ["git", "add", "README.md"],
+                cwd=worktree_dir, check=True, capture_output=True,
+            )
+            (worktree_dir / "README.md").write_text("# Twice\n")
+            assert "README.md" in detect_undeclared_writes(worktree_dir)
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_added_staged_file_flagged(self, temp_git_repo):
+        # Porcelain code "A ": added (staged), no working-tree diff. The
+        # branch-and-its-staged-content gets destroyed on cleanup just
+        # like an untracked file, so this must surface.
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            (worktree_dir / "executor_added.py").write_text("# new\n")
+            subprocess.run(
+                ["git", "add", "executor_added.py"],
+                cwd=worktree_dir, check=True, capture_output=True,
+            )
+            assert "executor_added.py" in detect_undeclared_writes(worktree_dir)
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_renamed_file_reports_destination(self, temp_git_repo):
+        # Porcelain v1 renames: "R  orig -> new". The destination path
+        # is what matters; the parser must extract it (not record
+        # "orig -> new" as one path).
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            subprocess.run(
+                ["git", "mv", "README.md", "RENAMED.md"],
+                cwd=worktree_dir, check=True, capture_output=True,
+            )
+            undeclared = detect_undeclared_writes(worktree_dir)
+            # Destination present, not the "orig -> new" composite.
+            assert "RENAMED.md" in undeclared
+            assert not any(" -> " in p for p in undeclared)
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_deleted_file_not_flagged(self, temp_git_repo):
+        # Deletions aren't "writes" — surfacing them would turn `git rm`
+        # between conditions into noise. Documented in the helper.
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            (worktree_dir / "README.md").unlink()
+            assert detect_undeclared_writes(worktree_dir) == []
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_renamed_destination_can_be_declared(self, temp_git_repo):
+        # The destination of a rename must round-trip through the
+        # declared_paths filter — i.e. declaring "RENAMED.md" suppresses it.
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            subprocess.run(
+                ["git", "mv", "README.md", "RENAMED.md"],
+                cwd=worktree_dir, check=True, capture_output=True,
+            )
+            assert detect_undeclared_writes(
+                worktree_dir, declared_paths={"RENAMED.md"},
+            ) == []
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_git_failure_logs_warning(self, tmp_path, caplog):
+        # When `git status --porcelain` exits non-zero, the function
+        # returns [] but logs at WARNING — silent loss is exactly what
+        # the helper exists to prevent, so a diagnostic-failure must
+        # not be quiet.
+        import logging
+        # tmp_path exists but isn't a git repo → git status will exit non-zero.
+        (tmp_path / "marker").write_text("x")
+        with caplog.at_level(logging.WARNING, logger="orchestrator.worktree"):
+            result = detect_undeclared_writes(tmp_path)
+        assert result == []
+        assert any(
+            "git status failed" in r.getMessage() and r.levelname == "WARNING"
+            for r in caplog.records
+        )
+
 
 class TestDeclaredCodeChangePaths:
     """#230 — read declared paths from bundle.arms[].code_changes[].file."""
@@ -420,3 +509,29 @@ class TestRecordUndeclaredWritesInFindings:
         _record_undeclared_writes_in_findings(findings_path, ["a.py"])
         # Original unchanged.
         assert findings_path.read_text() == "{not valid json"
+
+    def test_malformed_findings_logs_error_with_paths(self, tmp_path, caplog):
+        # Refused-to-write must be loud, not silent — the undeclared
+        # paths still need to appear somewhere the operator can recover.
+        import logging
+        findings_path = tmp_path / "findings.json"
+        findings_path.write_text("{not valid json")
+        with caplog.at_level(logging.ERROR, logger="orchestrator.iteration"):
+            _record_undeclared_writes_in_findings(
+                findings_path, ["lost1.py", "lost2.py"],
+            )
+        msg = " ".join(r.getMessage() for r in caplog.records if r.levelname == "ERROR")
+        assert "lost1.py" in msg
+        assert "lost2.py" in msg
+        assert "not valid JSON" in msg
+
+    def test_corrupted_bundle_logs_error(self, tmp_path, caplog):
+        # YAML parse failure surfaces — bundle.yaml is a system boundary.
+        import logging
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text("not: valid: yaml: [")
+        with caplog.at_level(logging.ERROR, logger="orchestrator.iteration"):
+            assert _declared_code_change_paths(bundle_path) == set()
+        msg = " ".join(r.getMessage() for r in caplog.records if r.levelname == "ERROR")
+        assert "bundle.yaml parse failed" in msg
+        assert str(bundle_path) in msg

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,10 +1,21 @@
 """Tests for git worktree experiment isolation."""
+import json
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
-from orchestrator.worktree import create_experiment_worktree, remove_experiment_worktree
+from orchestrator.iteration import (
+    _declared_code_change_paths,
+    _record_undeclared_writes_in_findings,
+)
+from orchestrator.worktree import (
+    create_experiment_worktree,
+    detect_undeclared_writes,
+    remove_experiment_worktree,
+)
 
 
 @pytest.fixture
@@ -83,3 +94,329 @@ class TestRemoveExperimentWorktree:
         remove_experiment_worktree(temp_git_repo, experiment_id)
         # Second call should not raise
         remove_experiment_worktree(temp_git_repo, experiment_id)
+
+
+class TestWorktreeExtras:
+    """#229 — `target_system.worktree_extras` symlinks gitignored deps
+    from main into each experiment worktree, so the executor doesn't
+    have to ``cd`` to the parent repo. Behavioral tests use a real
+    on-disk git repo in tmp_path."""
+
+    def _add_gitignored_dep(self, repo: Path, rel: str, content: str = "x") -> Path:
+        """Create a gitignored file/dir at ``rel`` under ``repo``."""
+        target = repo / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+        gi = repo / ".gitignore"
+        existing = gi.read_text() if gi.exists() else ""
+        gi.write_text(existing + rel.split("/")[0] + "\n")
+        subprocess.run(["git", "add", ".gitignore"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", f"ignore {rel.split('/')[0]}"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        return target
+
+    def test_extras_creates_symlinks_into_worktree(self, temp_git_repo):
+        # Two gitignored deps: a file and a directory.
+        venv = temp_git_repo / "py" / ".venv"
+        venv.mkdir(parents=True)
+        (venv / "marker").write_text("VENV_OK")
+        data_file = temp_git_repo / "data.bin"
+        data_file.write_text("DATA_OK")
+        # gitignore both
+        (temp_git_repo / ".gitignore").write_text("py/.venv/\ndata.bin\n")
+        subprocess.run(["git", "add", ".gitignore"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "ignore"],
+            cwd=temp_git_repo, check=True, capture_output=True,
+        )
+
+        worktree_dir, experiment_id = create_experiment_worktree(
+            temp_git_repo, 1, extras=["py/.venv", "data.bin"],
+        )
+        try:
+            link_venv = worktree_dir / "py" / ".venv"
+            link_data = worktree_dir / "data.bin"
+            assert link_venv.is_symlink(), "py/.venv should be a symlink in the worktree"
+            assert link_data.is_symlink(), "data.bin should be a symlink in the worktree"
+            # Resolves to the main repo's path → marker is readable through the link.
+            assert (link_venv / "marker").read_text() == "VENV_OK"
+            assert link_data.read_text() == "DATA_OK"
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_extras_creates_intermediate_parent_dirs(self, temp_git_repo):
+        # Source at nested path; parent dir does NOT exist in worktree yet.
+        nested = temp_git_repo / "deep" / "nested" / "asset.txt"
+        nested.parent.mkdir(parents=True)
+        nested.write_text("OK")
+        (temp_git_repo / ".gitignore").write_text("deep/\n")
+        subprocess.run(["git", "add", ".gitignore"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "ignore deep"],
+            cwd=temp_git_repo, check=True, capture_output=True,
+        )
+
+        worktree_dir, experiment_id = create_experiment_worktree(
+            temp_git_repo, 1, extras=["deep/nested/asset.txt"],
+        )
+        try:
+            link = worktree_dir / "deep" / "nested" / "asset.txt"
+            assert link.is_symlink()
+            assert link.read_text() == "OK"
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_extras_source_must_exist(self, temp_git_repo):
+        with pytest.raises(FileNotFoundError, match="worktree_extras source not found"):
+            create_experiment_worktree(temp_git_repo, 1, extras=["does/not/exist"])
+
+    def test_extras_rejects_absolute_path(self, temp_git_repo):
+        with pytest.raises(ValueError, match="non-empty relative paths"):
+            create_experiment_worktree(temp_git_repo, 1, extras=["/etc/passwd"])
+
+    def test_extras_rejects_path_escaping_repo(self, temp_git_repo, tmp_path):
+        # Create a file outside the repo, then point a relative ``..``
+        # extra at it — the resolver must reject it.
+        outside = tmp_path / "outside.txt"
+        outside.write_text("OUTSIDE")
+        with pytest.raises(ValueError, match="resolves outside repo_path"):
+            create_experiment_worktree(temp_git_repo, 1, extras=["../outside.txt"])
+
+    def test_extras_failure_cleans_up_partial_worktree(self, temp_git_repo):
+        # When an extras entry fails validation, the half-built worktree
+        # must not leak — neither the directory nor the branch.
+        with pytest.raises(FileNotFoundError):
+            create_experiment_worktree(temp_git_repo, 1, extras=["does/not/exist"])
+        # No experiment dirs left behind.
+        experiments = temp_git_repo / ".nous-experiments"
+        if experiments.exists():
+            assert list(experiments.iterdir()) == [], (
+                "create_experiment_worktree leaked a worktree on extras failure"
+            )
+        # No nous-exp-* branches left behind.
+        result = subprocess.run(
+            ["git", "branch"],
+            cwd=temp_git_repo, capture_output=True, text=True,
+        )
+        assert "nous-exp-" not in result.stdout
+
+    def test_extras_leaves_existing_path_untouched(self, temp_git_repo):
+        # README.md is tracked in main → it exists in the worktree checkout.
+        # Declaring it as an extra should warn (not overwrite).
+        worktree_dir, experiment_id = create_experiment_worktree(
+            temp_git_repo, 1, extras=["README.md"],
+        )
+        try:
+            link = worktree_dir / "README.md"
+            assert not link.is_symlink(), "tracked path must not be replaced by a symlink"
+            assert link.read_text() == "# Test repo\n"
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_extras_skipped_by_undeclared_write_detection(self, temp_git_repo):
+        # Symlinks created by extras must not be flagged as undeclared
+        # writes — they're orchestrator-managed inputs (#230 cross-#229).
+        venv = temp_git_repo / ".venv"
+        venv.mkdir()
+        (venv / "bin").mkdir()
+        (temp_git_repo / ".gitignore").write_text(".venv/\n")
+        subprocess.run(["git", "add", ".gitignore"], cwd=temp_git_repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "ignore venv"],
+            cwd=temp_git_repo, check=True, capture_output=True,
+        )
+
+        worktree_dir, experiment_id = create_experiment_worktree(
+            temp_git_repo, 1, extras=[".venv"],
+        )
+        try:
+            assert detect_undeclared_writes(worktree_dir) == []
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_extras_none_or_empty_is_noop(self, temp_git_repo):
+        # Backward-compat: omitting extras (or passing empty list) yields the
+        # current behavior — fresh worktree, no symlinks.
+        worktree_dir, experiment_id = create_experiment_worktree(
+            temp_git_repo, 1, extras=None,
+        )
+        try:
+            entries = sorted(p.name for p in worktree_dir.iterdir() if not p.name.startswith("."))
+            assert entries == ["README.md"]
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+        worktree_dir, experiment_id = create_experiment_worktree(
+            temp_git_repo, 1, extras=[],
+        )
+        try:
+            entries = sorted(p.name for p in worktree_dir.iterdir() if not p.name.startswith("."))
+            assert entries == ["README.md"]
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+
+class TestDetectUndeclaredWrites:
+    """#230 — pre-cleanup tripwire that surfaces executor writes the
+    bundle never declared as ``code_changes``."""
+
+    def test_untracked_file_flagged(self, temp_git_repo):
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            (worktree_dir / "executor_added.py").write_text("# new code\n")
+            assert detect_undeclared_writes(worktree_dir) == ["executor_added.py"]
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_modified_tracked_file_flagged(self, temp_git_repo):
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            (worktree_dir / "README.md").write_text("# Modified\n")
+            assert "README.md" in detect_undeclared_writes(worktree_dir)
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_declared_path_filtered_out(self, temp_git_repo):
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            (worktree_dir / "executor_added.py").write_text("# declared\n")
+            (worktree_dir / "executor_other.py").write_text("# undeclared\n")
+            undeclared = detect_undeclared_writes(
+                worktree_dir, declared_paths={"executor_added.py"},
+            )
+            assert undeclared == ["executor_other.py"]
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_clean_worktree_returns_empty(self, temp_git_repo):
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            assert detect_undeclared_writes(worktree_dir) == []
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+    def test_missing_worktree_returns_empty(self, tmp_path):
+        # Detection runs in cleanup paths that may also fire after
+        # remove_experiment_worktree — must not raise.
+        assert detect_undeclared_writes(tmp_path / "does-not-exist") == []
+
+    def test_symlinks_excluded(self, temp_git_repo, tmp_path):
+        # Symlinks (typically from `worktree_extras`) are not undeclared writes.
+        external = tmp_path / "external_dep"
+        external.mkdir()
+        (external / "marker").write_text("x")
+        worktree_dir, experiment_id = create_experiment_worktree(temp_git_repo, 1)
+        try:
+            os.symlink(external, worktree_dir / "external_dep")
+            # The symlink shows up in `git status --porcelain` but
+            # detect_undeclared_writes filters it.
+            assert detect_undeclared_writes(worktree_dir) == []
+        finally:
+            remove_experiment_worktree(temp_git_repo, experiment_id)
+
+
+class TestDeclaredCodeChangePaths:
+    """#230 — read declared paths from bundle.arms[].code_changes[].file."""
+
+    def test_extracts_file_paths_from_arms(self, tmp_path):
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text(yaml.safe_dump({
+            "arms": [
+                {"type": "h-main", "code_changes": [
+                    {"file": "src/foo.py", "intent": "x", "rationale": "y"},
+                    {"file": "src/bar.py", "intent": "x", "rationale": "y"},
+                ]},
+                {"type": "h-ablation", "code_changes": [
+                    {"file": "src/baz.py", "intent": "x", "rationale": "y"},
+                ]},
+            ],
+        }))
+        assert _declared_code_change_paths(bundle_path) == {
+            "src/foo.py", "src/bar.py", "src/baz.py",
+        }
+
+    def test_no_arms_returns_empty(self, tmp_path):
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text(yaml.safe_dump({"metadata": {}}))
+        assert _declared_code_change_paths(bundle_path) == set()
+
+    def test_arm_without_code_changes_skipped(self, tmp_path):
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text(yaml.safe_dump({
+            "arms": [{"type": "h-main", "prediction": "..."}],
+        }))
+        assert _declared_code_change_paths(bundle_path) == set()
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        # Bundle missing → empty set, never raises (#230 must not block cleanup).
+        assert _declared_code_change_paths(tmp_path / "missing.yaml") == set()
+
+    def test_malformed_yaml_returns_empty(self, tmp_path):
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text("not: valid: yaml: [")
+        assert _declared_code_change_paths(bundle_path) == set()
+
+
+class TestRecordUndeclaredWritesInFindings:
+    """#230 — merge worktree_uncommitted_writes into findings.json without
+    breaking schema or losing existing keys."""
+
+    def _make_findings(self, tmp_path: Path) -> Path:
+        findings_path = tmp_path / "findings.json"
+        findings_path.write_text(json.dumps({
+            "iteration": 1,
+            "bundle_ref": "runs/iter-1/bundle.yaml",
+            "arms": [{
+                "arm_type": "h-main", "predicted": "...", "observed": "...",
+                "status": "CONFIRMED", "error_type": None,
+                "diagnostic_note": None,
+            }],
+            "experiment_valid": True,
+            "discrepancy_analysis": "...",
+        }))
+        return findings_path
+
+    def test_writes_sorted_unique_paths(self, tmp_path):
+        findings_path = self._make_findings(tmp_path)
+        _record_undeclared_writes_in_findings(
+            findings_path,
+            ["b.py", "a.py", "b.py", "c.py"],
+        )
+        loaded = json.loads(findings_path.read_text())
+        assert loaded["worktree_uncommitted_writes"] == ["a.py", "b.py", "c.py"]
+        # Other keys preserved.
+        assert loaded["experiment_valid"] is True
+        assert loaded["arms"][0]["arm_type"] == "h-main"
+
+    def test_findings_remains_schema_valid(self, tmp_path):
+        import jsonschema
+        findings_path = self._make_findings(tmp_path)
+        _record_undeclared_writes_in_findings(findings_path, ["a.py"])
+        loaded = json.loads(findings_path.read_text())
+        schema_path = (
+            Path(__file__).resolve().parent.parent
+            / "orchestrator" / "schemas" / "findings.schema.json"
+        )
+        schema = json.loads(schema_path.read_text())
+        jsonschema.validate(loaded, schema)  # raises on failure
+
+    def test_empty_undeclared_is_noop(self, tmp_path):
+        findings_path = self._make_findings(tmp_path)
+        original = findings_path.read_text()
+        _record_undeclared_writes_in_findings(findings_path, [])
+        assert findings_path.read_text() == original
+
+    def test_missing_findings_no_raise(self, tmp_path):
+        # If findings.json wasn't produced (bad iteration), don't blow up.
+        _record_undeclared_writes_in_findings(
+            tmp_path / "missing.json", ["a.py"],
+        )
+
+    def test_malformed_findings_no_raise(self, tmp_path):
+        findings_path = tmp_path / "findings.json"
+        findings_path.write_text("{not valid json")
+        _record_undeclared_writes_in_findings(findings_path, ["a.py"])
+        # Original unchanged.
+        assert findings_path.read_text() == "{not valid json"


### PR DESCRIPTION
## Summary

Lands **v1 scope of all four subissues** of tracker #228 (worktree isolation, resume robustness, code persistence) as a single PR. Mirrors the #225 → #227 pattern. Each subissue closes a friction item observed across two independent campaigns on 2026-05-27 (`paper-burst` on `inference-sim` + `cross-account-signal-pooling` on `well-baked`).

Closes: **#229**, **#230**, **#231**, **#232** (v1).

The four subissues cluster into two themes:

1. **Worktree-as-real-isolation, not Potemkin village** (#229, #231) — `target_system.worktree_extras` makes parent-repo dependencies (venvs, data dirs, prior-iter outputs) explicit and symlinks them into each experiment worktree. The methodology guidance tells the executor to stay in the worktree and reference parent assets through those symlinks instead of `cd`-ing back to main.
2. **Surface what's currently silent** (#230, #232) — undeclared writes that would be lost on cleanup are now flagged in `findings.json`; rendering failures on unreplaced placeholders now log the present context keys so the next reproduction of the resume-time bug points at the actual cause.

## Per-subissue scope

### #229 — `target_system.worktree_extras` allowlist

`campaign.schema.yaml` gains an optional `target_system.worktree_extras: array of strings`. `create_experiment_worktree` accepts an `extras` kwarg; for each entry, symlinks `<worktree>/<entry>` → `<repo>/<entry>` (parent dirs created in the worktree as needed). Validation:
- Each path must be a non-empty relative path; absolute paths and `..`-traversal that escapes `repo_path` are rejected with `ValueError`.
- Source must exist; missing source raises `FileNotFoundError`.
- A path that's tracked in main and already exists in the worktree checkout is left untouched (warned, not overwritten).

On any extras failure, the half-built worktree + branch are cleaned up before re-raising — no leakage.

`iteration.py` reads `target_system.worktree_extras` from the campaign and threads it through to `create_experiment_worktree`.

### #230 — Pre-cleanup `git status --porcelain` warn on undeclared writes

`worktree.py:detect_undeclared_writes(worktree_path, declared_paths)` parses `git status --porcelain` and returns untracked + modified-tracked paths that are NOT in `declared_paths` (the union of `bundle.arms[].code_changes[].file`). Symlinks are excluded — they're orchestrator-managed inputs from #229, not undeclared executor writes.

`iteration.py` calls it before `remove_experiment_worktree`, logs at WARNING (truncated to first 20 entries), and merges into `findings.json` under the new optional `worktree_uncommitted_writes` key. The findings schema accepts the field; nothing else changes.

The orchestrator does NOT block cleanup on undeclared writes — this is a tripwire, not a gate. Future v2 work could promote it to a gate via an `auto_capture_writes` flag.

### #231 — Methodology guidance: worktree discipline

Both `execute_analyze.md` and `execute_analyze_thin.md` gain a "Worktree discipline" section. Three rules:
- Stay in your worktree; don't `cd` to the parent repo.
- Reference parent assets via `worktree_extras` symlinks (relative paths), not absolute paths into main.
- Declare any new file via `code_changes` to survive cleanup; otherwise it's flagged via #230 and lost.

Prose-only change. No new placeholders.

### #232 — Diagnostic logging for the resume-time placeholder bug

`prompt_loader.py` now logs at ERROR before raising `ValueError` on unreplaced placeholders, including: `template`, `resolved_path`, `missing_placeholders`, and `context_keys`. The forensic line surfaces what was *present* in the context — answering the question the existing error message couldn't (was the key absent or just spelled wrong?).

**No speculative fix for the underlying resume-time bug.** Without reproduction, a fix would be at best a guess and at worst would mask the real cause. The diagnostic is the seine; the fix waits for the next occurrence.

## Test plan

- [x] **1167 passed, 1 skipped, 0 regressions** (was 1133 + 1 in PR #227 baseline; **+34 new behavioral tests**).
- [x] All tests use real on-disk git repos in `tmp_path` or seam-injected fakes per `CLAUDE.md` ("no live LLM calls in tests"). Symlink + git-worktree behavior validated against real fs operations, never mocked.
- [x] New coverage:
  - `test_worktree.py::TestWorktreeExtras` (8): symlinks created, parent dirs created, source-must-exist, absolute-path-rejected, escape-rejected, partial-failure-cleans-up, existing-paths-untouched, none/empty-noop, symlinks-not-flagged-as-writes.
  - `test_worktree.py::TestDetectUndeclaredWrites` (6): untracked flagged, modified-tracked flagged, declared filtered, clean returns empty, missing worktree returns empty, symlinks excluded.
  - `test_worktree.py::TestDeclaredCodeChangePaths` (5): paths extracted from arms, no-arms returns empty, no-code-changes-arm skipped, missing file returns empty, malformed yaml returns empty.
  - `test_worktree.py::TestRecordUndeclaredWritesInFindings` (5): sorted+unique, schema-still-valid, empty-noop, missing-findings no-raise, malformed-findings no-raise.
  - `test_prompt_loader.py::TestWorktreeDisciplineGuidance` (3): full template carries section, thin template carries section, thin renders with existing context.
  - `test_prompt_loader.py::TestPlaceholderDiagnosticLogging` (2): logs missing + context keys on failure, no log on success.

## Out of scope (deferred to v2 — explicit, in tracker #228)

| Subissue | v1 scope (this PR) | v2 work deferred |
|---|---|---|
| #229 | schema field + symlink at create | post-execution `git -C <main> diff` fail-loud (defense in depth) |
| #230 | tripwire warning + findings.json key | `auto_capture_writes` synthetic `code_changes` flag |
| #232 | forensic logging only | actual fix (gated on reproduction) |

These deferrals are explicit and named in tracker #228 itself for follow-up.

## What worked well (from the external feedback that produced #228)

- Per-iteration mode + rehearsal/real split caught a baseline mismatch in iter-1 (~$3) before iter-2 wasted ~$10–15 on the wrong baseline.
- `ground_truth.pre_registered: true` with multi-clause AND `pass_condition` prevented post-hoc rationalization.
- `h-control-negative` arm-typing forced V1 to be pre-registered as expected-to-fail; refutation was scientifically meaningful.
- `h-ablation` produced the cleanest finding of the run.

The friction is real, but the framework's discipline is exactly what made the null result trustworthy. Worth fixing the rough edges; not worth replacing the structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
