### PR TITLE
fix(isolation): always emit `worktree_uncommitted_writes` (closes #235)

### DIFF
--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -95,6 +95,13 @@ def _record_undeclared_writes_in_findings(
 ) -> None:
     """Merge ``worktree_uncommitted_writes`` into ``findings.json`` (#230).
 
+    Always writes the (sorted, de-duplicated) list — including the empty
+    case (#235). Presence of the key signals "the tripwire ran"; the
+    value signals "what it found". Absence is reserved for the failure
+    modes below (findings missing or corrupt) so an absent key in an
+    otherwise-successful iteration is a real regression signal, not
+    silent success.
+
     No-op if findings.json is missing — the cleanup may be running in
     the execute-incomplete branch where findings was never produced
     (the caller surfaces the data via retry_log there instead).
@@ -104,7 +111,7 @@ def _record_undeclared_writes_in_findings(
     returns without writing — modifying a corrupt JSON file would
     only make recovery harder.
     """
-    if not undeclared or not findings_path.exists():
+    if not findings_path.exists():
         return
     try:
         findings = json.loads(findings_path.read_text())
@@ -1136,14 +1143,16 @@ def run_iteration(
         # worktree is removed below. Persist into findings.json so the
         # design agent on iter-N+1 can see what to declare in
         # ``code_changes``. Tripwire only — never blocks cleanup.
+        # #235: emit unconditionally (even when the list is empty) so
+        # an absent key in findings.json is a real regression signal,
+        # not silent success.
         if repo_path and experiment_id and experiment_dir is not None:
             undeclared = _detect_undeclared_writes_for_iter(
                 iter_dir, experiment_dir,
             )
-            if undeclared:
-                _record_undeclared_writes_in_findings(
-                    iter_dir / "findings.json", undeclared,
-                )
+            _record_undeclared_writes_in_findings(
+                iter_dir / "findings.json", undeclared,
+            )
         # Clean up worktree only on success
         if repo_path and experiment_id:
             remove_experiment_worktree(Path(repo_path), experiment_id)

--- a/orchestrator/schemas/findings.schema.json
+++ b/orchestrator/schemas/findings.schema.json
@@ -29,7 +29,7 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 },
       "uniqueItems": true,
-      "description": "#230 — paths the executor wrote inside the experiment worktree without declaring them in the bundle's `code_changes`. Surfaced just before worktree cleanup; logged at WARNING. Empty array (or absent) means the executor declared everything it wrote, or wrote nothing untracked. The orchestrator does not block cleanup on undeclared writes — this is a tripwire, not a gate."
+      "description": "#230 — paths the executor wrote inside the experiment worktree without declaring them in the bundle's `code_changes`. Surfaced just before worktree cleanup; logged at WARNING. #235: written unconditionally — presence of the key means the tripwire ran, value is what it found (empty list = clean run; non-empty = paths that will be lost on cleanup). Absent only when findings.json was never produced (execute-incomplete branch surfaces the data via `retry_log.jsonl` instead) or when findings.json was corrupt at write time. The orchestrator does not block cleanup on undeclared writes — this is a tripwire, not a gate."
     }
   },
   "$defs": {

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -491,17 +491,42 @@ class TestRecordUndeclaredWritesInFindings:
         schema = json.loads(schema_path.read_text())
         jsonschema.validate(loaded, schema)  # raises on failure
 
-    def test_empty_undeclared_is_noop(self, tmp_path):
+    def test_empty_undeclared_writes_empty_list(self, tmp_path):
+        # #235: empty list is written explicitly so "I checked, saw nothing"
+        # is distinguishable from "I never ran". Absence of evidence ≠
+        # evidence of absence.
         findings_path = self._make_findings(tmp_path)
-        original = findings_path.read_text()
         _record_undeclared_writes_in_findings(findings_path, [])
-        assert findings_path.read_text() == original
+        loaded = json.loads(findings_path.read_text())
+        assert "worktree_uncommitted_writes" in loaded
+        assert loaded["worktree_uncommitted_writes"] == []
+        # Other keys preserved.
+        assert loaded["experiment_valid"] is True
+
+    def test_empty_undeclared_keeps_findings_schema_valid(self, tmp_path):
+        # #235: the empty-list case must still validate against the schema.
+        import jsonschema
+        findings_path = self._make_findings(tmp_path)
+        _record_undeclared_writes_in_findings(findings_path, [])
+        loaded = json.loads(findings_path.read_text())
+        schema_path = (
+            Path(__file__).resolve().parent.parent
+            / "orchestrator" / "schemas" / "findings.schema.json"
+        )
+        schema = json.loads(schema_path.read_text())
+        jsonschema.validate(loaded, schema)
 
     def test_missing_findings_no_raise(self, tmp_path):
         # If findings.json wasn't produced (bad iteration), don't blow up.
+        # Applies whether undeclared is empty or non-empty — the recorder
+        # has no findings to merge into either way.
         _record_undeclared_writes_in_findings(
             tmp_path / "missing.json", ["a.py"],
         )
+        _record_undeclared_writes_in_findings(
+            tmp_path / "missing.json", [],
+        )
+        assert not (tmp_path / "missing.json").exists()
 
     def test_malformed_findings_no_raise(self, tmp_path):
         findings_path = tmp_path / "findings.json"


### PR DESCRIPTION
## Summary

- Always write `worktree_uncommitted_writes` into `findings.json` (even as `[]`) when the #230 tripwire ran. Presence = "the tripwire ran"; value = "what it found." Absence is now reserved for genuine failure modes (findings missing / corrupt), so it's a real regression signal instead of indistinguishable from silent success.
- Schema description updated to match. Recorder still no-ops when `findings.json` is missing (execute-incomplete branch) and still refuses to write a corrupt one (logged at ERROR with the lost paths).
- Tests express the parametric table from the issue.

Closes #235. Refs #228 (isolation tracker), #230 (worktree tripwire).

## Test plan

- [x] `pytest tests/test_worktree.py` — 40 passed (was 39)
- [x] `pytest` (full suite) — 1175 passed, 2 skipped, no regressions
- [x] Schema validates a findings.json with `worktree_uncommitted_writes: []`
- [x] Schema validates a findings.json with `worktree_uncommitted_writes: ["a.py", "b.py"]`
- [x] `_record_undeclared_writes_in_findings(missing_path, [])` and `(missing_path, ["a.py"])` both no-op (no findings to merge into)

🤖 Generated with [Claude Code](https://claude.com/claude-code)