### PR TITLE
docs: align CLAUDE.md and downstream docs with NOUS_CAMPAIGN_PARENT (#239)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,40 @@ Beyond tests, Nous itself must be frugal with tokens:
 - **Read-only mapping uses Explore subagents**, not Opus. See
   `orchestrator/explore_design.py`.
 
+## Campaign-artifact location (issue #239)
+
+Campaign work_dirs default to ``<target_repo>/.nous/<run_id>/`` for
+backward compat, but the recommended setup is to export
+``NOUS_CAMPAIGN_PARENT`` so artifacts live OUTSIDE the target:
+
+```bash
+# Add to your shell rc:
+export NOUS_CAMPAIGN_PARENT=~/Documents/Projects/nous-campaigns
+```
+
+When set, work_dirs land at ``$NOUS_CAMPAIGN_PARENT/<run_id>/``.
+The target repo's working tree stays clean — ``git stash -u`` won't
+capture campaign output, ``git status`` stays uncluttered, ``git add .``
+won't accidentally stage campaign content.
+
+**The split that matters:**
+
+| Artifact type | Lives at | Why |
+|---|---|---|
+| Code worktrees per arm (#133) | ``<target>/.nous-experiments/<run>/<arm>/`` | They ARE code FOR the target repo; share its git history. Unaffected by the env var. |
+| Campaign artifacts (state, ledger, principles, findings, JSON results) | ``$NOUS_CAMPAIGN_PARENT/<run_id>/`` if env var set, else ``<target>/.nous/<run_id>/`` | About *experiment results*, not target's code. Env-var location avoids working-tree pollution. |
+
+Path resolution lives in ``orchestrator/work_dir_resolver.py`` —
+single source of truth (``RESOLUTION RULES`` marker). Three call
+sites (``setup_work_dir``, ``cli.resolve_work_dir``, ``cli._cmd_run``)
+delegate there. State.json records the resolved ``work_dir`` and
+``repo_path`` for collision detection and per-campaign provenance.
+
+``find_existing_work_dir`` provides migration grace: pre-#239
+campaigns at the legacy path are still findable when the user later
+sets the env var, so existing campaigns don't break on env-var
+adoption.
+
 ## PR workflow (project owner: @sriumcp)
 
 1. Branch off `upstream/reflective` (NOT `main`).

--- a/README.md
+++ b/README.md
@@ -254,26 +254,27 @@ git clone https://github.com/inference-sim/inference-sim.git blis
 nous run examples/campaign.yaml --max-iterations 3
 ```
 
-Campaign artifacts will be created at `blis/.nous/<run_id>/`.
+Campaign artifacts will be created at `$NOUS_CAMPAIGN_PARENT/<run_id>/` if you've set the env var (recommended), else at `blis/.nous/<run_id>/`.
 
 ### Output
 
+Each campaign's work_dir contains:
+
 ```
-your-repo/.nous/<run_id>/
-  state.json              # orchestrator checkpoint
-  principles.json         # accumulated principles
-  ledger.json             # one row per iteration
-  handoff.md              # living exploration context (updated each iteration)
-  runs/iter-N/
-    problem.md            # problem framing
-    bundle.yaml           # hypothesis bundle
-    handoff_snapshot.md   # iteration snapshot of handoff
-    experiment_plan.yaml  # exact commands per arm
-    findings.json         # prediction vs outcome
-    principle_updates.json # proposed principle changes
-    patches/              # code diffs (evolve mode only)
-    inputs/               # agent-created input files (configs, workloads)
-    results/              # experiment output files
+state.json              # orchestrator checkpoint
+principles.json         # accumulated principles
+ledger.json             # one row per iteration
+handoff.md              # living exploration context (updated each iteration)
+runs/iter-N/
+  problem.md            # problem framing
+  bundle.yaml           # hypothesis bundle
+  handoff_snapshot.md   # iteration snapshot of handoff
+  experiment_plan.yaml  # exact commands per arm
+  findings.json         # prediction vs outcome
+  principle_updates.json # proposed principle changes
+  patches/              # code diffs (evolve mode only)
+  inputs/               # agent-created input files (configs, workloads)
+  results/              # experiment output files
 ```
 
 ### Other CLI commands
@@ -303,7 +304,7 @@ nous stop campaign.yaml --reason "out of budget"  # halt at next iteration bound
 | Watch progress live | `nous status campaign.yaml --watch` |
 | Cleanly halt a running campaign | `nous stop campaign.yaml` |
 | Resume after halt or interruption | `nous resume campaign.yaml` |
-| Diagnose a failed iteration | `cat .nous/<run>/runs/iter-N/inputs/executor_log.jsonl` (#190) and `cat .nous/<run>/retry_log.jsonl` |
+| Diagnose a failed iteration | `cat <work_dir>/runs/iter-N/inputs/executor_log.jsonl` (#190) and `cat <work_dir>/retry_log.jsonl`, where `<work_dir>` is `$NOUS_CAMPAIGN_PARENT/<run>/` (recommended) or `<repo>/.nous/<run>/` (legacy) |
 | Audit token spend | `nous cost campaign.yaml --cache-stats` |
 
 ### Observability (when nous looks stuck or wrong)
@@ -313,7 +314,8 @@ When a campaign is mid-iteration and you can't tell what's happening:
 1. **`nous status --watch`** — live redraw of phase / iteration / last
    tool call. Prints `STUCK` after 5 min of dispatcher silence.
 2. **`runs/iter-N/inputs/executor_log.jsonl`** (#190) — every SDK
-   streaming event with timestamps. Tail it: `tail -f .nous/<run>/runs/iter-N/inputs/executor_log.jsonl`.
+   streaming event with timestamps. Tail it: `tail -f <work_dir>/runs/iter-N/inputs/executor_log.jsonl`
+   (where `<work_dir>` is `$NOUS_CAMPAIGN_PARENT/<run>/` or `<repo>/.nous/<run>/`).
 3. **`retry_log.jsonl`** at the campaign root — every transient failure
    with attempt count, backoff, error string. The DESIGN-incomplete
    case (#187) writes a `failure_type: "design_incomplete"` entry with

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -62,6 +62,8 @@ A bookmark. It tells the orchestrator what phase we entered last, which iteratio
 | `family` | What mechanism we're currently exploring (e.g., "routing-signals") |
 | `timestamp` | When this was last updated (i.e., when `last_entered_phase` was last entered — *not* when an artifact was last written) |
 | `config_ref` | Path to the campaign configuration file (null before setup) |
+| `work_dir` | Absolute filesystem path to this campaign's work_dir, recorded at `setup_work_dir` (#239). Per-campaign source of truth; survives `NOUS_CAMPAIGN_PARENT` changes between runs. Machine-local — tools that travel state.json across machines must validate `Path(work_dir).exists()` before trusting it. Null before setup. |
+| `repo_path` | Absolute path to the target system's repo, recorded at `setup_work_dir` (#239). Used for collision detection when `NOUS_CAMPAIGN_PARENT` is set (refusing to clobber a same-named campaign that targets a different repo) and to identify which target a campaign belongs to. Machine-local; null before setup or when authored without `target_system.repo_path`. |
 
 The orchestrator writes this atomically (temp file + rename) so a crash never leaves a corrupt checkpoint.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -76,7 +76,7 @@ prompts:
 nous run campaign.yaml --max-iterations 3
 ```
 
-When `repo_path` is set in `campaign.yaml`, the campaign directory is created inside the target repo at `.nous/<run_id>/`.
+When `repo_path` is set in `campaign.yaml`, the campaign directory is created at `$NOUS_CAMPAIGN_PARENT/<run_id>/` if you've exported that env var (recommended — see [Environment setup](../README.md#environment-setup)), otherwise at the legacy `<repo_path>/.nous/<run_id>/`. Issue #239 gives the rationale.
 
 Each iteration runs the full Nous loop (design → execute+analyze → validate) and pauses at two human gates. Both agents write artifacts directly to disk and run `nous validate` before claiming done — if validation fails, the agent fixes and retries.
 

--- a/plugin/nous/skills/nous-bisect.md
+++ b/plugin/nous/skills/nous-bisect.md
@@ -14,7 +14,7 @@ Compare two iterations of one campaign. Powered by `compare_iterations` (#126).
 
 ## Inputs
 
-- `campaign-root` (required): the campaign work-dir (e.g. `<repo>/.nous/<run-id>`).
+- `campaign-root` (required): the campaign work-dir — typically `$NOUS_CAMPAIGN_PARENT/<run-id>/` (#239 recommended) or `<repo>/.nous/<run-id>/` (legacy default).
 - `iter-a` (required): first iteration number.
 - `iter-b` (required): second iteration number.
 

--- a/plugin/nous/skills/nous-list.md
+++ b/plugin/nous/skills/nous-list.md
@@ -14,7 +14,7 @@ List Nous campaigns under a search root.
 
 ## Inputs
 
-- `search-root` (required): directory to walk. Typically the parent of one or more `<repo>/.nous/` directories.
+- `search-root` (required): directory to walk for campaign work_dirs. Typically `$NOUS_CAMPAIGN_PARENT/` (#239 recommended) or the parent of one or more `<repo>/.nous/` directories (legacy layout). Both layouts coexist; `find_existing_work_dir` (orchestrator/work_dir_resolver.py) handles them transparently.
 - `query` (optional): case-insensitive substring filter against run_id.
 - `status` (optional): filter to a specific phase (`DONE`, `EXECUTE_ANALYZE`, `INIT`, etc.).
 - `repo` (optional): substring filter against the resolved repo path.

--- a/plugin/nous/skills/nous-resume.md
+++ b/plugin/nous/skills/nous-resume.md
@@ -14,7 +14,7 @@ Resume an interrupted Nous campaign from the latest checkpoint (#91).
 
 ## Inputs
 
-- `target` (required): campaign.yaml path. The orchestrator reads the matching `<repo>/.nous/<run-id>/state.json` to find the resume point.
+- `target` (required): campaign.yaml path. The orchestrator reads `state.json` from `$NOUS_CAMPAIGN_PARENT/<run-id>/` if that env var is set, else from `<repo>/.nous/<run-id>/` (legacy default; #239). `find_existing_work_dir` checks both candidates plus state.json's recorded `work_dir`, so campaigns created before/after env-var adoption are both resumable.
 - `max-iterations` (optional): override the campaign's cap.
 - `agent` (optional): backend to use on resume — usually matches the original.
 


### PR DESCRIPTION
Refs #239. Follow-up to #240 (which landed the implementation + README setup section).

This PR updates the remaining docs that still described the legacy `<repo>/.nous/<run_id>/` layout as if it were the only option.

## Files changed

| File | What's new |
|---|---|
| `CLAUDE.md` | New "Campaign-artifact location (issue #239)" section in the project-conventions list. Documents the env var, the worktree-vs-artifacts split, and the single-source-of-truth resolver. |
| `docs/quickstart.md` | "Run a campaign" paragraph now shows both env-var path and legacy default. |
| `docs/data-model.md` | state.json schema description gains `work_dir` and `repo_path` fields with their #239 semantics. |
| `plugin/nous/skills/nous-resume.md` | Explains resume reads state.json from either location; `find_existing_work_dir` provides migration grace. |
| `plugin/nous/skills/nous-bisect.md` | Campaign-root description now mentions both possible locations. |
| `plugin/nous/skills/nous-list.md` | Search-root description now covers both layouts. |
| `README.md` | Remaining 4 path references (Output / Quick reference / Observability) updated to use `<work_dir>` and document the env-var alternative. |

## Notes

- No code changes — purely doc updates.
- Test suite: 1,215 pass, 2 skip, 0 fail (unchanged from #240).
- `docs/plans/2026-05-24-claude-code-native-uplift.md` left as-is — it's a historical planning doc, not user-facing reference material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)