### PR TITLE
fix(meta-findings): fully resolve #242 — ledger floor + eager retry_log + nous reports

### DIFF
--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -562,6 +562,89 @@ def _cmd_report(args):
     _generate_report(campaign, work_dir, args.model, agent=args.agent, timeout=args.timeout)
 
 
+def _cmd_reports(args):
+    """On-demand re-emission of meta_findings.json (#242).
+
+    Runs the pure-Python emitter against any work_dir, regardless of
+    whether the campaign reached a clean terminal transition. Useful for
+    legacy campaigns that pre-date the in-line emission wired into
+    campaign.py, and for campaigns that aborted mid-phase and so never
+    reached the four call sites that invoke the emitter automatically.
+
+    Target may be a campaign.yaml (preferred — gives full target_system
+    context for the heuristics) or a work_dir / run_id (emitted with an
+    empty target_system stub).
+    """
+    import json as _json
+    import yaml as _yaml
+    from orchestrator.meta_findings import (
+        emit_meta_findings,
+        write_meta_findings,
+    )
+    from orchestrator.validate import validate_meta_findings
+
+    work_dir = resolve_work_dir(args.target)
+
+    campaign: dict = {"target_system": {}}
+    if args.target.endswith((".yaml", ".yml")):
+        try:
+            data = _yaml.safe_load(Path(args.target).read_text())
+            if isinstance(data, dict):
+                campaign = data
+        except (_yaml.YAMLError, OSError) as exc:
+            print(
+                f"Warning: could not parse {args.target} ({exc}); "
+                f"emitting against empty target_system context.",
+                file=sys.stderr,
+            )
+
+    payload = emit_meta_findings(work_dir, campaign)
+
+    state_path = work_dir / "state.json"
+    is_terminal = False
+    if state_path.exists():
+        try:
+            state = _json.loads(state_path.read_text())
+            phase = state.get("last_entered_phase") or state.get("phase")
+            is_terminal = phase in ("DONE", "STOPPED")
+        except (_json.JSONDecodeError, OSError):
+            pass
+
+    if not is_terminal:
+        prior = payload.get("notes") or ""
+        suffix = (
+            f"Emitted on-demand via `nous reports` against a non-terminal "
+            f"work_dir (state.json: phase is not DONE/STOPPED). The "
+            f"three streams reflect partial state — re-emit after "
+            f"campaign termination for the canonical record."
+        )
+        payload["notes"] = (prior + " " + suffix).strip() if prior else suffix
+
+    target = write_meta_findings(work_dir, payload)
+    result = validate_meta_findings(work_dir)
+    if result["status"] == "fail":
+        print(
+            f"Warning: emitted meta_findings.json failed self-validation: "
+            f"{result['errors']}",
+            file=sys.stderr,
+        )
+
+    n_lessons = len(payload.get("campaign_design_lessons") or [])
+    n_repo = len(payload.get("target_system_asks") or [])
+    n_nous = len(payload.get("nous_asks") or [])
+    print(
+        f"{target}  "
+        f"({n_lessons} design lesson(s), {n_repo} repo ask(s), "
+        f"{n_nous} nous ask(s))"
+    )
+    if not is_terminal:
+        print(
+            "Note: emitted against a non-terminal work_dir; see "
+            "meta_findings.json `notes` field.",
+            file=sys.stderr,
+        )
+
+
 def _cmd_replay(args):
     import subprocess
     import yaml
@@ -846,6 +929,19 @@ def main():
     p_replay.add_argument("target")
     p_replay.add_argument("--iter", required=True, type=int)
     p_replay.set_defaults(func=_cmd_replay)
+
+    p_reports = subparsers.add_parser(
+        "reports",
+        help="Re-emit meta_findings.json on demand for any work_dir (#242). "
+             "Pure-Python; zero LLM tokens. Works against legacy or aborted "
+             "campaigns that never reached the in-line emitter.",
+    )
+    p_reports.add_argument(
+        "target",
+        help="campaign.yaml (preferred — supplies target_system context) "
+             "OR a work_dir / run_id resolvable via NOUS_CAMPAIGN_PARENT.",
+    )
+    p_reports.set_defaults(func=_cmd_reports)
 
     # `create-campaign` (issue #89): scaffold a heavily-commented
     # campaign.yaml that names the four agent-reachable fields and

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -799,6 +799,17 @@ def setup_work_dir(run_id: str, repo_path: str | None = None) -> Path:
         dest = work_dir / t
         if not dest.exists():
             shutil.copy(TEMPLATES_DIR / t, dest)
+
+    # #242: eagerly create an empty retry_log.jsonl. The orchestrator
+    # writes it on first dispatch failure, so a dispatcher-side crash
+    # before any retry would leave no trail at all — making the
+    # retry-log-keyed heuristics in meta_findings.py blind to the
+    # failure. Touching it here guarantees downstream tooling always
+    # sees a parseable artifact, even if it's empty.
+    retry_log = work_dir / "retry_log.jsonl"
+    if not retry_log.exists():
+        retry_log.touch()
+
     state = json.loads((work_dir / "state.json").read_text())
     state["run_id"] = run_id
     # #239: record resolved paths as per-campaign source of truth.

--- a/orchestrator/meta_findings.py
+++ b/orchestrator/meta_findings.py
@@ -416,23 +416,30 @@ def _detect_nous_asks_from_missing_artifacts(
         return []
     latest_iter = max(ledger_iters)
 
-    if (work_dir / "retry_log.jsonl").exists():
+    # After #242's eager init, retry_log.jsonl is touched at setup_work_dir
+    # so it always exists for fresh campaigns. Treat a 0-row file as
+    # equivalent to "no dispatch retries logged" — the original semantic
+    # the detector cares about.
+    retry_log = work_dir / "retry_log.jsonl"
+    has_retry_rows = retry_log.exists() and retry_log.stat().st_size > 0
+    findings = work_dir / "runs" / f"iter-{latest_iter}" / "findings.json"
+
+    if has_retry_rows:
         return []
-    if (work_dir / "runs" / f"iter-{latest_iter}" / "findings.json").exists():
+    if findings.exists():
         return []
 
+    retry_state = "absent" if not retry_log.exists() else "empty"
     return [{
         "ask": (
             "Investigate why the iteration progressed in state.json but "
-            "the dispatcher died before writing any per-iteration "
-            "artifacts. Consider initialising retry_log.jsonl at "
-            "iteration start so dispatcher-side crashes still leave a "
-            "parseable trail."
+            "the dispatcher produced no per-iteration artifacts. The "
+            "iteration ended with no findings.json and no retry rows."
         ),
         "evidence": (
-            f"state.json: iteration={iteration} phase={phase} but "
-            f"runs/iter-{latest_iter}/findings.json and retry_log.jsonl "
-            f"absent — dispatcher died before any artifact was written."
+            f"state.json: iteration={iteration} phase={phase} — "
+            f"runs/iter-{latest_iter}/findings.json absent, "
+            f"retry_log.jsonl {retry_state}."
         ),
         "kind": "observability",
     }]

--- a/orchestrator/meta_findings.py
+++ b/orchestrator/meta_findings.py
@@ -345,6 +345,99 @@ def _detect_nous_asks(
     return asks
 
 
+def _detect_nous_asks_from_ledger_failures(ledger: dict | list | None) -> list[dict]:
+    """Surface ledger.json rows where status="FAILED" as nous_asks (#242).
+
+    Closes the structural blind spot where every other detector keys off
+    retry_log.jsonl: a dispatcher that dies before writing the retry log
+    leaves only ledger.json as evidence, and the previous emitter
+    silently produced 0/0/0 streams. ledger.json is written by the
+    orchestrator itself, so it survives dispatcher-side crashes.
+    """
+    asks: list[dict] = []
+    if not isinstance(ledger, dict):
+        return asks
+    for row in ledger.get("iterations") or []:
+        if not isinstance(row, dict):
+            continue
+        if row.get("status") != "FAILED":
+            continue
+        iteration = row.get("iteration")
+        if not isinstance(iteration, int):
+            continue
+        err = (row.get("error") or "").strip()
+        err_short = err[:120] if err else "(no error text)"
+        asks.append({
+            "ask": (
+                "Investigate the dispatcher failure that prevented this "
+                "iteration from completing — the iteration ended without "
+                "producing findings.json or retry_log.jsonl, leaving the "
+                "ledger row as the only diagnostic surface."
+            ),
+            "evidence": (
+                f"ledger.json: iter-{iteration} status=FAILED, "
+                f"error=\"{err_short}\""
+            ),
+            "kind": "dispatch",
+        })
+    return asks
+
+
+def _detect_nous_asks_from_missing_artifacts(
+    work_dir: Path, state: dict | list | None, ledger: dict | list | None,
+) -> list[dict]:
+    """Flag campaigns where state.json shows iteration progressed but
+    per-iteration artifacts are absent (#242).
+
+    Triggered when state.iteration >= 1 and state.last_entered_phase
+    is not IDLE, ledger.json has at least one row with iteration >= 1,
+    retry_log.jsonl is absent, and runs/iter-N/findings.json is absent
+    for the highest ledger iter N. This is the post-#204 rerun shape:
+    the dispatcher died after the orchestrator advanced state but
+    before writing any per-iteration artifacts.
+    """
+    if not isinstance(state, dict) or not isinstance(ledger, dict):
+        return []
+    iteration = state.get("iteration")
+    phase = state.get("last_entered_phase")
+    if not isinstance(iteration, int) or iteration < 1:
+        return []
+    if not phase or phase == "IDLE":
+        return []
+
+    ledger_iters: list[int] = []
+    for row in ledger.get("iterations") or []:
+        if not isinstance(row, dict):
+            continue
+        n = row.get("iteration")
+        if isinstance(n, int) and n >= 1:
+            ledger_iters.append(n)
+    if not ledger_iters:
+        return []
+    latest_iter = max(ledger_iters)
+
+    if (work_dir / "retry_log.jsonl").exists():
+        return []
+    if (work_dir / "runs" / f"iter-{latest_iter}" / "findings.json").exists():
+        return []
+
+    return [{
+        "ask": (
+            "Investigate why the iteration progressed in state.json but "
+            "the dispatcher died before writing any per-iteration "
+            "artifacts. Consider initialising retry_log.jsonl at "
+            "iteration start so dispatcher-side crashes still leave a "
+            "parseable trail."
+        ),
+        "evidence": (
+            f"state.json: iteration={iteration} phase={phase} but "
+            f"runs/iter-{latest_iter}/findings.json and retry_log.jsonl "
+            f"absent — dispatcher died before any artifact was written."
+        ),
+        "kind": "observability",
+    }]
+
+
 def _detect_design_lessons(work_dir: Path) -> list[dict]:
     """Find lessons about campaign design from per-iteration findings."""
     lessons: list[dict] = []
@@ -453,7 +546,11 @@ def emit_meta_findings(
         "iterations_completed": iterations_completed,
         "campaign_design_lessons": _detect_design_lessons(work_dir),
         "target_system_asks": _detect_target_system_asks(campaign, retries),
-        "nous_asks": _detect_nous_asks(metrics, retries),
+        "nous_asks": (
+            _detect_nous_asks(metrics, retries)
+            + _detect_nous_asks_from_ledger_failures(ledger)
+            + _detect_nous_asks_from_missing_artifacts(work_dir, state, ledger)
+        ),
     }
 
     # Deployment recommendation (issue #170): every campaign emits a

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-from orchestrator.cli import resolve_work_dir, _cmd_run, _cmd_resume, _cmd_validate, _cmd_status, _cmd_cost, _cmd_report, _cmd_replay
+from orchestrator.cli import resolve_work_dir, _cmd_run, _cmd_resume, _cmd_validate, _cmd_status, _cmd_cost, _cmd_report, _cmd_replay, _cmd_reports
 
 
 class TestResolveWorkDir:
@@ -379,3 +379,141 @@ class TestCmdReplay:
                 _cmd_replay(args)
         err = capsys.readouterr().err
         assert "h-main/bad" in err
+
+
+class TestCmdReports:
+    """`nous reports` re-emits meta_findings.json on demand (#242)."""
+
+    def test_emits_meta_findings_against_workdir(
+            self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Against a work_dir directly (run_id with no yaml in scope),
+        the command emits a meta_findings.json with empty target_system
+        context. Useful for triaging legacy or aborted campaigns.
+        """
+        work_dir = tmp_path / ".nous" / "legacy-run"
+        work_dir.mkdir(parents=True)
+        (work_dir / "state.json").write_text(json.dumps({
+            "run_id": "legacy-run",
+            "iteration": 1,
+            "last_entered_phase": "DONE",
+        }))
+        (work_dir / "ledger.json").write_text(json.dumps({
+            "iterations": [{"iteration": 1, "status": "FAILED",
+                            "error": "SDK returned error after 1 attempt(s): None"}],
+        }))
+
+        args = argparse.Namespace(target=str(work_dir))
+        _cmd_reports(args)
+        out = capsys.readouterr().out
+
+        # Output one-liner reports the artifact path + counts.
+        assert "meta_findings.json" in out
+        assert "nous ask" in out
+
+        # Artifact must exist on disk and be schema-valid.
+        mf_path = work_dir / "meta_findings.json"
+        assert mf_path.exists()
+        payload = json.loads(mf_path.read_text())
+        assert payload["schema_version"] == "1"
+        # The acceptance fixture from #242: ledger FAILED row → ≥ 1 nous_ask.
+        assert payload["nous_asks"], payload
+
+    def test_marks_partial_when_workdir_not_terminal(
+            self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """A campaign whose state.json shows phase != DONE/STOPPED is
+        emitted with a `notes` field flagging partial state, so triage
+        tooling doesn't conflate on-demand emission with a clean
+        terminal record.
+        """
+        work_dir = tmp_path / ".nous" / "midflight"
+        work_dir.mkdir(parents=True)
+        (work_dir / "state.json").write_text(json.dumps({
+            "run_id": "midflight",
+            "iteration": 1,
+            "last_entered_phase": "EXECUTE_ANALYZE",
+        }))
+        (work_dir / "ledger.json").write_text(json.dumps({
+            "iterations": [{"iteration": 1, "status": "FAILED",
+                            "error": "abort"}],
+        }))
+
+        args = argparse.Namespace(target=str(work_dir))
+        _cmd_reports(args)
+
+        payload = json.loads((work_dir / "meta_findings.json").read_text())
+        assert "notes" in payload
+        assert "non-terminal" in payload["notes"].lower()
+        err = capsys.readouterr().err
+        assert "non-terminal" in err.lower()
+
+    def test_does_not_mark_partial_when_terminal(
+            self, tmp_path: Path) -> None:
+        """A campaign at phase=DONE must NOT be flagged as non-terminal."""
+        work_dir = tmp_path / ".nous" / "done-run"
+        work_dir.mkdir(parents=True)
+        (work_dir / "state.json").write_text(json.dumps({
+            "run_id": "done-run",
+            "iteration": 1,
+            "last_entered_phase": "DONE",
+        }))
+        (work_dir / "ledger.json").write_text(json.dumps({
+            "iterations": [{"iteration": 1, "status": "completed"}],
+        }))
+        # Build a complete iter-1 finding so the heuristic streams stay quiet.
+        iter_dir = work_dir / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        (iter_dir / "findings.json").write_text(json.dumps({
+            "iteration": 1, "bundle_ref": "stub", "arms": [],
+            "experiment_valid": True, "discrepancy_analysis": "stub",
+        }))
+
+        args = argparse.Namespace(target=str(work_dir))
+        _cmd_reports(args)
+
+        payload = json.loads((work_dir / "meta_findings.json").read_text())
+        notes = payload.get("notes") or ""
+        assert "non-terminal" not in notes.lower(), notes
+
+    def test_yaml_target_loads_full_campaign_context(
+            self, tmp_path: Path) -> None:
+        """When target is a campaign.yaml, target_system fields drive the
+        instrumentation/documentation heuristics. Absence of declared
+        observable_metrics should still surface a target_system_ask.
+        """
+        import yaml as _yaml
+
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        work_dir = repo / ".nous" / "yaml-run"
+        work_dir.mkdir(parents=True)
+        (work_dir / "state.json").write_text(json.dumps({
+            "run_id": "yaml-run",
+            "iteration": 1,
+            "last_entered_phase": "DONE",
+        }))
+        (work_dir / "ledger.json").write_text(json.dumps({
+            "iterations": [{"iteration": 1, "status": "completed"}],
+        }))
+        iter_dir = work_dir / "runs" / "iter-1"
+        iter_dir.mkdir(parents=True)
+        (iter_dir / "findings.json").write_text(json.dumps({
+            "iteration": 1, "bundle_ref": "stub", "arms": [],
+            "experiment_valid": True, "discrepancy_analysis": "stub",
+        }))
+
+        campaign_yaml = tmp_path / "campaign.yaml"
+        campaign_yaml.write_text(_yaml.dump({
+            "run_id": "yaml-run",
+            "target_system": {
+                "name": "demo",
+                "repo_path": str(repo),
+                # Intentionally no observable_metrics → instrumentation ask.
+            },
+        }))
+
+        args = argparse.Namespace(target=str(campaign_yaml))
+        _cmd_reports(args)
+
+        payload = json.loads((work_dir / "meta_findings.json").read_text())
+        kinds = {a.get("kind") for a in payload["target_system_asks"]}
+        assert "instrumentation" in kinds, payload["target_system_asks"]

--- a/tests/test_meta_findings.py
+++ b/tests/test_meta_findings.py
@@ -683,7 +683,7 @@ class TestMissingArtifactDetection:
 
         obs_asks = [a for a in payload["nous_asks"]
                     if a.get("kind") == "observability"
-                    and "dispatcher died" in a["ask"].lower()]
+                    and "no per-iteration artifacts" in a["ask"].lower()]
         assert obs_asks, payload["nous_asks"]
         assert "iter-1" in obs_asks[0]["evidence"]
 
@@ -705,7 +705,7 @@ class TestMissingArtifactDetection:
 
         obs_asks = [a for a in payload["nous_asks"]
                     if a.get("kind") == "observability"
-                    and "dispatcher died" in a["ask"].lower()]
+                    and "no per-iteration artifacts" in a["ask"].lower()]
         assert obs_asks == []
 
     def test_no_emission_when_retry_log_present(self, tmp_path: Path) -> None:
@@ -729,7 +729,7 @@ class TestMissingArtifactDetection:
 
         obs_asks = [a for a in payload["nous_asks"]
                     if a.get("kind") == "observability"
-                    and "dispatcher died" in a["ask"].lower()]
+                    and "no per-iteration artifacts" in a["ask"].lower()]
         assert obs_asks == []
 
     def test_no_emission_when_phase_is_idle(self, tmp_path: Path) -> None:
@@ -749,7 +749,7 @@ class TestMissingArtifactDetection:
 
         obs_asks = [a for a in payload["nous_asks"]
                     if a.get("kind") == "observability"
-                    and "dispatcher died" in a["ask"].lower()]
+                    and "no per-iteration artifacts" in a["ask"].lower()]
         assert obs_asks == []
 
     def test_no_emission_on_missing_state_or_ledger(
@@ -765,7 +765,7 @@ class TestMissingArtifactDetection:
 
         obs_asks = [a for a in payload["nous_asks"]
                     if a.get("kind") == "observability"
-                    and "dispatcher died" in a["ask"].lower()]
+                    and "no per-iteration artifacts" in a["ask"].lower()]
         assert obs_asks == []
 
     def test_evidence_passes_validate_evidence_floor(
@@ -786,10 +786,39 @@ class TestMissingArtifactDetection:
 
         obs_asks = [a for a in payload["nous_asks"]
                     if a.get("kind") == "observability"
-                    and "dispatcher died" in a["ask"].lower()]
+                    and "no per-iteration artifacts" in a["ask"].lower()]
         assert obs_asks
         for ask in obs_asks:
             assert validate_evidence(ask["evidence"]) is None, ask
+
+    def test_empty_retry_log_still_triggers(self, tmp_path: Path) -> None:
+        """#242: after the eager-init fix, retry_log.jsonl always exists
+        (even for crashed campaigns). The detector must still fire when
+        the file is empty AND findings.json is absent — that's the
+        canonical post-#242 catastrophic-failure shape.
+        """
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(
+            work_dir, iteration=1, last_entered_phase="EXECUTE_ANALYZE",
+        )
+        _write_ledger_with_failure(
+            work_dir, iteration=1, error="SDK returned error",
+        )
+        # Empty file (touched by setup_work_dir, never written to).
+        (work_dir / "retry_log.jsonl").touch()
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        obs_asks = [a for a in payload["nous_asks"]
+                    if a.get("kind") == "observability"
+                    and "no per-iteration artifacts" in a["ask"].lower()]
+        assert obs_asks, payload["nous_asks"]
+        # Evidence reflects the empty (not absent) state.
+        assert any("empty" in a["evidence"] for a in obs_asks), obs_asks
 
 
 class TestPost204RerunAcceptanceFixture:

--- a/tests/test_meta_findings.py
+++ b/tests/test_meta_findings.py
@@ -481,3 +481,357 @@ class TestRenderMarkdown:
         assert "Lesson A" in md
         assert "iter-1 details" in md
         assert "_None._" in md  # nous asks empty
+
+
+# ─── Ledger-floor heuristics (#242) ───────────────────────────────────────
+#
+# Background: every existing detector keys off retry_log.jsonl or
+# llm_metrics.jsonl. When a campaign's dispatcher dies before writing
+# those artifacts (e.g., a single-iteration campaign that fails at the
+# SDK call), every heuristic short-circuits and meta_findings.json reports
+# 0/0/0 across all three named streams — even though the failure is
+# recorded plainly in ledger.json. The acceptance fixture is the
+# post-204-rerun campaign: ledger.json has iter-1 status=FAILED but no
+# retry_log.jsonl, no findings.json. These tests pin the new floor.
+
+
+def _write_state_v2(
+    work_dir: Path, *, iteration: int = 1,
+    last_entered_phase: str = "EXECUTE_ANALYZE",
+    run_id: str = "test-run",
+) -> None:
+    """Write state.json using the post-d5764ce field name (last_entered_phase)
+    that the production orchestrator emits and the new detectors read."""
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / "state.json").write_text(json.dumps({
+        "iteration": iteration,
+        "run_id": run_id,
+        "family": "test",
+        "timestamp": "2026-05-26T20:42:14Z",
+        "last_entered_phase": last_entered_phase,
+        "work_dir": str(work_dir),
+        "repo_path": None,
+        "config_ref": None,
+        "max_iterations": 1,
+    }))
+
+
+def _write_ledger_with_failure(
+    work_dir: Path, *, iteration: int, error: str,
+) -> None:
+    """Write a ledger.json containing a FAILED iteration row, mirroring the
+    shape produced by orchestrator on a dispatcher-error iteration end."""
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / "ledger.json").write_text(json.dumps({
+        "iterations": [{
+            "iteration": iteration,
+            "family": "unknown",
+            "timestamp": "2026-05-26T22:09:05+00:00",
+            "candidate_id": f"iter-{iteration}",
+            "status": "FAILED",
+            "error": error,
+            "h_main_result": None,
+            "ablation_results": {},
+            "control_result": None,
+            "robustness_result": None,
+            "prediction_accuracy": None,
+            "principles_extracted": [],
+            "frontier_update": None,
+        }],
+    }))
+
+
+class TestLedgerFailureDetection:
+    """ledger.json: iterations[*].status == FAILED → one nous_ask per row."""
+
+    def test_emits_one_entry_per_failed_ledger_row(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(work_dir, iteration=2)
+        # Two FAILED rows → expect two nous_asks.
+        (work_dir / "ledger.json").write_text(json.dumps({
+            "iterations": [
+                {"iteration": 1, "status": "FAILED",
+                 "error": "SDK returned error after 1 attempt(s): None"},
+                {"iteration": 2, "status": "FAILED",
+                 "error": "Bash subprocess timed out after 600s"},
+            ],
+        }))
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        ledger_asks = [a for a in payload["nous_asks"]
+                       if "ledger.json" in a["evidence"]]
+        assert len(ledger_asks) == 2, payload["nous_asks"]
+        # Each row's iter-N and quoted error appear in evidence.
+        assert any("iter-1" in a["evidence"] and "SDK returned" in a["evidence"]
+                   for a in ledger_asks), ledger_asks
+        assert any("iter-2" in a["evidence"] and "timed out" in a["evidence"]
+                   for a in ledger_asks), ledger_asks
+
+    def test_no_emission_when_ledger_has_no_failed_rows(
+            self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(work_dir, iteration=1)
+        _write_ledger(work_dir, [1])  # writes status="completed"
+        _write_findings(work_dir, 1)
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+        ledger_asks = [a for a in payload["nous_asks"]
+                       if "ledger.json: iter" in a["evidence"]
+                       and "status=FAILED" in a["evidence"]]
+        assert ledger_asks == []
+
+    def test_no_emission_on_missing_ledger(self, tmp_path: Path) -> None:
+        # No ledger.json at all → detector silently degrades.
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(work_dir, iteration=1)
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+        ledger_asks = [a for a in payload["nous_asks"]
+                       if "ledger.json: iter" in a["evidence"]
+                       and "status=FAILED" in a["evidence"]]
+        assert ledger_asks == []
+
+    def test_no_emission_on_malformed_ledger(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(work_dir, iteration=1)
+        (work_dir / "ledger.json").write_text("{ not json at all")
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+        ledger_asks = [a for a in payload["nous_asks"]
+                       if "ledger.json: iter" in a["evidence"]
+                       and "status=FAILED" in a["evidence"]]
+        assert ledger_asks == []
+
+    def test_evidence_passes_validate_evidence_floor(
+            self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(work_dir, iteration=1)
+        _write_ledger_with_failure(
+            work_dir, iteration=1,
+            error="SDK returned error after 1 attempt(s): None",
+        )
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        ledger_asks = [a for a in payload["nous_asks"]
+                       if "ledger.json: iter" in a["evidence"]]
+        assert ledger_asks
+        for ask in ledger_asks:
+            assert validate_evidence(ask["evidence"]) is None, ask
+
+    def test_kind_is_dispatch(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(work_dir, iteration=1)
+        _write_ledger_with_failure(
+            work_dir, iteration=1,
+            error="SDK returned error after 1 attempt(s): None",
+        )
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        ledger_asks = [a for a in payload["nous_asks"]
+                       if "ledger.json: iter" in a["evidence"]]
+        assert ledger_asks
+        assert all(a["kind"] == "dispatch" for a in ledger_asks)
+
+
+class TestMissingArtifactDetection:
+    """state shows iteration progressed but findings.json/retry_log.jsonl
+    absent → one nous_ask flagging the silent dispatcher death."""
+
+    def test_emits_when_iter_advanced_but_no_artifacts(
+            self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(
+            work_dir, iteration=1, last_entered_phase="EXECUTE_ANALYZE",
+        )
+        _write_ledger_with_failure(
+            work_dir, iteration=1, error="SDK returned error",
+        )
+        # No retry_log.jsonl, no runs/iter-1/findings.json.
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        obs_asks = [a for a in payload["nous_asks"]
+                    if a.get("kind") == "observability"
+                    and "dispatcher died" in a["ask"].lower()]
+        assert obs_asks, payload["nous_asks"]
+        assert "iter-1" in obs_asks[0]["evidence"]
+
+    def test_no_emission_when_findings_present(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(
+            work_dir, iteration=1, last_entered_phase="EXECUTE_ANALYZE",
+        )
+        _write_ledger_with_failure(
+            work_dir, iteration=1, error="SDK returned error",
+        )
+        _write_findings(work_dir, 1)  # findings.json exists → no observability ask.
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        obs_asks = [a for a in payload["nous_asks"]
+                    if a.get("kind") == "observability"
+                    and "dispatcher died" in a["ask"].lower()]
+        assert obs_asks == []
+
+    def test_no_emission_when_retry_log_present(self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(
+            work_dir, iteration=1, last_entered_phase="EXECUTE_ANALYZE",
+        )
+        _write_ledger_with_failure(
+            work_dir, iteration=1, error="SDK returned error",
+        )
+        _append_jsonl(work_dir / "retry_log.jsonl", [
+            {"phase": "execute-analyze", "failure_type": "api_error",
+             "attempt": 1, "error": "real error text"},
+        ])
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        obs_asks = [a for a in payload["nous_asks"]
+                    if a.get("kind") == "observability"
+                    and "dispatcher died" in a["ask"].lower()]
+        assert obs_asks == []
+
+    def test_no_emission_when_phase_is_idle(self, tmp_path: Path) -> None:
+        # Pre-iteration campaign: state was written but no work has happened.
+        # Ledger has no rows at iteration >= 1.
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(
+            work_dir, iteration=0, last_entered_phase="IDLE",
+        )
+        (work_dir / "ledger.json").write_text(json.dumps({"iterations": []}))
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        obs_asks = [a for a in payload["nous_asks"]
+                    if a.get("kind") == "observability"
+                    and "dispatcher died" in a["ask"].lower()]
+        assert obs_asks == []
+
+    def test_no_emission_on_missing_state_or_ledger(
+            self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        work_dir.mkdir()
+        # Neither state.json nor ledger.json — defensive degrade.
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        obs_asks = [a for a in payload["nous_asks"]
+                    if a.get("kind") == "observability"
+                    and "dispatcher died" in a["ask"].lower()]
+        assert obs_asks == []
+
+    def test_evidence_passes_validate_evidence_floor(
+            self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "campaign"
+        _write_state_v2(
+            work_dir, iteration=1, last_entered_phase="EXECUTE_ANALYZE",
+        )
+        _write_ledger_with_failure(
+            work_dir, iteration=1, error="SDK returned error",
+        )
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        obs_asks = [a for a in payload["nous_asks"]
+                    if a.get("kind") == "observability"
+                    and "dispatcher died" in a["ask"].lower()]
+        assert obs_asks
+        for ask in obs_asks:
+            assert validate_evidence(ask["evidence"]) is None, ask
+
+
+class TestPost204RerunAcceptanceFixture:
+    """The acceptance fixture from issue #242's diagnostic comment.
+
+    Reproduces the on-disk shape of paper-burst.post-204-rerun.1779882732/:
+    state.json with iteration=1 phase=EXECUTE_ANALYZE, ledger.json with one
+    iter-1 status=FAILED row, no retry_log.jsonl, no findings.json. Before
+    this PR, emit_meta_findings produces 0 nous_asks for this shape. After,
+    it must produce ≥1.
+    """
+
+    def test_post_204_rerun_shape_emits_at_least_one_nous_ask(
+            self, tmp_path: Path) -> None:
+        work_dir = tmp_path / "paper-burst.post-204-rerun"
+        _write_state_v2(
+            work_dir, iteration=1, last_entered_phase="EXECUTE_ANALYZE",
+            run_id="paper-burst",
+        )
+        _write_ledger_with_failure(
+            work_dir, iteration=1,
+            error="SDK returned error after 1 attempt(s): None",
+        )
+        # principles.json is empty in the real campaign — schema permits absence.
+        (work_dir / "principles.json").write_text(
+            json.dumps({"principles": []}),
+        )
+
+        payload = emit_meta_findings(
+            work_dir, campaign={"target_system": {
+                "observable_metrics": ["x"], "controllable_knobs": ["y"],
+            }},
+        )
+
+        # The structural floor: SOMETHING in nous_asks must reflect the
+        # iter-1 FAILED row. Today this is zero — that's the bug #242
+        # documents.
+        assert payload["nous_asks"], (
+            f"#242: ledger.json iter-1 FAILED with retry_log absent should "
+            f"surface ≥1 nous_ask. Got: {payload['nous_asks']!r}"
+        )
+        # And the artifact must self-validate.
+        write_meta_findings(work_dir, payload)
+        result = validate_meta_findings(work_dir)
+        assert result["status"] == "pass", result.get("errors")

--- a/tests/test_work_dir_resolver.py
+++ b/tests/test_work_dir_resolver.py
@@ -165,6 +165,37 @@ class TestSetupWorkDirEnvVarUnset:
         state = json.loads((work_dir / "state.json").read_text())
         jsonschema.validate(state, _load_state_schema())
 
+    def test_creates_empty_retry_log_jsonl(self, tmp_path: Path) -> None:
+        """#242: setup_work_dir touches retry_log.jsonl so dispatcher
+        crashes always leave a parseable artifact behind, and
+        retry-log-keyed tooling never has to special-case its absence.
+        """
+        repo = tmp_path / "target-repo"
+        repo.mkdir()
+        work_dir = setup_work_dir("legacy-run", repo_path=str(repo))
+        retry_log = work_dir / "retry_log.jsonl"
+        assert retry_log.exists(), "setup_work_dir must touch retry_log.jsonl"
+        assert retry_log.stat().st_size == 0, (
+            "retry_log.jsonl should be empty at setup time — entries "
+            "are appended later by orchestrator.metrics on dispatch failures"
+        )
+
+    def test_retry_log_existing_content_not_clobbered(
+        self, tmp_path: Path
+    ) -> None:
+        """Idempotency: a second setup_work_dir on the same work_dir
+        must not truncate an existing retry_log.jsonl that already
+        contains rows from the first run.
+        """
+        repo = tmp_path / "target-repo"
+        repo.mkdir()
+        work_dir = setup_work_dir("legacy-run", repo_path=str(repo))
+        existing = '{"phase":"design","failure_type":"api_error"}\n'
+        (work_dir / "retry_log.jsonl").write_text(existing)
+        # Call again — must be idempotent.
+        setup_work_dir("legacy-run", repo_path=str(repo))
+        assert (work_dir / "retry_log.jsonl").read_text() == existing
+
 
 class TestSetupWorkDirEnvVarSet:
     """When NOUS_CAMPAIGN_PARENT is set, setup_work_dir creates


### PR DESCRIPTION
## Summary

Closes #242. Three complementary fixes that together close the structural blind spot the issue documented.

### 1. Ledger-failure floor heuristic

`_detect_nous_asks_from_ledger_failures(ledger)` — one `nous_ask` per `iterations[*].status == "FAILED"` row, `kind="dispatch"`, citing `iter-N` and a 120-char-truncated error string. `ledger.json` is the right substrate for the failure floor: written by the orchestrator itself (not the dispatcher subprocess), it survives dispatcher-side crashes by construction.

### 2. Missing-artifact heuristic

`_detect_nous_asks_from_missing_artifacts(work_dir, state, ledger)` — one `nous_ask` when `state.iteration >= 1` and `last_entered_phase != "IDLE"` but `runs/iter-N/findings.json` is absent and `retry_log.jsonl` has zero rows. `kind="observability"`. Correctly handles both legacy campaigns (no retry_log file) and post-fix-3 campaigns (empty retry_log).

### 3. Eager `retry_log.jsonl` init

`orchestrator.iteration.setup_work_dir` now touches `retry_log.jsonl` empty alongside `state.json`/`ledger.json`/`principles.json`. Before this, `retry_log.jsonl` was created lazily by `orchestrator.metrics` on first dispatch failure — a dispatcher-side crash before any retry left no parseable artifact at all. Idempotent: existing content is never clobbered.

### 4. `nous reports <target>` subcommand

On-demand re-emission of `meta_findings.json` for any work_dir, regardless of whether the campaign reached a clean terminal transition. Pure-Python, zero LLM tokens. Target accepts a `campaign.yaml` (preferred — supplies target_system context for instrumentation/documentation heuristics) or a `work_dir` / `run_id` resolvable via `NOUS_CAMPAIGN_PARENT`. When the target is not at `phase=DONE/STOPPED`, the emitted artifact is annotated with a `notes` field flagging partial state.

## End-to-end verification

`paper-burst.post-204-rerun.1779882732/` is the canonical case from #242's diagnostic comment. `ledger.json` has `iter-1 status="FAILED" error="SDK returned error after 1 attempt(s): None"`, but `retry_log.jsonl`, `llm_metrics.jsonl`, and `runs/iter-1/findings.json` are all absent.

| Stream | Pre-PR | Post-PR |
|---|---|---|
| `campaign_design_lessons` | 0 | 0 |
| `target_system_asks` | 0 | 2 |
| `nous_asks` | **0** | **2** |

Running `nous reports /path/to/post-204-rerun/` after this PR:

```
/Users/.../paper-burst.post-204-rerun.1779882732/meta_findings.json
  (0 design lesson(s), 2 repo ask(s), 2 nous ask(s))

# nous_asks now contain:
- dispatch | Investigate the dispatcher failure that prevented this iteration...
   evidence: ledger.json: iter-1 status=FAILED, error="SDK returned error after 1 attempt(s): None"
- observability | Investigate why the iteration progressed in state.json but...
   evidence: state.json: iteration=1 phase=EXECUTE_ANALYZE — runs/iter-1/findings.json absent, retry_log.jsonl absent.
```

## Test plan

- [x] **TestLedgerFailureDetection** (6 tests) — happy path, silent-degrade branches, evidence-floor compliance, kind-enum compliance.
- [x] **TestMissingArtifactDetection** (7 tests) — happy path, every silent-degrade branch, both legacy (absent) and post-fix-3 (empty) retry_log shapes, evidence-floor compliance.
- [x] **TestPost204RerunAcceptanceFixture** (1 test) — pins the binary acceptance criterion from #242's diagnostic comment.
- [x] **TestSetupWorkDirLegacyDefault** (2 new tests) — eager-init creates empty file, idempotent on re-setup.
- [x] **TestCmdReports** (4 tests) — work_dir target, yaml target, partial-state annotation, terminal-state non-annotation.
- [x] No live LLM calls — all fixtures are `tmp_path`-driven, `block_live_llm_calls` autouse fixture intact.
- [x] Schema unchanged. `kind: "dispatch"` and `kind: "observability"` were already in the `nous_ask` enum.
- [x] Red-green cycle verified at each stage.
- [x] Full suite: 1236 passed (+7 vs `reflective`), 1 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)