### PR TITLE
fix(viz): accurate cost tracking with timestamp-based iteration assignment

### DIFF
--- a/scripts/visualize_campaign.py
+++ b/scripts/visualize_campaign.py
@@ -22,6 +22,7 @@ import json
 import re
 import sys
 import webbrowser
+from datetime import datetime, timezone
 from pathlib import Path
 
 HTML_TEMPLATE = """<!DOCTYPE html>
@@ -1927,8 +1928,10 @@ def load_campaign(campaign_path: Path):
 def load_llm_metrics(campaign_path: Path, ledger: dict) -> dict:
     """Load LLM cost metrics from llm_metrics.jsonl and group by iteration.
 
-    Returns a dict keyed by iteration ID (e.g., "iter-0") with cost breakdowns.
+    Returns a dict keyed by iteration ID (e.g., "iter-1") with cost breakdowns.
     Each iteration has two phases: design (planner) and execute-analyze (executor).
+    Handles retries correctly by assigning entries to iterations based on
+    timestamps rather than assuming strict design/execute pairs.
     """
     metrics_path = campaign_path / "llm_metrics.jsonl"
     if not metrics_path.exists():
@@ -1938,8 +1941,12 @@ def load_llm_metrics(campaign_path: Path, ledger: dict) -> dict:
     with open(metrics_path) as f:
         for line in f:
             line = line.strip()
-            if line:
+            if not line:
+                continue
+            try:
                 entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
 
     if not entries:
         return {}
@@ -1947,40 +1954,87 @@ def load_llm_metrics(campaign_path: Path, ledger: dict) -> dict:
     iterations = ledger.get("iterations", [])
     result = {}
 
-    # Entries come in pairs: design (planner) + execute-analyze (executor).
-    # The baseline iteration (iter-0, outcome=None) has no metrics —
-    # pairs map to non-baseline iterations only (iter-1, iter-2, ...).
-    non_baseline = [it for it in iterations if it.get("h_main_result") is not None]
-    for i, it in enumerate(non_baseline):
-        iter_id = f"iter-{it['iteration']}"
-        design_idx = i * 2
-        execute_idx = i * 2 + 1
+    # Include all iterations with a timestamp (excludes only baseline iter-0).
+    # FAILED iterations are included so their costs aren't misattributed to neighbors.
+    non_baseline = [
+        it for it in iterations
+        if isinstance(it.get("iteration"), int) and it["iteration"] > 0 and it.get("timestamp")
+    ]
+    if not non_baseline:
+        return {}
+
+    def parse_ts(ts_str):
+        if not ts_str:
+            return None
+        try:
+            dt = datetime.fromisoformat(ts_str)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except (ValueError, TypeError):
+            return None
+
+    # Build sorted iteration end-timestamps for bucketing metrics entries.
+    iter_boundaries = []
+    for it in non_baseline:
+        end_ts = parse_ts(it.get("timestamp"))
+        if end_ts is None:
+            continue
+        iter_boundaries.append({
+            "iter_id": f"iter-{it['iteration']}",
+            "end_ts": end_ts,
+        })
+    iter_boundaries.sort(key=lambda b: b["end_ts"])
+
+    if not iter_boundaries:
+        return {}
+
+    # Assign each metrics entry to the first iteration whose end_ts >= entry_ts.
+    iter_entries = {b["iter_id"]: [] for b in iter_boundaries}
+    for entry in entries:
+        entry_ts = parse_ts(entry.get("timestamp"))
+        if entry_ts is None:
+            continue
+        assigned = None
+        for b in iter_boundaries:
+            if entry_ts <= b["end_ts"]:
+                assigned = b["iter_id"]
+                break
+        if assigned is None:
+            # Entry after last completed iteration (e.g., failed/in-progress subsequent iter)
+            assigned = iter_boundaries[-1]["iter_id"]
+        iter_entries[assigned].append(entry)
+
+    # Aggregate per iteration: sum all design entries and all execute entries.
+    for b in iter_boundaries:
+        iter_id = b["iter_id"]
+        entries_for_iter = iter_entries[iter_id]
+
+        design_entries = [e for e in entries_for_iter if e.get("role") == "planner"]
+        execute_entries = [e for e in entries_for_iter if e.get("role") == "executor"]
 
         iter_metrics = {"design": None, "execute": None, "total_cost": 0, "total_duration_ms": 0, "total_turns": 0}
 
-        if design_idx < len(entries):
-            d = entries[design_idx]
+        if design_entries:
             iter_metrics["design"] = {
-                "model": d.get("model", "unknown"),
-                "cost_usd": d.get("cost_usd") or 0,
-                "duration_ms": d.get("duration_ms") or 0,
-                "num_turns": d.get("num_turns") or 0,
-                "input_tokens": d.get("input_tokens") or 0,
-                "output_tokens": d.get("output_tokens") or 0,
+                "model": design_entries[-1].get("model", "unknown"),
+                "cost_usd": sum(e.get("cost_usd") or 0 for e in design_entries),
+                "duration_ms": sum(e.get("duration_ms") or 0 for e in design_entries),
+                "num_turns": sum(e.get("num_turns") or 0 for e in design_entries),
+                "input_tokens": sum(e.get("input_tokens") or 0 for e in design_entries),
+                "output_tokens": sum(e.get("output_tokens") or 0 for e in design_entries),
             }
 
-        if execute_idx < len(entries):
-            e = entries[execute_idx]
+        if execute_entries:
             iter_metrics["execute"] = {
-                "model": e.get("model", "unknown"),
-                "cost_usd": e.get("cost_usd") or 0,
-                "duration_ms": e.get("duration_ms") or 0,
-                "num_turns": e.get("num_turns") or 0,
-                "input_tokens": e.get("input_tokens") or 0,
-                "output_tokens": e.get("output_tokens") or 0,
+                "model": execute_entries[-1].get("model", "unknown"),
+                "cost_usd": sum(e.get("cost_usd") or 0 for e in execute_entries),
+                "duration_ms": sum(e.get("duration_ms") or 0 for e in execute_entries),
+                "num_turns": sum(e.get("num_turns") or 0 for e in execute_entries),
+                "input_tokens": sum(e.get("input_tokens") or 0 for e in execute_entries),
+                "output_tokens": sum(e.get("output_tokens") or 0 for e in execute_entries),
             }
 
-        # Compute totals
         for phase in ["design", "execute"]:
             if iter_metrics[phase]:
                 iter_metrics["total_cost"] += iter_metrics[phase]["cost_usd"]

--- a/tests/test_load_llm_metrics.py
+++ b/tests/test_load_llm_metrics.py
@@ -1,0 +1,265 @@
+"""Tests for load_llm_metrics in scripts/visualize_campaign.py."""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ has no __init__.py; add to path for import.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from visualize_campaign import load_llm_metrics
+
+
+def _write_metrics(path, entries):
+    with open(path / "llm_metrics.jsonl", "w") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+class TestNormalCase:
+    """Normal campaign with 1 design + 1 execute per iteration."""
+
+    def test_three_iterations_no_retries(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+            {"iteration": 2, "timestamp": "2026-01-01T02:00:00+00:00", "h_main_result": "REFUTED"},
+            {"iteration": 3, "timestamp": "2026-01-01T03:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:30:00+00:00", "role": "planner", "cost_usd": 1.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 1000, "output_tokens": 200},
+            {"timestamp": "2026-01-01T00:50:00+00:00", "role": "executor", "cost_usd": 2.0, "duration_ms": 8000, "num_turns": 3, "input_tokens": 2000, "output_tokens": 500},
+            {"timestamp": "2026-01-01T01:30:00+00:00", "role": "planner", "cost_usd": 1.5, "duration_ms": 6000, "num_turns": 2, "input_tokens": 1100, "output_tokens": 210},
+            {"timestamp": "2026-01-01T01:50:00+00:00", "role": "executor", "cost_usd": 2.5, "duration_ms": 9000, "num_turns": 4, "input_tokens": 2200, "output_tokens": 600},
+            {"timestamp": "2026-01-01T02:30:00+00:00", "role": "planner", "cost_usd": 1.2, "duration_ms": 7000, "num_turns": 2, "input_tokens": 1200, "output_tokens": 220},
+            {"timestamp": "2026-01-01T02:50:00+00:00", "role": "executor", "cost_usd": 2.8, "duration_ms": 10000, "num_turns": 5, "input_tokens": 2400, "output_tokens": 700},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+
+        assert set(result.keys()) == {"iter-1", "iter-2", "iter-3"}
+        assert result["iter-1"]["design"]["cost_usd"] == 1.0
+        assert result["iter-1"]["execute"]["cost_usd"] == 2.0
+        assert result["iter-1"]["total_cost"] == 3.0
+        assert result["iter-2"]["total_cost"] == 4.0
+        assert result["iter-3"]["total_cost"] == 4.0
+
+    def test_total_cost_matches_sum_of_entries(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:20:00+00:00", "role": "planner", "cost_usd": 3.5, "duration_ms": 5000, "num_turns": 2, "input_tokens": 1000, "output_tokens": 200},
+            {"timestamp": "2026-01-01T00:40:00+00:00", "role": "executor", "cost_usd": 4.5, "duration_ms": 8000, "num_turns": 3, "input_tokens": 2000, "output_tokens": 500},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+        assert result["iter-1"]["total_cost"] == pytest.approx(8.0)
+
+
+class TestRetries:
+    """Campaigns with retries produce multiple entries per phase per iteration."""
+
+    def test_multiple_design_retries_summed(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:10:00+00:00", "role": "planner", "cost_usd": 2.0, "duration_ms": 5000, "num_turns": 10, "input_tokens": 1000, "output_tokens": 200},
+            {"timestamp": "2026-01-01T00:20:00+00:00", "role": "planner", "cost_usd": 2.0, "duration_ms": 5000, "num_turns": 10, "input_tokens": 1000, "output_tokens": 200},
+            {"timestamp": "2026-01-01T00:30:00+00:00", "role": "planner", "cost_usd": 2.0, "duration_ms": 5000, "num_turns": 10, "input_tokens": 1000, "output_tokens": 200},
+            {"timestamp": "2026-01-01T00:45:00+00:00", "role": "executor", "cost_usd": 3.0, "duration_ms": 8000, "num_turns": 5, "input_tokens": 2000, "output_tokens": 500},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+
+        assert result["iter-1"]["design"]["cost_usd"] == 6.0
+        assert result["iter-1"]["design"]["num_turns"] == 30
+        assert result["iter-1"]["design"]["duration_ms"] == 15000
+        assert result["iter-1"]["execute"]["cost_usd"] == 3.0
+        assert result["iter-1"]["total_cost"] == 9.0
+
+    def test_retries_dont_bleed_into_next_iteration(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+            {"iteration": 2, "timestamp": "2026-01-01T02:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            # 3 retries for iter-1 design, all before iter-1's boundary
+            {"timestamp": "2026-01-01T00:10:00+00:00", "role": "planner", "cost_usd": 1.0, "duration_ms": 3000, "num_turns": 5, "input_tokens": 500, "output_tokens": 100},
+            {"timestamp": "2026-01-01T00:20:00+00:00", "role": "planner", "cost_usd": 1.0, "duration_ms": 3000, "num_turns": 5, "input_tokens": 500, "output_tokens": 100},
+            {"timestamp": "2026-01-01T00:30:00+00:00", "role": "planner", "cost_usd": 1.0, "duration_ms": 3000, "num_turns": 5, "input_tokens": 500, "output_tokens": 100},
+            {"timestamp": "2026-01-01T00:50:00+00:00", "role": "executor", "cost_usd": 2.0, "duration_ms": 8000, "num_turns": 3, "input_tokens": 2000, "output_tokens": 500},
+            # iter-2: single design + execute
+            {"timestamp": "2026-01-01T01:30:00+00:00", "role": "planner", "cost_usd": 1.5, "duration_ms": 4000, "num_turns": 6, "input_tokens": 600, "output_tokens": 120},
+            {"timestamp": "2026-01-01T01:50:00+00:00", "role": "executor", "cost_usd": 2.5, "duration_ms": 9000, "num_turns": 4, "input_tokens": 2200, "output_tokens": 600},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+
+        # iter-1 gets all 3 retries + executor
+        assert result["iter-1"]["design"]["cost_usd"] == 3.0
+        assert result["iter-1"]["total_cost"] == 5.0
+        # iter-2 is clean
+        assert result["iter-2"]["design"]["cost_usd"] == 1.5
+        assert result["iter-2"]["total_cost"] == 4.0
+
+
+class TestFailedIterations:
+    """FAILED iterations should act as time boundaries for cost attribution."""
+
+    def test_failed_iter_captures_own_costs(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+            {"iteration": 2, "timestamp": "2026-01-01T02:00:00+00:00", "h_main_result": None, "status": "FAILED", "error": "Broken pipe"},
+            {"iteration": 3, "timestamp": "2026-01-01T03:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:30:00+00:00", "role": "planner", "cost_usd": 1.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 500, "output_tokens": 100},
+            {"timestamp": "2026-01-01T00:50:00+00:00", "role": "executor", "cost_usd": 2.0, "duration_ms": 8000, "num_turns": 3, "input_tokens": 1000, "output_tokens": 200},
+            # These belong to the FAILED iter-2
+            {"timestamp": "2026-01-01T01:30:00+00:00", "role": "planner", "cost_usd": 3.0, "duration_ms": 7000, "num_turns": 4, "input_tokens": 800, "output_tokens": 150},
+            {"timestamp": "2026-01-01T01:50:00+00:00", "role": "executor", "cost_usd": 1.5, "duration_ms": 6000, "num_turns": 2, "input_tokens": 700, "output_tokens": 130},
+            # These belong to iter-3
+            {"timestamp": "2026-01-01T02:30:00+00:00", "role": "planner", "cost_usd": 1.2, "duration_ms": 5500, "num_turns": 2, "input_tokens": 550, "output_tokens": 110},
+            {"timestamp": "2026-01-01T02:50:00+00:00", "role": "executor", "cost_usd": 2.2, "duration_ms": 8500, "num_turns": 3, "input_tokens": 1100, "output_tokens": 220},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+
+        # FAILED iter-2 captures its own costs, doesn't leak into iter-1 or iter-3
+        assert "iter-2" in result
+        assert result["iter-2"]["design"]["cost_usd"] == 3.0
+        assert result["iter-2"]["execute"]["cost_usd"] == 1.5
+        assert result["iter-2"]["total_cost"] == 4.5
+        # iter-1 and iter-3 are unaffected
+        assert result["iter-1"]["total_cost"] == 3.0
+        assert result["iter-3"]["total_cost"] == pytest.approx(3.4)
+
+    def test_consecutive_failures_each_capture_own_costs(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+            {"iteration": 2, "timestamp": "2026-01-01T02:00:00+00:00", "h_main_result": None, "status": "FAILED"},
+            {"iteration": 3, "timestamp": "2026-01-01T03:00:00+00:00", "h_main_result": None, "status": "FAILED"},
+            {"iteration": 4, "timestamp": "2026-01-01T04:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:30:00+00:00", "role": "planner", "cost_usd": 1.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 500, "output_tokens": 100},
+            {"timestamp": "2026-01-01T01:30:00+00:00", "role": "planner", "cost_usd": 2.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 500, "output_tokens": 100},
+            {"timestamp": "2026-01-01T02:30:00+00:00", "role": "planner", "cost_usd": 3.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 500, "output_tokens": 100},
+            {"timestamp": "2026-01-01T03:30:00+00:00", "role": "planner", "cost_usd": 4.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 500, "output_tokens": 100},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+
+        assert result["iter-1"]["total_cost"] == 1.0
+        assert result["iter-2"]["total_cost"] == 2.0
+        assert result["iter-3"]["total_cost"] == 3.0
+        assert result["iter-4"]["total_cost"] == 4.0
+
+
+class TestTimezoneHandling:
+    """Naive and aware timestamps must compare without raising TypeError."""
+
+    def test_naive_entry_vs_aware_boundary(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        # Entry timestamp has NO timezone offset
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:30:00", "role": "planner", "cost_usd": 5.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 1000, "output_tokens": 200},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+
+        assert "iter-1" in result
+        assert result["iter-1"]["design"]["cost_usd"] == 5.0
+
+    def test_aware_entry_vs_naive_boundary(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            # Boundary has no explicit timezone
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:30:00+00:00", "role": "executor", "cost_usd": 7.0, "duration_ms": 8000, "num_turns": 3, "input_tokens": 2000, "output_tokens": 500},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+
+        assert "iter-1" in result
+        assert result["iter-1"]["execute"]["cost_usd"] == 7.0
+
+
+class TestEdgeCases:
+    """Empty inputs, corrupt data, and boundary conditions."""
+
+    def test_missing_metrics_file_returns_empty(self, tmp_path):
+        ledger = {"iterations": [{"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"}]}
+        assert load_llm_metrics(tmp_path, ledger) == {}
+
+    def test_empty_metrics_file_returns_empty(self, tmp_path):
+        (tmp_path / "llm_metrics.jsonl").write_text("")
+        ledger = {"iterations": [{"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"}]}
+        assert load_llm_metrics(tmp_path, ledger) == {}
+
+    def test_only_baseline_returns_empty(self, tmp_path):
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:30:00+00:00", "role": "planner", "cost_usd": 1.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 500, "output_tokens": 100},
+        ])
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+        ]}
+        assert load_llm_metrics(tmp_path, ledger) == {}
+
+    def test_corrupt_jsonl_line_skipped(self, tmp_path):
+        (tmp_path / "llm_metrics.jsonl").write_text(
+            '{"timestamp": "2026-01-01T00:30:00+00:00", "role": "planner", "cost_usd": 5.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 1000, "output_tokens": 200}\n'
+            '{this is not valid json\n'
+            '{"timestamp": "2026-01-01T00:50:00+00:00", "role": "executor", "cost_usd": 3.0, "duration_ms": 8000, "num_turns": 3, "input_tokens": 2000, "output_tokens": 500}\n'
+        )
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        result = load_llm_metrics(tmp_path, ledger)
+        assert result["iter-1"]["design"]["cost_usd"] == 5.0
+        assert result["iter-1"]["execute"]["cost_usd"] == 3.0
+
+    def test_entry_after_last_boundary_assigned_to_last(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T05:00:00+00:00", "role": "executor", "cost_usd": 10.0, "duration_ms": 8000, "num_turns": 3, "input_tokens": 2000, "output_tokens": 500},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+        assert result["iter-1"]["execute"]["cost_usd"] == 10.0
+
+    def test_entry_with_missing_timestamp_skipped(self, tmp_path):
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:30:00+00:00", "role": "planner", "cost_usd": 2.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 500, "output_tokens": 100},
+            {"role": "executor", "cost_usd": 99.0, "duration_ms": 8000, "num_turns": 3, "input_tokens": 2000, "output_tokens": 500},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+        # Entry without timestamp is skipped, only the planner entry counts
+        assert result["iter-1"]["design"]["cost_usd"] == 2.0
+        assert result["iter-1"]["execute"] is None
+        assert result["iter-1"]["total_cost"] == 2.0
+
+    def test_null_iteration_in_ledger_skipped(self, tmp_path):
+        """Iteration with null value doesn't crash the filter."""
+        ledger = {"iterations": [
+            {"iteration": 0, "family": "baseline", "timestamp": "1970-01-01T00:00:00Z", "h_main_result": None},
+            {"iteration": None, "timestamp": "2026-01-01T00:30:00+00:00"},
+            {"iteration": 1, "timestamp": "2026-01-01T01:00:00+00:00", "h_main_result": "CONFIRMED"},
+        ]}
+        _write_metrics(tmp_path, [
+            {"timestamp": "2026-01-01T00:30:00+00:00", "role": "planner", "cost_usd": 1.0, "duration_ms": 5000, "num_turns": 2, "input_tokens": 500, "output_tokens": 100},
+        ])
+        result = load_llm_metrics(tmp_path, ledger)
+        assert "iter-1" in result
+        assert result["iter-1"]["design"]["cost_usd"] == 1.0


### PR DESCRIPTION
## Summary
- Cost chart previously assumed strict positional pairing of `llm_metrics.jsonl` entries (`entry[i*2]`=design, `entry[i*2+1]`=execute), which broke when retries appended extra entries
- Now assigns entries to iterations by comparing timestamps against ledger boundaries, correctly summing all design and execute costs including retries
- Verified against 3 campaigns: totals match `llm_metrics.jsonl` exactly

## Test plan
- [ ] Generate visualization for `epp-ttft-slope-detector` — verify total cost matches `$59.42`
- [ ] Generate visualization for `epp-ttft-slope-detector-v2` — verify total cost matches `$57.26`
- [ ] Generate visualization for a campaign with retries in `llm_metrics.jsonl` — verify per-iteration costs sum correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)