### PR TITLE
feat(orchestrator): decouple summarizer model from design

### DIFF
--- a/orchestrator/defaults.yaml
+++ b/orchestrator/defaults.yaml
@@ -21,6 +21,12 @@ models:
   # REPORT — generates final report.md at campaign end.
   report: "claude-sonnet-4-6"
 
+  # SUMMARIZER — generates per-iteration gate summaries via OpenAI-compatible
+  # proxy. Decoupled from `design` so DESIGN can use [1m] context variants
+  # via claude -p without forcing the same tag through a proxy that may not
+  # serve it.
+  summarizer: "claude-opus-4-6"
+
 # Max tool-use turns for claude -p phases.
 max_turns:
   design: 80

--- a/orchestrator/iteration.py
+++ b/orchestrator/iteration.py
@@ -381,7 +381,7 @@ def run_iteration(
                 max_retries=max_cli_retries,
             ) if repo_path else None
         )
-        llm_dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model=_model_for("design"))
+        llm_dispatcher = LLMDispatcher(work_dir=work_dir, campaign=campaign, model=_model_for("summarizer"))
     gate = HumanGate(auto_response="approve") if auto_approve else HumanGate()
 
     iter_dir = work_dir / "runs" / f"iter-{iteration}"

--- a/orchestrator/schemas/campaign.schema.yaml
+++ b/orchestrator/schemas/campaign.schema.yaml
@@ -70,6 +70,7 @@ properties:
       design: { type: string, description: "Model for DESIGN phase (claude -p). Default: claude-opus-4-6." }
       execute_analyze: { type: string, description: "Model for EXECUTE_ANALYZE phase (claude -p). Default: claude-sonnet-4-6." }
       report: { type: string, description: "Model for report generation (LLM API). Default: claude-sonnet-4-6." }
+      summarizer: { type: string, description: "Model for gate-summary generation (LLM API via OpenAI proxy). Must be proxy-allowed; need not match design. Default: claude-opus-4-6." }
 
   prompts:
     type: object


### PR DESCRIPTION
## Summary

- Per-iteration gate summaries previously read `models.design`, but the two phases use different transports: DESIGN goes through `claude -p` (which can carry the `[1m]` 1M-context tag) while gate summaries go through the LLM API via an OpenAI-compatible proxy that may not serve the same tag.
- Add a dedicated `models.summarizer` knob (default `claude-opus-4-6`), expose it in `campaign.schema.yaml`, and have `run_iteration` resolve the summarizer model via `_model_for("summarizer")` instead of `"design"`.
- DESIGN and EXECUTE_ANALYZE behavior is unchanged. The existing `summarizer` role plumbing in `dispatch.py`, `campaign.py`, and `llm_dispatch.py` already expected this — the previous `models.design` lookup was a leftover from when the two phases shared a model.

## Files changed

- `orchestrator/defaults.yaml` — new `models.summarizer` default.
- `orchestrator/schemas/campaign.schema.yaml` — schema entry so users can override per-campaign.
- `orchestrator/iteration.py` — one-line swap: `_model_for("design")` → `_model_for("summarizer")` for the summarizer's `LLMDispatcher`.

## Ripples considered

No `graphify-out/graph.json` is present in the repo, so no automated ripple detection. Manual sweep across `orchestrator/` and `docs/` for `models.summarizer` / `models.design` / `summarizer` shows no other call sites that need updating.

## Test plan

- [ ] On a campaign that does NOT set `models.summarizer`: confirm gate summaries run with `claude-opus-4-6` (the new default).
- [ ] On a campaign that sets `models.summarizer: <some-proxy-served-tag>` in `campaign.yaml`: confirm gate summaries use that override and DESIGN keeps its own `models.design`.
- [ ] On a campaign whose `models.design` is a `[1m]` variant the proxy doesn't serve: confirm DESIGN still works and summaries are no longer broken by the proxy mismatch.