### PR TITLE
feat(wiki): reject dangling principles in validation

### DIFF
--- a/.claude/commands/post-campaign.md
+++ b/.claude/commands/post-campaign.md
@@ -222,7 +222,7 @@ Index a completed Nous campaign into the shared wiki and generate a visualizatio
     - Extract 5-15 concepts, 3-10 parameters, and 5-10 entities per campaign.
     - Only include parameters that were actively varied during the campaign.
     - Skip common industry terms (TTFT, LLM, GPU, p99, etc.). Focus on campaign-specific vocabulary.
-    - Every active principle should be referenced by at least one concept, parameter, or entity.
+    - Every active principle MUST be referenced by at least one concept, parameter, or entity. The validator will reject dangling principles (present in principles.json but not referenced by any node). If a principle has no natural home, either create a concept that captures the pattern it describes, or attach it to the most relevant existing entity/concept.
     - The `evolution` array for parameters should include every iteration where the parameter's value was meaningfully varied.
 
     **Entity validation (mandatory):** After drafting the entity list, verify each entity is truly pre-existing — NOT something the campaign introduced. You cannot rely on git history (campaign code may not be committed). Instead, use these sources of truth:
@@ -262,6 +262,7 @@ Index a completed Nous campaign into the shared wiki and generate a visualizatio
     - "orphaned parameter" → add it to the owning concept's `parameters` array
     - "unreachable entity" → either add an `operates_on` reference from a concept, or remove the entity
     - "unknown entity/parameter/concept" → fix the spelling to match exactly
+    - "dangling principles" → add the principle ID to the `principles` array of the most relevant entity, concept, or parameter. If no existing node fits, create a new concept that captures the pattern the principle describes.
 
     Do NOT proceed to step 10b until `validate_concepts.py` exits 0.
 

--- a/scripts/validate_concepts.py
+++ b/scripts/validate_concepts.py
@@ -11,6 +11,7 @@ Checks:
   7. Bidirectional consistency: concept.parameters ↔ parameter.parent_concept
   8. No orphaned parameters (not in any concept's parameters array)
   9. No unreachable entities (not in any concept's operates_on)
+  10. No dangling principles (in principles.json but not referenced by any node)
 
 Usage:
     python scripts/validate_concepts.py <path-to-concepts.json>
@@ -107,6 +108,47 @@ def validate(path: Path) -> list[str]:
             full_path = Path(repo_path) / file_part
             if not full_path.exists():
                 errors.append(f"entity '{entity['name']}': source file not found: {full_path}")
+
+    # Dangling principles: every active principle in principles.json must be
+    # referenced by at least one entity, concept, or parameter in concepts.json
+    principles_path = path.parent / "principles.json"
+    if principles_path.exists():
+        try:
+            with open(principles_path) as f:
+                principles_data = json.load(f)
+        except json.JSONDecodeError as e:
+            errors.append(f"principles.json contains invalid JSON: {e}")
+            principles_data = None
+        except OSError as e:
+            errors.append(f"principles.json could not be read: {e}")
+            principles_data = None
+
+        if principles_data is not None:
+            if not isinstance(principles_data, dict):
+                errors.append(
+                    f"principles.json has invalid structure: expected a JSON object, "
+                    f"got {type(principles_data).__name__}"
+                )
+            else:
+                all_principle_ids = {
+                    p["id"]
+                    for p in principles_data.get("principles", [])
+                    if isinstance(p, dict) and "id" in p and p.get("status", "active") == "active"
+                }
+                referenced_principle_ids = set()
+                for entity in data.get("entities", []):
+                    referenced_principle_ids.update(entity.get("principles") or [])
+                for concept in data.get("concepts", []):
+                    referenced_principle_ids.update(concept.get("principles") or [])
+                for param in data.get("parameters", []):
+                    referenced_principle_ids.update(param.get("principles") or [])
+
+                dangling = sorted(all_principle_ids - referenced_principle_ids)
+                if dangling:
+                    errors.append(
+                        f"dangling principles (in principles.json but not referenced by any "
+                        f"entity/concept/parameter): {dangling}"
+                    )
 
     return errors
 


### PR DESCRIPTION
## Summary
- Adds check #10 to `validate_concepts.py`: flags principles in `principles.json` that aren't referenced by any entity, concept, or parameter in `concepts.json`
- Upgrades the soft guideline in `/post-campaign` to a hard requirement — every principle must be attached to at least one knowledge graph node
- Adds "dangling principles" to the common validation fixes list with remediation guidance

## Motivation
Standalone principles (present in `principles.json` but not annotated on any graph node) are stored in the registry but are invisible to `/suggest-next` retrieval and visualization. This creates "dark knowledge" that never surfaces through automated tooling. Catching them at write time during `/post-campaign` prevents silent accumulation.

Running against existing campaigns confirms this was a real problem:
```
FAIL epp-saturation-detector-archive: dangling principles ['RP-10', 'RP-16', 'RP-18', 'RP-34', 'RP-4']
FAIL epp-ttft-slope-detector: dangling principles ['RP-16', 'RP-3']
```

## Test plan
- [x] `python scripts/validate_concepts.py ~/.nous/wiki/campaigns/*/concepts.json` — correctly flags dangling principles in existing campaigns
- [x] `blis-search-algo2` passes clean (no dangling principles)
- [ ] Run `/post-campaign` on a new campaign and verify the validator blocks until all principles are attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)