### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nous"
-version = "0.1.0"
+version = "0.4.0"
 description = "Nous — hypothesis-driven experimentation framework for software systems"
 requires-python = ">=3.11"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Version bump for the reflective release (v0.4.0). Tags will be created after merge.

See PR #279 for the full changelog.