### PR TITLE
fix(schema): accept channels: in campaign schema (#296)

### DIFF
--- a/orchestrator/schemas/campaign.schema.yaml
+++ b/orchestrator/schemas/campaign.schema.yaml
@@ -584,3 +584,36 @@ properties:
         items: { type: integer }
         minItems: 1
         description: "Pre-registered seed list. Locking these in advance prevents seed cherry-picking after the fact."
+
+  channels:
+    type: array
+    description: >
+      Issue #130 (Phase A): notification channels POSTed a markdown gate
+      summary at each DESIGN/FINDINGS gate, so reviewers can monitor a run
+      without sitting at the terminal. Fires even under --auto-approve (the
+      notification happens before the gate decision). Consumed by
+      ``orchestrator/channels.py``. Best-effort: a webhook timeout, 5xx, or
+      DNS failure logs a warning and never blocks the gate or campaign.
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        kind:
+          type: string
+          enum: [webhook, slack]
+          description: >
+            Dispatcher. ``webhook`` POSTs ``{"markdown": ...}`` to ``url``;
+            ``slack`` POSTs ``{"text": ...}`` to ``webhook_url``. Defaults to
+            ``webhook`` when omitted.
+        url:
+          type: string
+          minLength: 1
+          description: "Target URL for a ``webhook`` channel."
+        webhook_url:
+          type: string
+          minLength: 1
+          description: "Incoming-webhook URL for a ``slack`` channel."
+        headers:
+          type: object
+          additionalProperties: true
+          description: "Optional extra HTTP headers for a ``webhook`` channel."

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -581,6 +581,84 @@ class TestCampaignSchema:
         }
         jsonschema.validate(minimal, schema)  # Should not raise
 
+    def test_channels_accepted(self, load_schema):
+        """A campaign declaring channels: validates (#296).
+
+        Regression guard: orchestrator/channels.py reads campaign.channels
+        at every gate, but the schema used to omit the property while
+        forbidding unknown top-level keys, so notify-enabled campaigns were
+        rejected at pre-flight.
+        """
+        schema = load_schema("campaign.schema.yaml")
+        instance = {
+            "research_question": "What affects latency?",
+            "target_system": {
+                "name": "x",
+                "description": "x",
+                "observable_metrics": ["m"],
+                "controllable_knobs": ["k"],
+            },
+            "prompts": {"methodology_layer": "prompts/"},
+            "channels": [
+                {"kind": "slack", "webhook_url": "https://hooks.slack.com/services/X/Y/Z"},
+                {
+                    "kind": "webhook",
+                    "url": "https://example.com/nous/gate",
+                    "headers": {"Authorization": "Bearer t"},
+                },
+            ],
+        }
+        jsonschema.validate(instance, schema)
+
+    def test_channels_default_kind_accepted(self, load_schema):
+        """kind is optional — channels.py defaults it to 'webhook'."""
+        schema = load_schema("campaign.schema.yaml")
+        instance = {
+            "research_question": "What affects latency?",
+            "target_system": {
+                "name": "x",
+                "description": "x",
+                "observable_metrics": ["m"],
+                "controllable_knobs": ["k"],
+            },
+            "prompts": {"methodology_layer": "prompts/"},
+            "channels": [{"url": "https://example.com/nous/gate"}],
+        }
+        jsonschema.validate(instance, schema)
+
+    def test_channels_invalid_kind_rejected(self, load_schema):
+        schema = load_schema("campaign.schema.yaml")
+        instance = {
+            "research_question": "What affects latency?",
+            "target_system": {
+                "name": "x",
+                "description": "x",
+                "observable_metrics": ["m"],
+                "controllable_knobs": ["k"],
+            },
+            "prompts": {"methodology_layer": "prompts/"},
+            "channels": [{"kind": "carrier-pigeon", "url": "https://example.com"}],
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance, schema)
+
+    def test_channels_unknown_field_rejected(self, load_schema):
+        """additionalProperties: false on a channel entry catches typos."""
+        schema = load_schema("campaign.schema.yaml")
+        instance = {
+            "research_question": "What affects latency?",
+            "target_system": {
+                "name": "x",
+                "description": "x",
+                "observable_metrics": ["m"],
+                "controllable_knobs": ["k"],
+            },
+            "prompts": {"methodology_layer": "prompts/"},
+            "channels": [{"kind": "webhook", "url": "https://example.com", "headerz": {}}],
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance, schema)
+
 
 class TestPrinciplesCategoryField:
     def test_domain_category_accepted(self, load_schema):


### PR DESCRIPTION
Fixes #296.

## Problem

The runtime reads `campaign.channels` at every DESIGN/FINDINGS gate and POSTs a markdown gate summary to each configured channel:

- `orchestrator/iteration.py` → `from orchestrator.channels import notify_gate; notify_gate(channels, ...)`
- `orchestrator/channels.py` documents the shape (`kind` ∈ {`slack`, `webhook`}, `url`, `webhook_url`, `headers`).

But `orchestrator/schemas/campaign.schema.yaml` never declared a `channels` property while setting `additionalProperties: false` at the top level. So `nous run` aborts during pre-flight validation:

```
Campaign validation error: Additional properties are not allowed ('channels' was unexpected)
```

The documented feature is therefore impossible to use — the campaign is rejected before the run ever starts, and `nous schema campaign` doesn't list `channels`.

## Fix

Add a `channels` property to the campaign schema whose item shape mirrors **exactly** what `orchestrator/channels.py` reads:

- `kind` — enum `[webhook, slack]`, optional (the dispatcher loop defaults it to `webhook`).
- `url` — target URL for a `webhook` channel.
- `webhook_url` — incoming-webhook URL for a `slack` channel.
- `headers` — optional extra HTTP headers for a `webhook` channel.

`additionalProperties: false` on each entry catches field typos, matching the strictness of the rest of the schema.

## Tests

Adds regression tests under `TestCampaignSchema` in `tests/test_schemas.py`, so the schema and runtime can't drift apart again:

- `test_channels_accepted` — a `channels:`-bearing campaign (slack + webhook) validates.
- `test_channels_default_kind_accepted` — `kind` is optional.
- `test_channels_invalid_kind_rejected` — bad enum value rejected.
- `test_channels_unknown_field_rejected` — typo'd channel field rejected.

```
$ pytest tests/test_schemas.py tests/test_nous_schema_command.py
63 passed
```

(`nous schema campaign` now lists `channels` with its description.)